### PR TITLE
EXPORTABLE now supports name hints

### DIFF
--- a/.changeset/tricky-hornets-love.md
+++ b/.changeset/tricky-hornets-love.md
@@ -1,0 +1,14 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"graphile-utils": patch
+"postgraphile": patch
+"graphile-export": patch
+"@dataplan/pg": patch
+"grafast": patch
+"tamedevil": patch
+---
+
+EXPORTABLE now accepts a third argument, `nameHint`, which is used to hint what
+variable name to use for the given value. Used this in `graphile-export` along
+with some fixes and optimizations to improve the exports further.

--- a/grafast/dataplan-pg/src/datasource.ts
+++ b/grafast/dataplan-pg/src/datasource.ts
@@ -58,6 +58,7 @@ import type {
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -67,6 +68,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/grafast/dataplan-pg/src/datasource.ts
+++ b/grafast/dataplan-pg/src/datasource.ts
@@ -68,7 +68,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;
@@ -464,6 +464,7 @@ export class PgResource<
           (...args: PgSelectArgumentDigest[]) =>
             sql`unnest(${fnFrom(...args)})`,
         [fnFrom, sql],
+        `${name}_from`,
       );
       return {
         codec,
@@ -491,6 +492,7 @@ export class PgResource<
               ...args,
             )} with ordinality as ${sqlTmp} (arr, ${sqlPartitionByIndex}) cross join lateral unnest (${sqlTmp}.arr)`,
         [fnFrom, sql, sqlPartitionByIndex, sqlTmp],
+        `${name}_from`,
       );
       return {
         codec,
@@ -1367,6 +1369,7 @@ export function makeRegistryBuilder(): PgRegistryBuilder<{}, {}, {}> {
       return EXPORTABLE(
         (makeRegistry, registryConfig) => makeRegistry(registryConfig),
         [makeRegistry, registryConfig],
+        "registry",
       );
     },
   };

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -124,6 +124,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -133,6 +134,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -134,7 +134,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;
@@ -171,6 +171,7 @@ export function makeExampleSchema(
         },
       }),
     [PgExecutor, context, object],
+    "defaultPgExecutor",
   );
 
   /**
@@ -181,6 +182,7 @@ export function makeExampleSchema(
       $step.where(sql`true /* authorization checks */`);
     },
     [sql],
+    "selectAuth",
   );
 
   const registryConfig = EXPORTABLE(
@@ -1621,11 +1623,13 @@ export function makeExampleSchema(
       sql,
       sqlFromArgDigests,
     ],
+    "registryConfig",
   );
 
   const registry = EXPORTABLE(
     (makeRegistry, registryConfig) => makeRegistry(registryConfig),
     [makeRegistry, registryConfig],
+    "registry",
   );
 
   if (Math.random() > 2) {

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -212,14 +212,16 @@ export function makeGrafastSchema(details: {
                   `Invalid configuration for plans.${typeName}.${fieldName}.args.${argName} - saw a function, but expected an object with 'inputPlan' (optional) and 'applyPlan' (optional) plans`,
                 );
               } else {
-                exportNameHint(
-                  argSpec.applyPlan,
-                  `${typeName}_${fieldName}_${argName}_applyPlan`,
-                );
-                exportNameHint(
-                  argSpec.inputPlan,
-                  `${typeName}_${fieldName}_${argName}_inputPlan`,
-                );
+                if (argSpec) {
+                  exportNameHint(
+                    argSpec.applyPlan,
+                    `${typeName}_${fieldName}_${argName}_applyPlan`,
+                  );
+                  exportNameHint(
+                    argSpec.inputPlan,
+                    `${typeName}_${fieldName}_${argName}_inputPlan`,
+                  );
+                }
                 const grafastExtensions: Grafast.ArgumentExtensions =
                   Object.create(null);
                 (arg.extensions as any).grafast = grafastExtensions;
@@ -251,14 +253,16 @@ export function makeGrafastSchema(details: {
             `Expected input object type '${typeName}' field '${fieldName}' to be an object, but found a function. We don't know if this should be the 'inputPlan' or 'applyPlan' - please supply an object.`,
           );
         } else {
-          exportNameHint(
-            fieldSpec.inputPlan,
-            `${typeName}_${fieldName}_inputPlan`,
-          );
-          exportNameHint(
-            fieldSpec.applyPlan,
-            `${typeName}_${fieldName}_applyPlan`,
-          );
+          if (fieldSpec) {
+            exportNameHint(
+              fieldSpec.inputPlan,
+              `${typeName}_${fieldName}_inputPlan`,
+            );
+            exportNameHint(
+              fieldSpec.applyPlan,
+              `${typeName}_${fieldName}_applyPlan`,
+            );
+          }
           // it's a spec
           const grafastExtensions: Grafast.InputFieldExtensions =
             Object.create(null);

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -14,6 +14,7 @@ import type {
   ScalarPlanResolver,
 } from "./interfaces.js";
 import type { ExecutableStep } from "./step.js";
+import { exportNameHint } from "./utils.js";
 
 const {
   buildASTSchema,
@@ -140,6 +141,7 @@ export function makeGrafastSchema(details: {
       const fields = type.getFields();
       for (const [fieldName, fieldSpec] of Object.entries(objSpec)) {
         if (fieldName === "__assertStep") {
+          exportNameHint(fieldSpec, `${typeName}_assertStep`);
           (
             type.extensions as graphql.GraphQLObjectTypeExtensions<any, any>
           ).grafast = { assertStep: fieldSpec as any };
@@ -159,6 +161,7 @@ export function makeGrafastSchema(details: {
         }
 
         if (typeof fieldSpec === "function") {
+          exportNameHint(fieldSpec, `${typeName}_${fieldName}_plan`);
           // it's a plan
           (field.extensions as any).grafast = {
             plan: fieldSpec,
@@ -169,15 +172,28 @@ export function makeGrafastSchema(details: {
             Object.create(null);
           (field.extensions as any).grafast = grafastExtensions;
           if (typeof fieldSpec.resolve === "function") {
+            exportNameHint(
+              fieldSpec.resolve,
+              `${typeName}_${fieldName}_resolve`,
+            );
             field.resolve = fieldSpec.resolve;
           }
           if (typeof fieldSpec.subscribe === "function") {
+            exportNameHint(
+              fieldSpec.subscribe,
+              `${typeName}_${fieldName}_subscribe`,
+            );
             field.subscribe = fieldSpec.subscribe;
           }
           if (typeof fieldSpec.plan === "function") {
+            exportNameHint(fieldSpec.plan, `${typeName}_${fieldName}_plan`);
             grafastExtensions!.plan = fieldSpec.plan;
           }
           if (typeof fieldSpec.subscribePlan === "function") {
+            exportNameHint(
+              fieldSpec.subscribePlan,
+              `${typeName}_${fieldName}_subscribePlan`,
+            );
             grafastExtensions!.subscribePlan = fieldSpec.subscribePlan;
           }
 
@@ -196,6 +212,14 @@ export function makeGrafastSchema(details: {
                   `Invalid configuration for plans.${typeName}.${fieldName}.args.${argName} - saw a function, but expected an object with 'inputPlan' (optional) and 'applyPlan' (optional) plans`,
                 );
               } else {
+                exportNameHint(
+                  argSpec.applyPlan,
+                  `${typeName}_${fieldName}_${argName}_applyPlan`,
+                );
+                exportNameHint(
+                  argSpec.inputPlan,
+                  `${typeName}_${fieldName}_${argName}_inputPlan`,
+                );
                 const grafastExtensions: Grafast.ArgumentExtensions =
                   Object.create(null);
                 (arg.extensions as any).grafast = grafastExtensions;
@@ -227,6 +251,14 @@ export function makeGrafastSchema(details: {
             `Expected input object type '${typeName}' field '${fieldName}' to be an object, but found a function. We don't know if this should be the 'inputPlan' or 'applyPlan' - please supply an object.`,
           );
         } else {
+          exportNameHint(
+            fieldSpec.inputPlan,
+            `${typeName}_${fieldName}_inputPlan`,
+          );
+          exportNameHint(
+            fieldSpec.applyPlan,
+            `${typeName}_${fieldName}_applyPlan`,
+          );
           // it's a spec
           const grafastExtensions: Grafast.InputFieldExtensions =
             Object.create(null);
@@ -240,6 +272,7 @@ export function makeGrafastSchema(details: {
       }
       const polySpec = spec as InterfaceOrUnionPlans;
       if (polySpec.__resolveType) {
+        exportNameHint(polySpec.__resolveType, `${typeName}_resolveType`);
         type.resolveType = polySpec.__resolveType;
       }
     } else if (isScalarType(type)) {
@@ -248,15 +281,19 @@ export function makeGrafastSchema(details: {
       }
       const scalarSpec = spec as ScalarPlans;
       if (typeof scalarSpec.serialize === "function") {
+        exportNameHint(scalarSpec.serialize, `${typeName}_serialize`);
         type.serialize = scalarSpec.serialize;
       }
       if (typeof scalarSpec.parseValue === "function") {
+        exportNameHint(scalarSpec.parseValue, `${typeName}_parseValue`);
         type.parseValue = scalarSpec.parseValue;
       }
       if (typeof scalarSpec.parseLiteral === "function") {
+        exportNameHint(scalarSpec.parseLiteral, `${typeName}_parseLiteral`);
         type.parseLiteral = scalarSpec.parseLiteral;
       }
       if (typeof scalarSpec.plan === "function") {
+        exportNameHint(scalarSpec.plan, `${typeName}_plan`);
         (type.extensions as any).grafast = { plan: scalarSpec.plan };
       }
     } else if (isEnumType(type)) {
@@ -275,6 +312,10 @@ export function makeGrafastSchema(details: {
           continue;
         }
         if (typeof enumValueSpec === "function") {
+          exportNameHint(
+            enumValueSpec,
+            `${typeName}_${enumValueName}_applyPlan`,
+          );
           // It's a plan
           (enumValue.extensions as any).grafast = {
             applyPlan: enumValueSpec,
@@ -282,6 +323,10 @@ export function makeGrafastSchema(details: {
         } else if (typeof enumValueSpec === "object" && enumValueSpec != null) {
           // It's a full spec
           if (enumValueSpec.applyPlan) {
+            exportNameHint(
+              enumValueSpec.applyPlan,
+              `${typeName}_${enumValueName}_applyPlan`,
+            );
             (enumValue.extensions as any).grafast = {
               applyPlan: enumValueSpec.applyPlan,
             } as Grafast.EnumValueExtensions;

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -1066,11 +1066,13 @@ export function hasItemPlan(
 
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
-    if (!obj.$exporter$name) {
+    if (!("$exporter$name" in obj)) {
       Object.defineProperty(obj, "$exporter$name", {
         writable: true,
         value: nameHint,
       });
+    } else if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
     }
   }
 }

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -1067,7 +1067,10 @@ export function hasItemPlan(
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
     if (!obj.$exporter$name) {
-      obj.$exporter$name = nameHint;
+      Object.defineProperty(obj, "$exporter$name", {
+        writable: true,
+        value: nameHint,
+      });
     }
   }
 }

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -1063,3 +1063,11 @@ export function hasItemPlan(
 } {
   return "itemPlan" in step && typeof step.itemPlan === "function";
 }
+
+export function exportNameHint(obj: any, nameHint: string): void {
+  if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
+    if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
+    }
+  }
+}

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -21,7 +21,7 @@ import {
 import { EXPORTABLE, gatherConfig } from "graphile-build";
 import type { PgAttribute, PgClass, PgType } from "pg-introspection";
 
-import { addBehaviorToTags } from "../utils.js";
+import { addBehaviorToTags, exportNameHint } from "../utils.js";
 import { version } from "../version.js";
 
 interface State {
@@ -416,6 +416,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
           const executor =
             info.helpers.pgIntrospection.getExecutorForService(serviceName);
           const sqlIdent = info.helpers.pgBasics.identifier(nspName, className);
+          exportNameHint(attributes, `${codecName}Attributes`);
           const spec: PgRecordTypeCodecSpec<any, any> = EXPORTABLE(
             (
               attributes,
@@ -440,6 +441,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               extensions,
               sqlIdent,
             ],
+            `${codecName}CodecSpec`,
           );
           await info.process("pgCodecs_recordType_spec", {
             serviceName,
@@ -450,6 +452,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
           const codec = EXPORTABLE(
             (recordCodec, spec) => recordCodec(spec),
             [recordCodec, spec],
+            `${spec.name}Codec`,
           );
           await info.process("pgCodecs_PgCodec", {
             pgCodec: codec,
@@ -637,6 +640,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               extensions,
               sqlIdent,
             ],
+            `${codecName}Codec`,
           );
           return;
         }
@@ -714,6 +718,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               rangeOfCodec,
               sqlIdent,
             ],
+            `${codecName}Codec`,
           );
           return;
         }
@@ -786,6 +791,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                 notNull,
                 sqlIdent,
               ],
+              `${codecName}Codec`,
             );
             return;
           }
@@ -851,6 +857,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                   name,
                   typeDelim,
                 ],
+                `${name}Codec`,
               );
               return;
             }

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -416,6 +416,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
           const executor =
             info.helpers.pgIntrospection.getExecutorForService(serviceName);
           const sqlIdent = info.helpers.pgBasics.identifier(nspName, className);
+          exportNameHint(sqlIdent, `${codecName}Identifier`);
           exportNameHint(attributes, `${codecName}Attributes`);
           const spec: PgRecordTypeCodecSpec<any, any> = EXPORTABLE(
             (
@@ -767,6 +768,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               namespaceName,
               typeName,
             );
+            exportNameHint(sqlIdent, `${codecName}Identifier`);
             event.pgCodec = EXPORTABLE(
               (
                 codecName,
@@ -834,6 +836,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                 pgType: type,
                 serviceName,
               });
+              exportNameHint(extensions, `${name}CodecExtensions`);
               event.pgCodec = EXPORTABLE(
                 (
                   description,

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -371,6 +371,7 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
             serviceName,
             withPgClientKey,
           ],
+          serviceName === "main" ? `executor` : `${serviceName}Executor`,
         );
         info.state.executors[serviceName] = executor;
         return executor;

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -21,7 +21,7 @@ import { EXPORTABLE, gatherConfig } from "graphile-build";
 import type { PgProc, PgProcArgument } from "pg-introspection";
 import sql from "pg-sql2";
 
-import { addBehaviorToTags } from "../utils.js";
+import { addBehaviorToTags, exportNameHint } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
@@ -410,6 +410,7 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
             namespaceName,
             procName,
           );
+          exportNameHint(sqlIdent, `${procName}FunctionIdentifer`);
           const fromCallback = EXPORTABLE(
             (sql, sqlFromArgDigests, sqlIdent) =>
               (...args: PgSelectArgumentDigest[]) =>

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -10,7 +10,7 @@ import { object } from "grafast";
 import { EXPORTABLE, gatherConfig } from "graphile-build";
 import type { PgClass, PgConstraint, PgNamespace } from "pg-introspection";
 
-import { addBehaviorToTags } from "../utils.js";
+import { addBehaviorToTags, exportNameHint } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
@@ -431,6 +431,7 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
             serviceName,
             pgClass,
           });
+          exportNameHint(uniques, `${name}Uniques`);
           const identifier = `${serviceName}.${namespace.nspname}.${pgClass.relname}`;
 
           const { tags, description } = pgClass.getTagsAndDescription();

--- a/graphile-build/graphile-build-pg/src/utils.ts
+++ b/graphile-build/graphile-build-pg/src/utils.ts
@@ -473,3 +473,11 @@ export const resolveResourceRefPath = (
   }
   return result;
 };
+
+export function exportNameHint(obj: any, nameHint: string): void {
+  if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
+    if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
+    }
+  }
+}

--- a/graphile-build/graphile-build-pg/src/utils.ts
+++ b/graphile-build/graphile-build-pg/src/utils.ts
@@ -477,7 +477,10 @@ export const resolveResourceRefPath = (
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
     if (!obj.$exporter$name) {
-      obj.$exporter$name = nameHint;
+      Object.defineProperty(obj, "$exporter$name", {
+        writable: true,
+        value: nameHint,
+      });
     }
   }
 }

--- a/graphile-build/graphile-build-pg/src/utils.ts
+++ b/graphile-build/graphile-build-pg/src/utils.ts
@@ -476,11 +476,13 @@ export const resolveResourceRefPath = (
 
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
-    if (!obj.$exporter$name) {
+    if (!("$exporter$name" in obj)) {
       Object.defineProperty(obj, "$exporter$name", {
         writable: true,
         value: nameHint,
       });
+    } else if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
     }
   }
 }

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -313,6 +313,7 @@ declare global {
       EXPORTABLE<T, TScope extends any[]>(
         factory: (...args: TScope) => T,
         args: [...TScope],
+        nameHint?: string,
       ): T;
 
       /**

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -315,6 +315,7 @@ declare global {
         args: [...TScope],
         nameHint?: string,
       ): T;
+      exportNameHint(obj: any, nameHint: string): void;
 
       /**
        * Use `build.grafast` rather than importing `grafast` directly to try

--- a/graphile-build/graphile-build/src/makeNewBuild.ts
+++ b/graphile-build/graphile-build/src/makeNewBuild.ts
@@ -23,7 +23,12 @@ import * as semver from "semver";
 
 import extend, { indent } from "./extend.js";
 import type SchemaBuilder from "./SchemaBuilder.js";
-import { EXPORTABLE, stringTypeSpec, wrapDescription } from "./utils.js";
+import {
+  EXPORTABLE,
+  exportNameHint,
+  stringTypeSpec,
+  wrapDescription,
+} from "./utils.js";
 import { version } from "./version.js";
 
 const BUILTINS = ["Int", "Float", "Boolean", "ID", "String"];
@@ -140,6 +145,7 @@ export default function makeNewBuild(
     },
 
     EXPORTABLE,
+    exportNameHint,
     grafast,
     graphql,
 

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -31,7 +31,10 @@ export function EXPORTABLE<T, TScope extends any[]>(
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
     if (!obj.$exporter$name) {
-      obj.$exporter$name = nameHint;
+      Object.defineProperty(obj, "$exporter$name", {
+        writable: true,
+        value: nameHint,
+      });
     }
   }
 }

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -12,6 +12,7 @@ import plz from "pluralize";
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -21,6 +22,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -28,6 +28,14 @@ export function EXPORTABLE<T, TScope extends any[]>(
   return fn;
 }
 
+export function exportNameHint(obj: any, nameHint: string): void {
+  if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
+    if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
+    }
+  }
+}
+
 /**
  * Loops over all the given `keys` and binds the method of that name on `obj`
  * to `obj` so that destructuring `build`/etc won't relate in broken `this`

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -22,7 +22,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;
@@ -30,11 +30,13 @@ export function EXPORTABLE<T, TScope extends any[]>(
 
 export function exportNameHint(obj: any, nameHint: string): void {
   if ((typeof obj === "object" && obj != null) || typeof obj === "function") {
-    if (!obj.$exporter$name) {
+    if (!("$exporter$name" in obj)) {
       Object.defineProperty(obj, "$exporter$name", {
         writable: true,
         value: nameHint,
       });
+    } else if (!obj.$exporter$name) {
+      obj.$exporter$name = nameHint;
     }
   }
 }

--- a/graphile-build/graphile-utils/src/exportable.ts
+++ b/graphile-build/graphile-utils/src/exportable.ts
@@ -11,7 +11,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;

--- a/graphile-build/graphile-utils/src/exportable.ts
+++ b/graphile-build/graphile-utils/src/exportable.ts
@@ -1,6 +1,7 @@
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -10,6 +11,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -1065,9 +1065,14 @@ export function makeExtendSchemaPlugin(
           const possiblePlan = (
             plans[Self.name] as Maybe<ObjectPlan<any, any>>
           )?.[fieldName];
+          build.exportNameHint(possiblePlan, `${Self.name}_${fieldName}_plan`);
           const possibleResolver = (
             resolvers[Self.name] as Maybe<ObjectResolver>
           )?.[fieldName];
+          build.exportNameHint(
+            possibleResolver,
+            `${Self.name}_${fieldName}_resolver`,
+          );
           if (possiblePlan && possibleResolver) {
             throw new Error(
               `You must set only plans.${Self.name}.${fieldName} or resolvers.${Self.name}.${fieldName} - not both!`,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,32 +3371,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3412,12 +3412,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3430,17 +3430,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3449,12 +3449,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3469,15 +3469,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3729,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,16 +3791,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3820,11 +3820,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3944,11 +3944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3968,11 +3968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3992,11 +3992,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4016,11 +4016,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4040,11 +4040,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4088,11 +4088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4112,11 +4112,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4142,11 +4142,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4172,11 +4172,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4202,11 +4202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4232,11 +4232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4261,11 +4261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4291,11 +4291,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4320,11 +4320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4349,11 +4349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4378,11 +4378,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4407,11 +4407,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4436,11 +4436,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4465,11 +4465,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4499,11 +4499,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4533,11 +4533,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4567,11 +4567,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4635,11 +4635,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4669,11 +4669,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4703,11 +4703,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4737,11 +4737,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4771,11 +4771,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4805,11 +4805,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4839,11 +4839,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4873,11 +4873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4907,11 +4907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4942,11 +4942,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4966,11 +4966,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4990,11 +4990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5014,11 +5014,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5049,11 +5049,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5073,11 +5073,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5121,11 +5121,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5146,11 +5146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5185,11 +5185,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5224,11 +5224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5263,11 +5263,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5302,11 +5302,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5341,11 +5341,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5365,11 +5365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5394,11 +5394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5433,11 +5433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5472,11 +5472,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5496,11 +5496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5525,11 +5525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5578,11 +5578,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5602,11 +5602,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5626,11 +5626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5650,7 +5650,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5671,12 +5671,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5690,12 +5690,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5709,12 +5709,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5728,12 +5728,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5747,12 +5747,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5766,12 +5766,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5786,7 +5786,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5812,7 +5812,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5832,12 +5832,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5852,12 +5852,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5872,12 +5872,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5891,12 +5891,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5910,7 +5910,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5941,12 +5941,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5960,11 +5960,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5992,7 +5992,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6011,11 +6011,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6050,7 +6050,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6073,7 +6073,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6095,7 +6095,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6133,7 +6133,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6165,7 +6165,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6187,7 +6187,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6209,7 +6209,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6243,7 +6243,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6267,7 +6267,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6301,11 +6301,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6355,11 +6355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6409,11 +6409,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6438,11 +6438,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6467,11 +6467,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6496,11 +6496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6525,11 +6525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6561,11 +6561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6597,11 +6597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6626,11 +6626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6655,11 +6655,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6694,11 +6694,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6733,11 +6733,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6772,11 +6772,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6815,7 +6815,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6837,7 +6837,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6864,7 +6864,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6891,7 +6891,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6918,7 +6918,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6945,7 +6945,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6972,7 +6972,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7005,7 +7005,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7032,7 +7032,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7059,7 +7059,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7113,7 +7113,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7145,7 +7145,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7169,11 +7169,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7232,11 +7232,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7261,11 +7261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7330,11 +7330,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7394,11 +7394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7428,11 +7428,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7462,11 +7462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7496,11 +7496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7530,11 +7530,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7572,7 +7572,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7623,7 +7623,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7645,7 +7645,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7667,7 +7667,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7689,7 +7689,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7757,7 +7757,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7779,7 +7779,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7836,7 +7836,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7858,7 +7858,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7880,7 +7880,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7907,7 +7907,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7961,7 +7961,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7993,7 +7993,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8015,7 +8015,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8037,7 +8037,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30651,7 +30651,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30667,7 +30667,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33165,7 +33165,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33181,7 +33181,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33603,7 +33603,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33619,7 +33619,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34240,7 +34240,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34256,7 +34256,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35325,7 +35325,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35341,7 +35341,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35446,7 +35446,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35462,7 +35462,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35567,7 +35567,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35583,7 +35583,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35688,7 +35688,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35704,7 +35704,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35809,7 +35809,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35825,7 +35825,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35930,7 +35930,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35946,7 +35946,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36469,7 +36469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36485,7 +36485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36647,7 +36647,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36663,7 +36663,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36825,7 +36825,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36841,7 +36841,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37060,7 +37060,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37076,7 +37076,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37352,7 +37352,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37368,7 +37368,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37919,7 +37919,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37935,7 +37935,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38460,7 +38460,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38476,7 +38476,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38752,7 +38752,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38768,7 +38768,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42380,7 +42380,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42467,7 +42467,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42716,7 +42716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42773,7 +42773,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43030,7 +43030,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43141,7 +43141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43223,7 +43223,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43290,7 +43290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43357,7 +43357,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43424,7 +43424,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43491,7 +43491,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43558,7 +43558,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43786,7 +43786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43860,7 +43860,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43939,7 +43939,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44020,7 +44020,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44111,7 +44111,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44199,7 +44199,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44344,7 +44344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44482,7 +44482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44575,7 +44575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44649,7 +44649,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44712,7 +44712,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44849,7 +44849,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45262,7 +45262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45342,7 +45342,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45422,7 +45422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45502,7 +45502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45582,7 +45582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45662,7 +45662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45791,7 +45791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45878,7 +45878,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45970,7 +45970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46064,7 +46064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46169,7 +46169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46270,7 +46270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46371,7 +46371,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46472,7 +46472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46592,7 +46592,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46679,7 +46679,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46799,7 +46799,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46963,7 +46963,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47394,7 +47394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47458,7 +47458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47522,7 +47522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47586,7 +47586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47650,7 +47650,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47714,7 +47714,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47798,7 +47798,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47862,7 +47862,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47931,7 +47931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47995,7 +47995,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48070,7 +48070,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48134,7 +48134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48198,7 +48198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48262,7 +48262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48339,7 +48339,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48403,7 +48403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48472,7 +48472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48544,7 +48544,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,732 +3339,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6511,274 +3420,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6796,254 +3457,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7158,19 +3592,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7179,9 +3634,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7196,813 +3807,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8014,7 +5658,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8025,7 +5679,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8036,7 +5698,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8047,7 +5717,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8058,7 +5736,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8069,7 +5755,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8080,7 +5774,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8089,10 +5791,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8100,10 +5817,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8115,7 +5840,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8127,7 +5860,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8139,7 +5880,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8150,7 +5899,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8158,10 +5915,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8172,33 +5949,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8207,394 +6055,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9444,25 +8909,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9605,21 +9051,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9670,21 +9101,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9793,21 +9209,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10298,21 +9699,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,12 +9791,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10833,21 +10213,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10916,21 +10281,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11317,21 +10667,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11660,21 +10995,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11725,21 +11045,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11836,21 +11141,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11901,21 +11191,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11984,21 +11259,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12049,21 +11309,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12325,385 +11570,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13277,21 +12147,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13372,21 +12227,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13486,66 +12326,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13593,24 +12373,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13691,21 +12453,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14129,348 +12876,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14517,26 +12923,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14583,9 +12969,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,9 +13015,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14681,9 +13061,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14730,9 +13107,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14779,9 +13153,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14828,9 +13199,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14883,9 +13251,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14938,9 +13303,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14993,9 +13355,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15048,9 +13407,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15103,9 +13459,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15158,9 +13511,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15219,9 +13569,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15280,9 +13627,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15341,9 +13685,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15402,9 +13743,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15463,9 +13801,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15524,9 +13859,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15585,9 +13917,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15646,9 +13975,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15707,9 +14033,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15768,9 +14091,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15817,9 +14137,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15866,9 +14183,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15915,9 +14229,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15982,9 +14293,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16031,9 +14339,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16086,9 +14391,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16141,9 +14443,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16190,9 +14489,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16239,9 +14535,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16306,9 +14599,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16355,9 +14645,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16422,9 +14709,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16477,9 +14761,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16526,9 +14807,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16575,9 +14853,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16642,9 +14917,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16709,9 +14981,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16794,9 +15063,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16849,9 +15115,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16904,9 +15167,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16959,9 +15219,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17014,9 +15271,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17075,9 +15329,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17130,9 +15381,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17185,9 +15433,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17240,9 +15485,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17301,9 +15543,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17362,9 +15601,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17411,9 +15647,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17460,9 +15693,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17509,9 +15739,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17558,9 +15785,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17613,9 +15837,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17662,2061 +15883,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29823,7 +26134,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30069,27 +26382,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30109,23 +26435,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30137,23 +26473,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30175,23 +26521,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30275,23 +26631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30307,11 +26673,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30383,23 +26753,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30414,23 +26794,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30488,23 +26878,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30564,23 +26964,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30592,23 +27002,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30624,23 +27044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30652,23 +27082,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30696,23 +27136,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30724,23 +27174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30926,23 +27386,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30969,23 +27439,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31012,23 +27492,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31055,23 +27545,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31098,23 +27598,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31141,23 +27651,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31184,23 +27704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31227,23 +27757,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31270,23 +27810,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31313,23 +27863,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31356,23 +27916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31399,23 +27969,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31442,23 +28022,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31485,23 +28075,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31528,23 +28128,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31571,23 +28181,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31614,23 +28234,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31657,23 +28287,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31700,23 +28340,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31743,23 +28393,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31786,23 +28446,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31829,23 +28499,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31872,23 +28552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31915,23 +28605,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32075,23 +28775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32493,23 +29203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32530,23 +29250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32672,23 +29402,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32718,23 +29458,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32774,23 +29524,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32820,23 +29580,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33004,12 +29774,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33025,23 +29807,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33386,23 +30178,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33430,9 +30232,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33448,8 +30257,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33590,9 +30403,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36256,9 +33076,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36717,9 +33544,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37109,9 +33943,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37370,9 +34211,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37697,9 +34545,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37715,9 +34570,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37733,9 +34595,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37751,9 +34620,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37778,9 +34654,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37835,9 +34718,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37862,9 +34752,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37927,9 +34824,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37969,9 +34873,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38290,9 +35201,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38378,9 +35296,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38492,9 +35417,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38606,9 +35538,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38720,9 +35659,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38834,9 +35780,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38948,9 +35901,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39119,9 +36079,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39258,9 +36225,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39466,9 +36440,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39637,9 +36618,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39808,9 +36796,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40036,9 +37031,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40321,9 +37323,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40606,9 +37615,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40874,9 +37890,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41159,9 +38182,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41401,9 +38431,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41686,9 +38723,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41868,7 +38912,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41883,7 +38929,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41898,7 +38946,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41913,7 +38963,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41928,7 +38980,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41943,7 +38997,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41958,7 +39014,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41973,7 +39031,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41988,7 +39048,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42003,7 +39065,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42018,7 +39082,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42033,7 +39099,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42048,7 +39116,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42063,7 +39133,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42078,7 +39150,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42093,7 +39167,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42108,7 +39184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42123,7 +39201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42138,7 +39218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42153,7 +39235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42168,7 +39252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42183,7 +39269,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42198,7 +39286,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42213,7 +39303,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42228,7 +39320,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42243,7 +39337,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42258,7 +39354,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42273,7 +39371,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42288,7 +39388,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42303,7 +39405,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42318,7 +39422,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42333,7 +39439,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42348,7 +39456,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42363,7 +39473,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42378,7 +39490,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42393,7 +39507,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42408,7 +39524,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42423,7 +39541,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42438,7 +39558,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42453,7 +39575,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42468,7 +39592,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42483,7 +39609,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42498,7 +39626,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42513,7 +39643,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42528,7 +39660,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42543,7 +39677,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42558,7 +39694,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42573,7 +39711,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42588,7 +39728,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42603,7 +39745,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42618,7 +39762,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42633,7 +39779,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42648,7 +39796,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42663,7 +39813,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42678,7 +39830,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42693,7 +39847,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42708,7 +39864,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42723,7 +39881,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42738,7 +39898,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42753,7 +39915,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42768,7 +39932,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42783,7 +39949,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42798,7 +39966,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42813,7 +39983,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42828,7 +40000,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42843,7 +40017,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42858,7 +40034,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42873,7 +40051,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42888,7 +40068,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42903,7 +40085,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42918,7 +40102,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42933,7 +40119,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42948,7 +40136,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42963,7 +40153,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42978,7 +40170,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42993,7 +40187,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43008,7 +40204,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43023,7 +40221,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43038,7 +40238,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43052,7 +40254,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43068,7 +40272,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43082,7 +40288,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43098,7 +40306,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43112,7 +40322,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43128,7 +40340,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43142,7 +40356,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43158,7 +40374,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43172,7 +40390,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43188,7 +40408,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43202,7 +40424,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43218,7 +40442,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43234,7 +40460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43248,7 +40476,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43264,7 +40494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43278,7 +40510,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43294,7 +40528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43308,7 +40544,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43324,7 +40562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43338,7 +40578,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43355,7 +40597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43369,7 +40613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43385,7 +40631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43399,7 +40647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43415,7 +40665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43429,7 +40681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43445,7 +40699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43459,7 +40715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43475,7 +40733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43491,7 +40751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43505,7 +40767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43521,7 +40785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43535,7 +40801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43551,7 +40819,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43565,7 +40835,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43581,7 +40853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43597,7 +40871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43611,7 +40887,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43627,7 +40905,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43641,7 +40921,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43657,7 +40939,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43671,7 +40955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43687,7 +40973,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43701,7 +40989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43717,7 +41007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43731,7 +41023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43747,7 +41041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43761,7 +41057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43777,7 +41075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43791,7 +41091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43807,7 +41109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43823,7 +41127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43837,7 +41143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43853,7 +41161,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43867,7 +41177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43883,7 +41195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43897,7 +41211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43913,7 +41229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43927,7 +41245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43944,7 +41264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43958,7 +41280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43974,7 +41298,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43988,7 +41314,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44004,7 +41332,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44018,7 +41348,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44034,7 +41366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44048,7 +41382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44064,7 +41400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44080,7 +41418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44094,7 +41434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44110,7 +41452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44124,7 +41468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44140,7 +41486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44154,7 +41502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44170,7 +41520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44186,7 +41538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44200,7 +41554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44216,193 +41572,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44410,15 +41846,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44426,15 +41868,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44442,15 +41890,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44458,15 +41912,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44474,15 +41934,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44490,15 +41956,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44506,15 +41978,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44522,15 +42000,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44538,15 +42022,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44554,11 +42044,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44571,17 +42065,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44594,17 +42094,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44617,21 +42123,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44640,11 +42154,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44660,17 +42178,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44683,65 +42207,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44750,11 +42300,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44776,21 +42330,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44799,11 +42361,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44843,7 +42409,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44880,11 +42448,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44919,35 +42491,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44956,11 +42542,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44992,7 +42582,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45001,15 +42593,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45021,11 +42619,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45044,48 +42646,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45125,18 +42745,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45176,7 +42802,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45228,56 +42856,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45305,7 +42955,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45313,11 +42965,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45345,7 +43001,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45353,11 +43011,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45392,59 +43054,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45489,30 +43175,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45547,11 +43247,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45566,9 +43271,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45603,11 +43314,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45622,9 +43338,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45659,11 +43381,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45678,9 +43405,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45715,11 +43448,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45734,9 +43472,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45771,11 +43515,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45790,9 +43539,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45827,11 +43582,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45853,9 +43613,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45870,11 +43636,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45903,17 +43674,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45935,17 +43717,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45974,9 +43767,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46011,11 +43810,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46037,9 +43841,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46079,11 +43889,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46105,9 +43920,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46142,11 +43963,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46175,9 +44001,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46222,11 +44054,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46255,9 +44092,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46292,11 +44135,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46332,9 +44180,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46369,11 +44223,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46409,17 +44268,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46455,9 +44325,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46492,11 +44368,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46532,17 +44413,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46571,9 +44463,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46613,11 +44511,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46653,9 +44556,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46690,11 +44599,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46716,9 +44630,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46758,19 +44678,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46805,11 +44736,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46894,9 +44830,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46941,11 +44883,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47296,9 +45243,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47333,11 +45286,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47351,18 +45309,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47397,11 +45366,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47415,18 +45389,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47461,11 +45446,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47479,18 +45469,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47525,11 +45526,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47543,18 +45549,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47589,11 +45606,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47607,18 +45629,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47653,11 +45686,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47678,26 +45716,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47718,9 +45772,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47755,11 +45815,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47780,18 +45845,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47831,11 +45907,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47856,18 +45937,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47902,11 +45994,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47934,18 +46031,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47990,11 +46098,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48022,19 +46135,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48069,11 +46193,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48108,18 +46237,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48154,11 +46294,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48193,18 +46338,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48239,11 +46395,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48278,18 +46439,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48329,11 +46501,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48368,27 +46545,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48423,11 +46616,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48448,18 +46646,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48499,11 +46708,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48552,18 +46766,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48598,11 +46823,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48686,27 +46916,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48751,11 +46997,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49105,23 +47356,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49156,26 +47418,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49210,26 +47482,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49264,26 +47546,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49318,26 +47610,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49372,26 +47674,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49426,38 +47738,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49492,26 +47822,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49551,26 +47891,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49605,26 +47955,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49669,27 +48029,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49724,26 +48094,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49778,26 +48158,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49832,26 +48222,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49891,32 +48291,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49951,26 +48363,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50010,26 +48432,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50064,32 +48496,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50134,13 +48578,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -65,7 +65,7 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   name: "FuncOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: Object.assign(Object.create(null), {
@@ -113,7 +113,7 @@ const attributes2 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes2,
@@ -144,7 +144,7 @@ const attributes3 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes3,
@@ -175,7 +175,7 @@ const attributes4 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes4,
@@ -206,7 +206,7 @@ const attributes5 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes5,
@@ -237,7 +237,7 @@ const attributes6 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes6,
@@ -268,7 +268,7 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
+const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes7,
@@ -307,7 +307,7 @@ const attributes8 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes8,
@@ -338,7 +338,7 @@ const attributes9 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
+const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes9,
@@ -377,7 +377,7 @@ const attributes10 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes10,
@@ -408,7 +408,7 @@ const attributes11 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
+const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes11,
@@ -421,21 +421,20 @@ const registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableM
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidCodec = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid"
-  },
-  tags: Object.create(null)
-};
-const guidCodec2 = sql.identifier(...["b", "guid"]);
-const registry_pgCodecs_guid_guidCodec = domainOfCodec(TYPES.varchar, "guid", guidCodec2, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
-  extensions: guidCodec,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "guid"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const intervalArrayCodec = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -443,13 +442,13 @@ const intervalArrayCodec = {
   },
   tags: Object.create(null)
 };
-const registry_pgCodecs_intervalArray_intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodec,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodec = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -457,13 +456,13 @@ const textArrayCodec = {
   },
   tags: Object.create(null)
 };
-const registry_pgCodecs_textArray_textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodec,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewCodecSpec_nonUpdatableViewAttributes = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -474,7 +473,7 @@ const nonUpdatableViewCodecSpec_nonUpdatableViewAttributes = Object.assign(Objec
     }
   }
 });
-const nonUpdatableViewCodecSpec = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -484,17 +483,17 @@ const nonUpdatableViewCodecSpec = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewCodecSpec2 = sql.identifier(...parts2);
-const nonUpdatableViewCodec_nonUpdatableViewCodecSpec = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewCodecSpec2,
-  attributes: nonUpdatableViewCodecSpec_nonUpdatableViewAttributes,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: nonUpdatableViewCodecSpec,
+  extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodec_nonUpdatableViewCodecSpec);
-const inputsCodecSpec_inputsAttributes = Object.assign(Object.create(null), {
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -505,7 +504,7 @@ const inputsCodecSpec_inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const inputsCodecSpec = {
+const extensions3 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -515,17 +514,17 @@ const inputsCodecSpec = {
   tags: Object.create(null)
 };
 const parts3 = ["a", "inputs"];
-const inputsCodecSpec2 = sql.identifier(...parts3);
-const inputsCodec_inputsCodecSpec = {
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
   name: "inputs",
-  identifier: inputsCodecSpec2,
-  attributes: inputsCodecSpec_inputsAttributes,
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: inputsCodecSpec,
+  extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_inputs_inputsCodec = recordCodec(inputsCodec_inputsCodecSpec);
-const patchsCodecSpec_patchsAttributes = Object.assign(Object.create(null), {
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -536,7 +535,7 @@ const patchsCodecSpec_patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const patchsCodecSpec = {
+const extensions4 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -546,17 +545,17 @@ const patchsCodecSpec = {
   tags: Object.create(null)
 };
 const parts4 = ["a", "patchs"];
-const patchsCodecSpec2 = sql.identifier(...parts4);
-const patchsCodec_patchsCodecSpec = {
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
   name: "patchs",
-  identifier: patchsCodecSpec2,
-  attributes: patchsCodecSpec_patchsAttributes,
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: patchsCodecSpec,
+  extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_patchs_patchsCodec = recordCodec(patchsCodec_patchsCodecSpec);
-const reservedCodecSpec_reservedAttributes = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -567,7 +566,7 @@ const reservedCodecSpec_reservedAttributes = Object.assign(Object.create(null), 
     }
   }
 });
-const reservedCodecSpec = {
+const extensions5 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -577,17 +576,17 @@ const reservedCodecSpec = {
   tags: Object.create(null)
 };
 const parts5 = ["a", "reserved"];
-const reservedCodecSpec2 = sql.identifier(...parts5);
-const reservedCodec_reservedCodecSpec = {
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
   name: "reserved",
-  identifier: reservedCodecSpec2,
-  attributes: reservedCodecSpec_reservedAttributes,
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
   description: undefined,
-  extensions: reservedCodecSpec,
+  extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_reserved_reservedCodec = recordCodec(reservedCodec_reservedCodecSpec);
-const reservedPatchsCodecSpec_reservedPatchsAttributes = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -598,7 +597,7 @@ const reservedPatchsCodecSpec_reservedPatchsAttributes = Object.assign(Object.cr
     }
   }
 });
-const reservedPatchsCodecSpec = {
+const extensions6 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -608,17 +607,17 @@ const reservedPatchsCodecSpec = {
   tags: Object.create(null)
 };
 const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsCodecSpec2 = sql.identifier(...parts6);
-const reservedPatchsCodec_reservedPatchsCodecSpec = {
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
   name: "reservedPatchs",
-  identifier: reservedPatchsCodecSpec2,
-  attributes: reservedPatchsCodecSpec_reservedPatchsAttributes,
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: reservedPatchsCodecSpec,
+  extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_reservedPatchs_reservedPatchsCodec = recordCodec(reservedPatchsCodec_reservedPatchsCodecSpec);
-const reservedInputCodecSpec_reservedInputAttributes = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -629,7 +628,7 @@ const reservedInputCodecSpec_reservedInputAttributes = Object.assign(Object.crea
     }
   }
 });
-const reservedInputCodecSpec = {
+const extensions7 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -639,17 +638,17 @@ const reservedInputCodecSpec = {
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const reservedInputCodecSpec2 = sql.identifier(...parts7);
-const reservedInputCodec_reservedInputCodecSpec = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: reservedInputCodecSpec2,
-  attributes: reservedInputCodecSpec_reservedInputAttributes,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: reservedInputCodecSpec,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_reservedInput_reservedInputCodec = recordCodec(reservedInputCodec_reservedInputCodecSpec);
-const defaultValueCodecSpec_defaultValueAttributes = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -669,7 +668,7 @@ const defaultValueCodecSpec_defaultValueAttributes = Object.assign(Object.create
     }
   }
 });
-const defaultValueCodecSpec = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -679,17 +678,17 @@ const defaultValueCodecSpec = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const defaultValueCodecSpec2 = sql.identifier(...parts8);
-const defaultValueCodec_defaultValueCodecSpec = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: defaultValueCodecSpec2,
-  attributes: defaultValueCodecSpec_defaultValueAttributes,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: defaultValueCodecSpec,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_defaultValue_defaultValueCodec = recordCodec(defaultValueCodec_defaultValueCodecSpec);
-const foreignKeyCodecSpec_foreignKeyAttributes = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -718,7 +717,7 @@ const foreignKeyCodecSpec_foreignKeyAttributes = Object.assign(Object.create(nul
     }
   }
 });
-const foreignKeyCodecSpec = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -728,17 +727,17 @@ const foreignKeyCodecSpec = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const foreignKeyCodecSpec2 = sql.identifier(...parts9);
-const foreignKeyCodec_foreignKeyCodecSpec = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: foreignKeyCodecSpec2,
-  attributes: foreignKeyCodecSpec_foreignKeyAttributes,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: foreignKeyCodecSpec,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_foreignKey_foreignKeyCodec = recordCodec(foreignKeyCodec_foreignKeyCodecSpec);
-const noPrimaryKeyCodecSpec_noPrimaryKeyAttributes = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -758,7 +757,7 @@ const noPrimaryKeyCodecSpec_noPrimaryKeyAttributes = Object.assign(Object.create
     }
   }
 });
-const noPrimaryKeyCodecSpec = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -768,17 +767,17 @@ const noPrimaryKeyCodecSpec = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyCodecSpec2 = sql.identifier(...parts10);
-const noPrimaryKeyCodec_noPrimaryKeyCodecSpec = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyCodecSpec2,
-  attributes: noPrimaryKeyCodecSpec_noPrimaryKeyAttributes,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: noPrimaryKeyCodecSpec,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodec_noPrimaryKeyCodecSpec);
-const testviewCodecSpec_testviewAttributes = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -807,7 +806,7 @@ const testviewCodecSpec_testviewAttributes = Object.assign(Object.create(null), 
     }
   }
 });
-const testviewCodecSpec = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -817,17 +816,17 @@ const testviewCodecSpec = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const testviewCodecSpec2 = sql.identifier(...parts11);
-const testviewCodec_testviewCodecSpec = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: testviewCodecSpec2,
-  attributes: testviewCodecSpec_testviewAttributes,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: testviewCodecSpec,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_testview_testviewCodec = recordCodec(testviewCodec_testviewCodecSpec);
-const uniqueForeignKeyCodecSpec_uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -847,7 +846,7 @@ const uniqueForeignKeyCodecSpec_uniqueForeignKeyAttributes = Object.assign(Objec
     }
   }
 });
-const uniqueForeignKeyCodecSpec = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -860,17 +859,17 @@ const uniqueForeignKeyCodecSpec = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyCodecSpec2 = sql.identifier(...parts12);
-const uniqueForeignKeyCodec_uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyCodecSpec2,
-  attributes: uniqueForeignKeyCodecSpec_uniqueForeignKeyAttributes,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: uniqueForeignKeyCodecSpec,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodec_uniqueForeignKeyCodecSpec);
-const myTableCodecSpec_myTableAttributes = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -890,7 +889,7 @@ const myTableCodecSpec_myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableCodecSpec = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -900,17 +899,17 @@ const myTableCodecSpec = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const myTableCodecSpec2 = sql.identifier(...parts13);
-const myTableCodec_myTableCodecSpec = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: myTableCodecSpec2,
-  attributes: myTableCodecSpec_myTableAttributes,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: myTableCodecSpec,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_myTable_myTableCodec = recordCodec(myTableCodec_myTableCodecSpec);
-const personSecretCodecSpec_personSecretAttributes = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -932,7 +931,7 @@ const personSecretCodecSpec_personSecretAttributes = Object.assign(Object.create
     }
   }
 });
-const personSecretCodecSpec = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -944,17 +943,17 @@ const personSecretCodecSpec = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const personSecretCodecSpec2 = sql.identifier(...parts14);
-const personSecretCodec_personSecretCodecSpec = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: personSecretCodecSpec2,
-  attributes: personSecretCodecSpec_personSecretAttributes,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: personSecretCodecSpec,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_personSecret_personSecretCodec = recordCodec(personSecretCodec_personSecretCodecSpec);
-const viewTableCodecSpec_viewTableAttributes = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -983,7 +982,7 @@ const viewTableCodecSpec_viewTableAttributes = Object.assign(Object.create(null)
     }
   }
 });
-const viewTableCodecSpec = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -993,17 +992,17 @@ const viewTableCodecSpec = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const viewTableCodecSpec2 = sql.identifier(...parts15);
-const viewTableCodec_viewTableCodecSpec = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: viewTableCodecSpec2,
-  attributes: viewTableCodecSpec_viewTableAttributes,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: viewTableCodecSpec,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_viewTable_viewTableCodec = recordCodec(viewTableCodec_viewTableCodecSpec);
-const compoundKeyCodecSpec_compoundKeyAttributes = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1032,7 +1031,7 @@ const compoundKeyCodecSpec_compoundKeyAttributes = Object.assign(Object.create(n
     }
   }
 });
-const compoundKeyCodecSpec = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1042,17 +1041,17 @@ const compoundKeyCodecSpec = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const compoundKeyCodecSpec2 = sql.identifier(...parts16);
-const compoundKeyCodec_compoundKeyCodecSpec = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: compoundKeyCodecSpec2,
-  attributes: compoundKeyCodecSpec_compoundKeyAttributes,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: compoundKeyCodecSpec,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_compoundKey_compoundKeyCodec = recordCodec(compoundKeyCodec_compoundKeyCodecSpec);
-const similarTable1CodecSpec_similarTable1Attributes = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1090,7 +1089,7 @@ const similarTable1CodecSpec_similarTable1Attributes = Object.assign(Object.crea
     }
   }
 });
-const similarTable1CodecSpec = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1100,17 +1099,17 @@ const similarTable1CodecSpec = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const similarTable1CodecSpec2 = sql.identifier(...parts17);
-const similarTable1Codec_similarTable1CodecSpec = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: similarTable1CodecSpec2,
-  attributes: similarTable1CodecSpec_similarTable1Attributes,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: similarTable1CodecSpec,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_similarTable1_similarTable1Codec = recordCodec(similarTable1Codec_similarTable1CodecSpec);
-const similarTable2CodecSpec_similarTable2Attributes = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1148,7 +1147,7 @@ const similarTable2CodecSpec_similarTable2Attributes = Object.assign(Object.crea
     }
   }
 });
-const similarTable2CodecSpec = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1158,17 +1157,17 @@ const similarTable2CodecSpec = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const similarTable2CodecSpec2 = sql.identifier(...parts18);
-const similarTable2Codec_similarTable2CodecSpec = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: similarTable2CodecSpec2,
-  attributes: similarTable2CodecSpec_similarTable2Attributes,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: similarTable2CodecSpec,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_similarTable2_similarTable2Codec = recordCodec(similarTable2Codec_similarTable2CodecSpec);
-const updatableViewCodecSpec_updatableViewAttributes = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1206,7 +1205,7 @@ const updatableViewCodecSpec_updatableViewAttributes = Object.assign(Object.crea
     }
   }
 });
-const updatableViewCodecSpec = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1219,17 +1218,17 @@ const updatableViewCodecSpec = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const updatableViewCodecSpec2 = sql.identifier(...parts19);
-const updatableViewCodec_updatableViewCodecSpec = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: updatableViewCodecSpec2,
-  attributes: updatableViewCodecSpec_updatableViewAttributes,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: updatableViewCodecSpec,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_updatableView_updatableViewCodec = recordCodec(updatableViewCodec_updatableViewCodecSpec);
-const nullTestRecordCodecSpec_nullTestRecordAttributes = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1267,7 +1266,7 @@ const nullTestRecordCodecSpec_nullTestRecordAttributes = Object.assign(Object.cr
     }
   }
 });
-const nullTestRecordCodecSpec = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1277,17 +1276,17 @@ const nullTestRecordCodecSpec = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const nullTestRecordCodecSpec2 = sql.identifier(...parts20);
-const nullTestRecordCodec_nullTestRecordCodecSpec = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: nullTestRecordCodecSpec2,
-  attributes: nullTestRecordCodecSpec_nullTestRecordAttributes,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: nullTestRecordCodecSpec,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_nullTestRecord_nullTestRecordCodec = recordCodec(nullTestRecordCodec_nullTestRecordCodecSpec);
-const uuidArrayCodec = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1295,13 +1294,13 @@ const uuidArrayCodec = {
   },
   tags: Object.create(null)
 };
-const registry_pgCodecs_uuidArray_uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodec,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseCodecSpec_edgeCaseAttributes = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1330,7 +1329,7 @@ const edgeCaseCodecSpec_edgeCaseAttributes = Object.assign(Object.create(null), 
     }
   }
 });
-const edgeCaseCodecSpec = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1340,17 +1339,17 @@ const edgeCaseCodecSpec = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const edgeCaseCodecSpec2 = sql.identifier(...parts21);
-const edgeCaseCodec_edgeCaseCodecSpec = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: edgeCaseCodecSpec2,
-  attributes: edgeCaseCodecSpec_edgeCaseAttributes,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: edgeCaseCodecSpec,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_edgeCase_edgeCaseCodec = recordCodec(edgeCaseCodec_edgeCaseCodecSpec);
-const leftArmCodecSpec_leftArmAttributes = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1388,7 +1387,7 @@ const leftArmCodecSpec_leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const leftArmCodecSpec = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1398,17 +1397,17 @@ const leftArmCodecSpec = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const leftArmCodecSpec2 = sql.identifier(...parts22);
-const leftArmCodec_leftArmCodecSpec = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: leftArmCodecSpec2,
-  attributes: leftArmCodecSpec_leftArmAttributes,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: leftArmCodecSpec,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_leftArm_leftArmCodec = recordCodec(leftArmCodec_leftArmCodecSpec);
-const jwtTokenCodecSpec_jwtTokenAttributes = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1455,7 +1454,7 @@ const jwtTokenCodecSpec_jwtTokenAttributes = Object.assign(Object.create(null), 
     }
   }
 });
-const jwtTokenCodecSpec = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1465,17 +1464,17 @@ const jwtTokenCodecSpec = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const jwtTokenCodecSpec2 = sql.identifier(...parts23);
-const jwtTokenCodec_jwtTokenCodecSpec = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: jwtTokenCodecSpec2,
-  attributes: jwtTokenCodecSpec_jwtTokenAttributes,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: jwtTokenCodecSpec,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_jwtToken_jwtTokenCodec = recordCodec(jwtTokenCodec_jwtTokenCodecSpec);
-const notNullTimestampCodec = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1484,13 +1483,13 @@ const notNullTimestampCodec = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampCodec2 = sql.identifier(...parts24);
-const issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampCodec2, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: notNullTimestampCodec,
+  extensions: extensions24,
   notNull: true
 });
-const issue756CodecSpec_issue756Attributes = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1502,7 +1501,7 @@ const issue756CodecSpec_issue756Attributes = Object.assign(Object.create(null), 
   },
   ts: {
     description: undefined,
-    codec: issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1510,7 +1509,7 @@ const issue756CodecSpec_issue756Attributes = Object.assign(Object.create(null), 
     }
   }
 });
-const issue756CodecSpec = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1520,20 +1519,20 @@ const issue756CodecSpec = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const issue756CodecSpec2 = sql.identifier(...parts25);
-const issue756Codec_issue756CodecSpec = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: issue756CodecSpec2,
-  attributes: issue756CodecSpec_issue756Attributes,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: issue756CodecSpec,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_issue756_issue756Codec = recordCodec(issue756Codec_issue756CodecSpec);
-const authPayloadCodecSpec_authPayloadAttributes = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registry_pgCodecs_jwtToken_jwtTokenCodec,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1559,7 +1558,7 @@ const authPayloadCodecSpec_authPayloadAttributes = Object.assign(Object.create(n
     }
   }
 });
-const authPayloadCodecSpec = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1571,18 +1570,17 @@ const authPayloadCodecSpec = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const authPayloadCodecSpec2 = sql.identifier(...parts26);
-const authPayloadCodec_authPayloadCodecSpec = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: authPayloadCodecSpec2,
-  attributes: authPayloadCodecSpec_authPayloadAttributes,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: authPayloadCodecSpec,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_authPayload_authPayloadCodec = recordCodec(authPayloadCodec_authPayloadCodecSpec);
-const colorCodec = ["red", "green", "blue"];
-const colorCodec2 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1591,16 +1589,15 @@ const colorCodec2 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const colorCodec3 = sql.identifier(...parts27);
-const compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: colorCodec3,
-  values: colorCodec,
+  identifier: sql.identifier(...parts27),
+  values: ["red", "green", "blue"],
   description: undefined,
-  extensions: colorCodec2
+  extensions: extensions27
 });
-const enumCapsCodec = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const enumCapsCodec2 = {
+const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1609,16 +1606,16 @@ const enumCapsCodec2 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const enumCapsCodec3 = sql.identifier(...parts28);
-const compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: enumCapsCodec3,
-  values: enumCapsCodec,
+  identifier: sqlIdent2,
+  values: enumLabels2,
   description: undefined,
-  extensions: enumCapsCodec2
+  extensions: extensions28
 });
-const enumWithEmptyStringCodec = ["", "one", "two"];
-const enumWithEmptyStringCodec2 = {
+const enumLabels3 = ["", "one", "two"];
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1627,15 +1624,15 @@ const enumWithEmptyStringCodec2 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const enumWithEmptyStringCodec3 = sql.identifier(...parts29);
-const compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: enumWithEmptyStringCodec3,
-  values: enumWithEmptyStringCodec,
+  identifier: sqlIdent3,
+  values: enumLabels3,
   description: undefined,
-  extensions: enumWithEmptyStringCodec2
+  extensions: extensions29
 });
-const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1656,7 +1653,7 @@ const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create
   },
   c: {
     description: undefined,
-    codec: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1674,7 +1671,7 @@ const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create
   },
   e: {
     description: undefined,
-    codec: compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1683,7 +1680,7 @@ const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create
   },
   f: {
     description: undefined,
-    codec: compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1709,7 +1706,7 @@ const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create
     }
   }
 });
-const compoundTypeCodecSpec = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1719,16 +1716,16 @@ const compoundTypeCodecSpec = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const compoundTypeCodecSpec2 = sql.identifier(...parts30);
-const compoundTypeCodec_compoundTypeCodecSpec = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: compoundTypeCodecSpec2,
-  attributes: compoundTypeCodecSpec_compoundTypeAttributes,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: compoundTypeCodecSpec,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundTypeCodec = recordCodec(compoundTypeCodec_compoundTypeCodecSpec);
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
 const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
@@ -1740,14 +1737,14 @@ const attributes12 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
     }
   }
 });
-const registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes12,
@@ -1771,14 +1768,14 @@ const attributes13 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
     }
   }
 });
-const registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes13,
@@ -1791,7 +1788,7 @@ const registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundT
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodec = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1799,8 +1796,8 @@ const anEnumArrayCodec = {
   },
   tags: Object.create(null)
 };
-const anEnumCodec = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const anEnumCodec2 = {
+const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1809,21 +1806,21 @@ const anEnumCodec2 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const anEnumCodec3 = sql.identifier(...parts31);
-const anEnumArrayCodec_anEnumCodec = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: anEnumCodec3,
-  values: anEnumCodec,
+  identifier: sqlIdent4,
+  values: enumLabels4,
   description: undefined,
-  extensions: anEnumCodec2
+  extensions: extensions31
 });
-const postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec = listOfCodec(anEnumArrayCodec_anEnumCodec, {
-  extensions: anEnumArrayCodec,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodec = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1831,7 +1828,7 @@ const comptypeArrayCodec = {
   },
   tags: Object.create(null)
 };
-const comptypeCodecSpec_comptypeAttributes = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1851,7 +1848,7 @@ const comptypeCodecSpec_comptypeAttributes = Object.assign(Object.create(null), 
     }
   }
 });
-const comptypeCodecSpec = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1861,23 +1858,23 @@ const comptypeCodecSpec = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const comptypeCodecSpec2 = sql.identifier(...parts32);
-const comptypeCodec_comptypeCodecSpec = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: comptypeCodecSpec2,
-  attributes: comptypeCodecSpec_comptypeAttributes,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: comptypeCodecSpec,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const comptypeArrayCodec_comptypeCodec = recordCodec(comptypeCodec_comptypeCodecSpec);
-const postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec = listOfCodec(comptypeArrayCodec_comptypeCodec, {
-  extensions: comptypeArrayCodec,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postCodecSpec_postAttributes = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1916,7 +1913,7 @@ const postCodecSpec_postAttributes = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1925,7 +1922,7 @@ const postCodecSpec_postAttributes = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1933,7 +1930,7 @@ const postCodecSpec_postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const postCodecSpec = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1943,16 +1940,16 @@ const postCodecSpec = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const postCodecSpec2 = sql.identifier(...parts33);
-const postCodec_postCodecSpec = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: postCodecSpec2,
-  attributes: postCodecSpec_postAttributes,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: postCodecSpec,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_postCodec = recordCodec(postCodec_postCodecSpec);
+const postCodec = recordCodec(postCodecSpec);
 const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
@@ -1964,7 +1961,7 @@ const attributes14 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registry_pgCodecs_leftArm_leftArmCodec,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1972,14 +1969,14 @@ const attributes14 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_postCodec,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
     }
   }
 });
-const registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
+const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes14,
@@ -2010,7 +2007,7 @@ const attributes15 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
+const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes15,
@@ -2041,7 +2038,7 @@ const attributes16 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
+const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes16,
@@ -2054,7 +2051,7 @@ const registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const emailCodec = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2063,13 +2060,13 @@ const emailCodec = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const emailCodec2 = sql.identifier(...parts34);
-const personCodecSpec_personAttributes_email_codec_emailCodec = domainOfCodec(TYPES.text, "email", emailCodec2, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: emailCodec,
+  extensions: extensions34,
   notNull: false
 });
-const notNullUrlCodec = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2078,16 +2075,16 @@ const notNullUrlCodec = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const notNullUrlCodec2 = sql.identifier(...parts35);
-const wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlCodec2, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: notNullUrlCodec,
+  extensions: extensions35,
   notNull: true
 });
-const wrappedUrlCodecSpec_wrappedUrlAttributes = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2095,7 +2092,7 @@ const wrappedUrlCodecSpec_wrappedUrlAttributes = Object.assign(Object.create(nul
     }
   }
 });
-const wrappedUrlCodecSpec = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2105,17 +2102,17 @@ const wrappedUrlCodecSpec = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const wrappedUrlCodecSpec2 = sql.identifier(...parts36);
-const wrappedUrlCodec_wrappedUrlCodecSpec = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: wrappedUrlCodecSpec2,
-  attributes: wrappedUrlCodecSpec_wrappedUrlAttributes,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: wrappedUrlCodecSpec,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const personCodecSpec_personAttributes_site_codec_wrappedUrlCodec = recordCodec(wrappedUrlCodec_wrappedUrlCodecSpec);
-const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2138,7 +2135,7 @@ const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registry_pgCodecs_textArray_textArrayCodec,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2156,7 +2153,7 @@ const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: personCodecSpec_personAttributes_email_codec_emailCodec,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2165,7 +2162,7 @@ const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: personCodecSpec_personAttributes_site_codec_wrappedUrlCodec,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2220,7 +2217,7 @@ const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const personCodecSpec = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2230,20 +2227,20 @@ const personCodecSpec = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const personCodecSpec2 = sql.identifier(...parts37);
-const personCodec_personCodecSpec = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: personCodecSpec2,
-  attributes: personCodecSpec_personAttributes,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: personCodecSpec,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_personCodec = recordCodec(personCodec_personCodecSpec);
+const personCodec = recordCodec(personCodecSpec);
 const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2258,7 +2255,7 @@ const attributes17 = Object.assign(Object.create(null), {
     }
   }
 });
-const registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
+const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes17,
@@ -2282,7 +2279,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2290,14 +2287,14 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes18,
@@ -2321,7 +2318,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2329,14 +2326,14 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
+const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes19,
@@ -2360,7 +2357,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2368,14 +2365,14 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes20,
@@ -2399,7 +2396,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2407,14 +2404,14 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
+const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes21,
@@ -2438,7 +2435,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2446,14 +2443,14 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_personCodec,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
     }
   }
 });
-const registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
+const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes22,
@@ -2466,7 +2463,7 @@ const registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodec = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2474,13 +2471,13 @@ const colorArrayCodec = {
   },
   tags: Object.create(null)
 };
-const typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec = listOfCodec(compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec, {
-  extensions: colorArrayCodec,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const anIntCodec = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2489,13 +2486,13 @@ const anIntCodec = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const anIntCodec2 = sql.identifier(...parts38);
-const typesCodecSpec_typesAttributes_domain_codec_anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntCodec2, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: anIntCodec,
+  extensions: extensions38,
   notNull: false
 });
-const anotherIntCodec = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2504,13 +2501,13 @@ const anotherIntCodec = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const anotherIntCodec2 = sql.identifier(...parts39);
-const typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec = domainOfCodec(typesCodecSpec_typesAttributes_domain_codec_anIntCodec, "anotherInt", anotherIntCodec2, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: anotherIntCodec,
+  extensions: extensions39,
   notNull: false
 });
-const numrangeCodec = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2519,12 +2516,12 @@ const numrangeCodec = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const numrangeCodec2 = sql.identifier(...parts40);
-const typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", numrangeCodec2, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: numrangeCodec
+  extensions: extensions40
 });
-const daterangeCodec = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2533,12 +2530,12 @@ const daterangeCodec = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const daterangeCodec2 = sql.identifier(...parts41);
-const typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec = rangeOfCodec(TYPES.date, "daterange", daterangeCodec2, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: daterangeCodec
+  extensions: extensions41
 });
-const anIntRangeCodec = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2547,15 +2544,15 @@ const anIntRangeCodec = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const anIntRangeCodec2 = sql.identifier(...parts42);
-const typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec = rangeOfCodec(typesCodecSpec_typesAttributes_domain_codec_anIntCodec, "anIntRange", anIntRangeCodec2, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: anIntRangeCodec
+  extensions: extensions42
 });
-const nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2564,7 +2561,7 @@ const nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes = Object.assign(O
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2581,7 +2578,7 @@ const nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes = Object.assign(O
     }
   }
 });
-const nestedCompoundTypeCodecSpec = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2591,17 +2588,17 @@ const nestedCompoundTypeCodecSpec = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeCodecSpec2 = sql.identifier(...parts43);
-const nestedCompoundTypeCodec_nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeCodecSpec2,
-  attributes: nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: nestedCompoundTypeCodecSpec,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodec_nestedCompoundTypeCodecSpec);
-const textArrayDomainCodec = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2610,13 +2607,13 @@ const textArrayDomainCodec = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const textArrayDomainCodec2 = sql.identifier(...parts44);
-const typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec = domainOfCodec(registry_pgCodecs_textArray_textArrayCodec, "textArrayDomain", textArrayDomainCodec2, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: textArrayDomainCodec,
+  extensions: extensions44,
   notNull: false
 });
-const int8ArrayDomainCodec = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2624,7 +2621,7 @@ const int8ArrayDomainCodec = {
   },
   tags: Object.create(null)
 };
-const int8ArrayCodec = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2632,20 +2629,20 @@ const int8ArrayCodec = {
   },
   tags: Object.create(null)
 };
-const int8ArrayDomainCodec_int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodec,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainCodec2 = sql.identifier(...parts45);
-const typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec = domainOfCodec(int8ArrayDomainCodec_int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainCodec2, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: int8ArrayDomainCodec,
+  extensions: extensions45,
   notNull: false
 });
-const byteaArrayCodec = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2653,13 +2650,13 @@ const byteaArrayCodec = {
   },
   tags: Object.create(null)
 };
-const typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodec,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const typesCodecSpec_typesAttributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2671,8 +2668,8 @@ const typesCodecSpec_typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesCodecSpec_typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesCodecSpec_typesAttributes_ltree_codec_ltree);
-const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2738,7 +2735,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2747,7 +2744,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2756,7 +2753,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_domain_codec_anIntCodec,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2765,7 +2762,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2774,7 +2771,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registry_pgCodecs_textArray_textArrayCodec,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2801,7 +2798,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2810,7 +2807,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2819,7 +2816,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2828,7 +2825,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2891,7 +2888,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2909,7 +2906,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2918,7 +2915,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2927,7 +2924,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundTypeCodec,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2936,7 +2933,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3062,7 +3059,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3071,7 +3068,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3089,7 +3086,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3098,7 +3095,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3107,7 +3104,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: typesCodecSpec_typesAttributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3115,7 +3112,7 @@ const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const typesCodecSpec = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3127,17 +3124,17 @@ const typesCodecSpec = {
   })
 };
 const parts46 = ["b", "types"];
-const typesCodecSpec2 = sql.identifier(...parts46);
-const typesCodec_typesCodecSpec = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: typesCodecSpec2,
-  attributes: typesCodecSpec_typesAttributes,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: typesCodecSpec,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registry_pgCodecs_types_typesCodec = recordCodec(typesCodec_typesCodecSpec);
-const compoundTypeArrayCodec = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3145,7 +3142,7 @@ const compoundTypeArrayCodec = {
   },
   tags: Object.create(null)
 };
-const jwtTokenArrayCodec = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3153,7 +3150,7 @@ const jwtTokenArrayCodec = {
   },
   tags: Object.create(null)
 };
-const typesArrayCodec = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3161,7 +3158,7 @@ const typesArrayCodec = {
   },
   tags: Object.create(null)
 };
-const int4ArrayCodec = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3169,13 +3166,13 @@ const int4ArrayCodec = {
   },
   tags: Object.create(null)
 };
-const registry_pgCodecs_int4Array_int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodec,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const floatrangeCodec = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3184,12 +3181,12 @@ const floatrangeCodec = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const floatrangeCodec2 = sql.identifier(...parts47);
-const registry_pgCodecs_floatrange_floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", floatrangeCodec2, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: floatrangeCodec
+  extensions: extensions47
 });
-const postArrayCodec = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3197,13 +3194,13 @@ const postArrayCodec = {
   },
   tags: Object.create(null)
 };
-const registry_pgCodecs_postArray_postArrayCodec = listOfCodec(attributes_post_codec_postCodec, {
-  extensions: postArrayCodec,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2CodecSpec_tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3232,7 +3229,7 @@ const tablefuncCrosstab2CodecSpec_tablefuncCrosstab2Attributes = Object.assign(O
     }
   }
 });
-const tablefuncCrosstab2CodecSpec = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3242,16 +3239,16 @@ const tablefuncCrosstab2CodecSpec = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2CodecSpec2 = sql.identifier(...parts48);
-const tablefuncCrosstab2Codec_tablefuncCrosstab2CodecSpec = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2CodecSpec2,
-  attributes: tablefuncCrosstab2CodecSpec_tablefuncCrosstab2Attributes,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: tablefuncCrosstab2CodecSpec,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const tablefuncCrosstab3CodecSpec_tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3289,7 +3286,7 @@ const tablefuncCrosstab3CodecSpec_tablefuncCrosstab3Attributes = Object.assign(O
     }
   }
 });
-const tablefuncCrosstab3CodecSpec = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3299,16 +3296,16 @@ const tablefuncCrosstab3CodecSpec = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3CodecSpec2 = sql.identifier(...parts49);
-const tablefuncCrosstab3Codec_tablefuncCrosstab3CodecSpec = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3CodecSpec2,
-  attributes: tablefuncCrosstab3CodecSpec_tablefuncCrosstab3Attributes,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: tablefuncCrosstab3CodecSpec,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const tablefuncCrosstab4CodecSpec_tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3355,7 +3352,7 @@ const tablefuncCrosstab4CodecSpec_tablefuncCrosstab4Attributes = Object.assign(O
     }
   }
 });
-const tablefuncCrosstab4CodecSpec = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3365,18 +3362,28 @@ const tablefuncCrosstab4CodecSpec = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4CodecSpec2 = sql.identifier(...parts50);
-const tablefuncCrosstab4Codec_tablefuncCrosstab4CodecSpec = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4CodecSpec2,
-  attributes: tablefuncCrosstab4CodecSpec_tablefuncCrosstab4Attributes,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: tablefuncCrosstab4CodecSpec,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
+const extensions51 = {
+  pg: {
+    serviceName: "main",
+    schemaName: "c",
+    name: "current_user_id"
+  },
+  tags: {
+    behavior: ["queryField -mutationField -typeField", "-filter -order"]
+  }
+};
 const parts51 = ["c", "current_user_id"];
-const sqlIdent = sql.identifier(...parts51);
-const extensions2 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3388,10 +3395,10 @@ const extensions2 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent2 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions3 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3403,10 +3410,10 @@ const extensions3 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent3 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions4 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3417,10 +3424,10 @@ const extensions4 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent4 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions5 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3432,10 +3439,10 @@ const extensions5 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent5 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions6 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3447,10 +3454,10 @@ const extensions6 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent6 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent6}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions7 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3461,10 +3468,10 @@ const extensions7 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent7 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent7}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions8 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3475,10 +3482,10 @@ const extensions8 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent8 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions9 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3489,10 +3496,10 @@ const extensions9 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent9 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions10 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3503,10 +3510,10 @@ const extensions10 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent10 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions11 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3517,10 +3524,10 @@ const extensions11 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent11 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions12 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3531,10 +3538,10 @@ const extensions12 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent12 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions13 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3545,10 +3552,10 @@ const extensions13 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent13 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions14 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3560,15 +3567,15 @@ const extensions14 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent14 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions15 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3580,15 +3587,15 @@ const extensions15 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent15 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions16 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3600,15 +3607,15 @@ const extensions16 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent16 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions17 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3620,15 +3627,15 @@ const extensions17 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent17 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions18 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3639,15 +3646,15 @@ const extensions18 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent18 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions19 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3659,15 +3666,15 @@ const extensions19 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent19 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions20 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3678,15 +3685,15 @@ const extensions20 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent20 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions21 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3697,15 +3704,15 @@ const extensions21 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent21 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions22 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3716,15 +3723,15 @@ const extensions22 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent22 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions23 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3735,15 +3742,15 @@ const extensions23 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions24 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3754,15 +3761,15 @@ const extensions24 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent24 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions25 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3773,15 +3780,15 @@ const extensions25 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent25 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions26 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3792,8 +3799,8 @@ const extensions26 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent26 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3805,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions27 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3816,8 +3823,8 @@ const extensions27 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent27 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3829,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions28 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3840,8 +3847,8 @@ const extensions28 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent28 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3853,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions29 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3864,8 +3871,8 @@ const extensions29 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent29 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3877,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions30 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3888,8 +3895,8 @@ const extensions30 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent30 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3901,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions31 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3912,8 +3919,8 @@ const extensions31 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent31 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3925,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions32 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3936,8 +3943,8 @@ const extensions32 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent32 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3949,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions33 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3960,8 +3967,8 @@ const extensions33 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent33 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3973,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions34 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3984,8 +3991,8 @@ const extensions34 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent34 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -3997,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions35 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4008,8 +4015,8 @@ const extensions35 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent35 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4021,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions36 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4032,8 +4039,8 @@ const extensions36 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent36 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4045,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions37 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4056,8 +4063,8 @@ const extensions37 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent37 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4069,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions38 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4080,8 +4087,8 @@ const extensions38 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent38 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4093,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions39 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4105,8 +4112,8 @@ const extensions39 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent39 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4118,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions40 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4129,10 +4136,10 @@ const extensions40 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent40 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions41 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4143,10 +4150,10 @@ const extensions41 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent41 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions42 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4157,10 +4164,10 @@ const extensions42 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent42 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions43 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4172,8 +4179,8 @@ const extensions43 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent43 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4185,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions44 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4196,10 +4203,10 @@ const extensions44 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent44 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions45 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4210,10 +4217,10 @@ const extensions45 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent45 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions46 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4224,10 +4231,10 @@ const extensions46 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent46 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions47 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4239,10 +4246,10 @@ const extensions47 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent47 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions48 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4253,8 +4260,8 @@ const extensions48 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent48 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4271,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4282,8 +4289,8 @@ const extensions49 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent49 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4300,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4311,8 +4318,8 @@ const extensions50 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent50 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4329,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4340,8 +4347,8 @@ const extensions51 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent51 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4358,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4369,8 +4376,8 @@ const extensions52 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent52 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4387,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions53 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4398,10 +4405,10 @@ const extensions53 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent53 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions54 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4412,15 +4419,15 @@ const extensions54 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent54 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions55 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4431,8 +4438,8 @@ const extensions55 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent55 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4449,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions56 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4460,8 +4467,8 @@ const extensions56 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent56 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4478,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions57 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4489,10 +4496,10 @@ const extensions57 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions58 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4503,15 +4510,15 @@ const extensions58 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4522,15 +4529,15 @@ const extensions59 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent59 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registry_pgCodecs_guid_guidCodec
+  codec: guidCodec
 }];
-const extensions60 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4541,10 +4548,10 @@ const extensions60 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent60 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions61 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4555,10 +4562,10 @@ const extensions61 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent61 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions62 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4569,10 +4576,10 @@ const extensions62 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent62 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions63 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4583,10 +4590,10 @@ const extensions63 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent63 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions64 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4597,7 +4604,7 @@ const extensions64 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions65 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4614,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions66 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4631,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions67 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4648,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4665,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions69 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4682,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions70 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4699,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions71 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4709,18 +4716,18 @@ const extensions71 = {
   tags: {}
 };
 const uniques8 = [];
-const registry_pgResources_foreign_key_foreign_key = {
+const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registry_pgCodecs_foreignKey_foreignKeyCodec.sqlType,
-  codec: registry_pgCodecs_foreignKey_foreignKeyCodec,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
+  extensions: extensions121
 };
-const extensions72 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4737,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions73 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4747,7 +4754,7 @@ const extensions73 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions74 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4756,7 +4763,7 @@ const extensions74 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: uniqueForeignKeyCodecSpec.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4767,18 +4774,18 @@ const uniques11 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_unique_foreign_key_unique_foreign_key = {
+const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec.sqlType,
-  codec: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions74
+  extensions: extensions124
 };
-const extensions75 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4795,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions76 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4814,18 +4821,18 @@ const uniques13 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_person_secret_person_secret = {
+const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registry_pgCodecs_personSecret_personSecretCodec.sqlType,
-  codec: registry_pgCodecs_personSecret_personSecretCodec,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions76
+  extensions: extensions126
 };
-const extensions77 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4842,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions78 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4859,18 +4866,18 @@ const uniques15 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_compound_key_compound_key = {
+const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registry_pgCodecs_compoundKey_compoundKeyCodec.sqlType,
-  codec: registry_pgCodecs_compoundKey_compoundKeyCodec,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions78
+  extensions: extensions128
 };
-const extensions79 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4887,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions80 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4904,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions81 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4926,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions82 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4943,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions83 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4954,21 +4961,21 @@ const extensions83 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registry_pgCodecs_edgeCase_edgeCaseCodec
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4986,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions84 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4997,13 +5004,13 @@ const extensions84 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent66 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registry_pgCodecs_textArray_textArrayCodec
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5015,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions85 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5025,7 +5032,7 @@ const extensions85 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions86 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5049,24 +5056,24 @@ const uniques21 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_left_arm_left_arm = {
+const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registry_pgCodecs_leftArm_leftArmCodec.sqlType,
-  codec: registry_pgCodecs_leftArm_leftArmCodec,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions86
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent67 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5084,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5100,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registry_pgCodecs_jwtToken_jwtTokenCodec.sqlType,
-  codec: registry_pgCodecs_jwtToken_jwtTokenCodec,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions87
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent68 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5146,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions88 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5163,30 +5170,30 @@ const uniques23 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_issue756_issue756 = {
+const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registry_pgCodecs_issue756_issue756Codec.sqlType,
-  codec: registry_pgCodecs_issue756_issue756Codec,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions88
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent69 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registry_pgCodecs_leftArm_leftArmCodec,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5209,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent70 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5233,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent71 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5257,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent72 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5296,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent73 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5334,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions89 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5351,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registry_pgCodecs_authPayload_authPayloadCodec.sqlType,
-  codec: registry_pgCodecs_authPayload_authPayloadCodec,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions89
+  extensions: extensions139
 };
-const extensions90 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5369,8 +5376,8 @@ const extensions90 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent74 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5390,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registry_pgCodecs_int4Array_int4ArrayCodec
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5400,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registry_pgCodecs_floatrange_floatrangeCodec
+  codec: floatrangeCodec
 }];
-const extensions91 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5413,8 +5420,8 @@ const extensions91 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent75 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5434,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registry_pgCodecs_int4Array_int4ArrayCodec
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5444,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registry_pgCodecs_floatrange_floatrangeCodec
+  codec: floatrangeCodec
 }];
-const extensions92 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5457,15 +5464,15 @@ const extensions92 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent76 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundTypeCodec
+  codec: compoundTypeCodec
 }];
-const extensions93 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5476,15 +5483,15 @@ const extensions93 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent77 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }];
-const extensions94 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5495,15 +5502,15 @@ const extensions94 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent78 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }];
-const extensions95 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5514,15 +5521,15 @@ const extensions95 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent79 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }];
-const extensions96 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5535,20 +5542,20 @@ const extensions96 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent80 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5561,20 +5568,20 @@ const extensions97 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent81 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5585,15 +5592,15 @@ const extensions98 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent82 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5604,15 +5611,15 @@ const extensions99 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent83 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5623,13 +5630,13 @@ const extensions100 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent84 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5641,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions101 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5652,13 +5659,13 @@ const extensions101 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent85 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5670,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions102 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5681,13 +5688,13 @@ const extensions102 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent86 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_postCodec
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5699,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions103 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5710,8 +5717,8 @@ const extensions103 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent87 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5728,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions104 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5745,24 +5752,24 @@ const uniques25 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_post_post = {
+const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_postCodec.sqlType,
-  codec: attributes_post_codec_postCodec,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions104
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent88 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5780,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions105 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5796,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundTypeCodec.sqlType,
-  codec: attributes_o2_codec_compoundTypeCodec,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions105
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent89 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5833,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent90 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5862,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent91 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5891,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent92 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5920,12 +5927,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent93 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5949,18 +5956,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent94 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_postCodec
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5984,18 +5991,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent95 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6013,18 +6020,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent96 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6042,18 +6049,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent97 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6071,18 +6078,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent98 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6100,23 +6107,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent99 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_postCodec
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundTypeCodec
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6134,18 +6141,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent100 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registry_pgCodecs_postArray_postArrayCodec
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6162,7 +6169,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions106 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6177,15 +6184,15 @@ const extensions106 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent101 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }];
-const extensions107 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6197,15 +6204,15 @@ const extensions107 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent102 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }];
-const extensions108 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6216,15 +6223,15 @@ const extensions108 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent103 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }];
-const extensions109 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6236,20 +6243,20 @@ const extensions109 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent104 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions110 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6260,20 +6267,20 @@ const extensions110 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent105 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions111 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6285,20 +6292,20 @@ const extensions111 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent106 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: personCodecSpec_personAttributes_email_codec_emailCodec
+  codec: emailCodec
 }];
-const extensions112 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6309,15 +6316,15 @@ const extensions112 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent107 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }];
-const extensions113 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6328,8 +6335,8 @@ const extensions113 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent108 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6341,7 +6348,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions114 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6352,8 +6359,8 @@ const extensions114 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent109 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6365,7 +6372,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions115 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6376,8 +6383,8 @@ const extensions115 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent110 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6389,7 +6396,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions116 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6400,8 +6407,8 @@ const extensions116 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent111 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6413,7 +6420,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions117 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6424,13 +6431,13 @@ const extensions117 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent112 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_personCodec
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6443,18 +6450,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent113 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6471,7 +6478,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions118 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6495,24 +6502,24 @@ const uniques27 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_person_person = {
+const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_personCodec.sqlType,
-  codec: attributes_person_codec_personCodec,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions118
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent114 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6532,12 +6539,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent115 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6556,12 +6563,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent116 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6580,12 +6587,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent117 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6604,12 +6611,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent118 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6628,12 +6635,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent119 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6652,12 +6659,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent120 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6678,12 +6685,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent121 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6702,18 +6709,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent122 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6732,18 +6739,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent123 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6761,7 +6768,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions119 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6769,7 +6776,7 @@ const extensions119 = {
     name: "types"
   },
   tags: {
-    foreignKey: typesCodecSpec.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6780,24 +6787,24 @@ const uniques28 = [{
     tags: Object.create(null)
   }
 }];
-const registry_pgResources_types_types = {
+const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registry_pgCodecs_types_typesCodec.sqlType,
-  codec: registry_pgCodecs_types_typesCodec,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions119
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent124 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6816,12 +6823,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent125 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6840,12 +6847,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent126 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6869,12 +6876,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent127 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6898,18 +6905,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent128 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6927,18 +6934,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent129 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6961,12 +6968,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent130 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6985,12 +6992,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent131 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7009,18 +7016,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent132 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_personCodec
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7037,7 +7044,7 @@ const options_person_type_function_list = {
   },
   description: undefined
 };
-const registry = {
+const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
     void: TYPES.void,
@@ -7045,95 +7052,95 @@ const registry = {
     int8: TYPES.bigint,
     json: TYPES.json,
     jsonb: TYPES.jsonb,
-    FuncOutOutRecord: registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
+    FuncOutOutRecord: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
     text: TYPES.text,
-    FuncOutOutSetofRecord: registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
-    FuncOutOutUnnamedRecord: registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
-    MutationOutOutRecord: registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
-    MutationOutOutSetofRecord: registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
-    MutationOutOutUnnamedRecord: registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
-    SearchTestSummariesRecord: registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
-    FuncOutUnnamedOutOutUnnamedRecord: registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
-    FuncReturnsTableMultiColRecord: registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
-    MutationOutUnnamedOutOutUnnamedRecord: registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
-    MutationReturnsTableMultiColRecord: registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registry_pgCodecs_guid_guidCodec,
+    FuncOutOutSetofRecord: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
+    FuncOutOutUnnamedRecord: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
+    MutationOutOutRecord: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
+    MutationOutOutSetofRecord: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
+    MutationOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
+    SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
+    FuncOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
+    FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
+    MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
+    MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registry_pgCodecs_intervalArray_intervalArrayCodec,
-    textArray: registry_pgCodecs_textArray_textArrayCodec,
-    nonUpdatableView: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec,
-    inputs: registry_pgCodecs_inputs_inputsCodec,
-    patchs: registry_pgCodecs_patchs_patchsCodec,
-    reserved: registry_pgCodecs_reserved_reservedCodec,
-    reservedPatchs: registry_pgCodecs_reservedPatchs_reservedPatchsCodec,
-    reservedInput: registry_pgCodecs_reservedInput_reservedInputCodec,
-    defaultValue: registry_pgCodecs_defaultValue_defaultValueCodec,
-    foreignKey: registry_pgCodecs_foreignKey_foreignKeyCodec,
-    noPrimaryKey: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec,
-    testview: registry_pgCodecs_testview_testviewCodec,
-    uniqueForeignKey: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
-    myTable: registry_pgCodecs_myTable_myTableCodec,
-    personSecret: registry_pgCodecs_personSecret_personSecretCodec,
-    viewTable: registry_pgCodecs_viewTable_viewTableCodec,
-    compoundKey: registry_pgCodecs_compoundKey_compoundKeyCodec,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registry_pgCodecs_similarTable1_similarTable1Codec,
-    similarTable2: registry_pgCodecs_similarTable2_similarTable2Codec,
-    updatableView: registry_pgCodecs_updatableView_updatableViewCodec,
-    nullTestRecord: registry_pgCodecs_nullTestRecord_nullTestRecordCodec,
-    uuidArray: registry_pgCodecs_uuidArray_uuidArrayCodec,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registry_pgCodecs_edgeCase_edgeCaseCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registry_pgCodecs_leftArm_leftArmCodec,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registry_pgCodecs_jwtToken_jwtTokenCodec,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registry_pgCodecs_issue756_issue756Codec,
-    notNullTimestamp: issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registry_pgCodecs_authPayload_authPayloadCodec,
-    FuncOutOutCompoundTypeRecord: registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundTypeCodec,
-    color: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
-    enumCaps: compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec,
-    enumWithEmptyString: compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec,
-    MutationOutOutCompoundTypeRecord: registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
-    QueryOutputTwoRowsRecord: registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_postCodec,
-    anEnumArray: postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec,
-    anEnum: anEnumArrayCodec_anEnumCodec,
-    comptypeArray: postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec,
-    comptype: comptypeArrayCodec_comptypeCodec,
-    PersonComputedOutOutRecord: registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
-    PersonComputedInoutOutRecord: registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
-    PersonComputedFirstArgInoutOutRecord: registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_personCodec,
-    email: personCodecSpec_personAttributes_email_codec_emailCodec,
-    wrappedUrl: personCodecSpec_personAttributes_site_codec_wrappedUrlCodec,
-    notNullUrl: wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec,
+    authPayload: authPayloadCodec,
+    FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
+    MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
+    QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
+    PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
+    PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
+    PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr,
     timestamp: TYPES.timestamp,
-    FuncOutComplexRecord: registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
-    FuncOutComplexSetofRecord: registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
-    MutationOutComplexRecord: registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
-    MutationOutComplexSetofRecord: registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
-    PersonComputedComplexRecord: registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registry_pgCodecs_types_typesCodec,
-    colorArray: typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec,
-    anInt: typesCodecSpec_typesAttributes_domain_codec_anIntCodec,
-    anotherInt: typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec,
-    numrange: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
-    daterange: typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec,
+    FuncOutComplexRecord: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
+    FuncOutComplexSetofRecord: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
+    MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
+    MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
+    PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7143,38 +7150,38 @@ const registry = {
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec,
-    int8ArrayDomain: typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec,
-    ltree: typesCodecSpec_typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesCodecSpec_typesAttributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundTypeCodec, {
-      extensions: compoundTypeArrayCodec,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registry_pgCodecs_jwtToken_jwtTokenCodec, {
-      extensions: jwtTokenArrayCodec,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registry_pgCodecs_types_typesCodec, {
-      extensions: typesArrayCodec,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registry_pgCodecs_int4Array_int4ArrayCodec,
-    floatrange: registry_pgCodecs_floatrange_floatrangeCodec,
-    postArray: registry_pgCodecs_postArray_postArrayCodec,
-    int8Array: int8ArrayDomainCodec_int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2Codec_tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3Codec_tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4Codec_tablefuncCrosstab4CodecSpec)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7182,23 +7189,14 @@ const registry = {
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: {
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "current_user_id"
-        },
-        tags: {
-          behavior: ["queryField -mutationField -typeField", "-filter -order"]
-        }
-      },
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7211,7 +7209,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions2,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7224,7 +7222,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions3,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7237,7 +7235,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions4,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7250,7 +7248,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions5,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7263,7 +7261,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions6,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7276,7 +7274,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions7,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7289,7 +7287,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions8,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7302,7 +7300,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions9,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7315,7 +7313,7 @@ const registry = {
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions10,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7328,7 +7326,7 @@ const registry = {
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions11,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7341,7 +7339,7 @@ const registry = {
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions12,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7354,7 +7352,7 @@ const registry = {
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions13,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7367,7 +7365,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions14,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7380,7 +7378,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions15,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7393,7 +7391,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions16,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7406,7 +7404,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions17,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7419,7 +7417,7 @@ const registry = {
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions18,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7432,7 +7430,7 @@ const registry = {
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7445,7 +7443,7 @@ const registry = {
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions20,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7458,7 +7456,7 @@ const registry = {
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions21,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7471,7 +7469,7 @@ const registry = {
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions22,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7484,7 +7482,7 @@ const registry = {
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions23,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7497,7 +7495,7 @@ const registry = {
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions24,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7510,7 +7508,7 @@ const registry = {
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions25,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7523,7 +7521,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions26,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7536,7 +7534,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions27,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7549,7 +7547,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions28,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7562,7 +7560,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions29,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7575,7 +7573,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions30,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7588,7 +7586,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7601,7 +7599,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions32,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7614,7 +7612,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions33,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7627,7 +7625,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions34,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7640,7 +7638,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7653,7 +7651,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7666,7 +7664,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7679,7 +7677,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions38,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7692,7 +7690,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7702,10 +7700,10 @@ const registry = {
       from: fromCallback40,
       parameters: parameters40,
       isUnique: !false,
-      codec: registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
+      codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7715,10 +7713,10 @@ const registry = {
       from: fromCallback41,
       parameters: parameters41,
       isUnique: !true,
-      codec: registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
+      codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7728,10 +7726,10 @@ const registry = {
       from: fromCallback42,
       parameters: parameters42,
       isUnique: !false,
-      codec: registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
+      codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7744,7 +7742,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7754,10 +7752,10 @@ const registry = {
       from: fromCallback44,
       parameters: parameters44,
       isUnique: !false,
-      codec: registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
+      codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7767,10 +7765,10 @@ const registry = {
       from: fromCallback45,
       parameters: parameters45,
       isUnique: !true,
-      codec: registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
+      codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7780,10 +7778,10 @@ const registry = {
       from: fromCallback46,
       parameters: parameters46,
       isUnique: !false,
-      codec: registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
+      codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7793,10 +7791,10 @@ const registry = {
       from: fromCallback47,
       parameters: parameters47,
       isUnique: !true,
-      codec: registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
+      codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7809,7 +7807,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7822,7 +7820,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7835,7 +7833,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7848,7 +7846,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7861,7 +7859,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7871,10 +7869,10 @@ const registry = {
       from: fromCallback53,
       parameters: parameters53,
       isUnique: !false,
-      codec: registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
+      codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7884,10 +7882,10 @@ const registry = {
       from: fromCallback54,
       parameters: parameters54,
       isUnique: !true,
-      codec: registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
+      codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7900,7 +7898,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7913,7 +7911,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions56,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7923,10 +7921,10 @@ const registry = {
       from: fromCallback57,
       parameters: parameters57,
       isUnique: !false,
-      codec: registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
+      codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7936,10 +7934,10 @@ const registry = {
       from: fromCallback58,
       parameters: parameters58,
       isUnique: !true,
-      codec: registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
+      codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7949,10 +7947,10 @@ const registry = {
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registry_pgCodecs_guid_guidCodec,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7962,10 +7960,10 @@ const registry = {
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7975,10 +7973,10 @@ const registry = {
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7988,10 +7986,10 @@ const registry = {
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registry_pgCodecs_textArray_textArrayCodec,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8001,180 +7999,180 @@ const registry = {
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registry_pgCodecs_textArray_textArrayCodec,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec.sqlType,
-      codec: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registry_pgCodecs_inputs_inputsCodec.sqlType,
-      codec: registry_pgCodecs_inputs_inputsCodec,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions65
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registry_pgCodecs_patchs_patchsCodec.sqlType,
-      codec: registry_pgCodecs_patchs_patchsCodec,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions66
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registry_pgCodecs_reserved_reservedCodec.sqlType,
-      codec: registry_pgCodecs_reserved_reservedCodec,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registry_pgCodecs_reservedPatchs_reservedPatchsCodec.sqlType,
-      codec: registry_pgCodecs_reservedPatchs_reservedPatchsCodec,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions68
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registry_pgCodecs_reservedInput_reservedInputCodec.sqlType,
-      codec: registry_pgCodecs_reservedInput_reservedInputCodec,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions69
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registry_pgCodecs_defaultValue_defaultValueCodec.sqlType,
-      codec: registry_pgCodecs_defaultValue_defaultValueCodec,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions70
+      extensions: extensions120
     },
-    foreign_key: registry_pgResources_foreign_key_foreign_key,
+    foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec.sqlType,
-      codec: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions72
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registry_pgCodecs_testview_testviewCodec.sqlType,
-      codec: registry_pgCodecs_testview_testviewCodec,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions123
     },
-    unique_foreign_key: registry_pgResources_unique_foreign_key_unique_foreign_key,
+    unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registry_pgCodecs_myTable_myTableCodec.sqlType,
-      codec: registry_pgCodecs_myTable_myTableCodec,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions75
+      extensions: extensions125
     },
-    person_secret: registry_pgResources_person_secret_person_secret,
+    person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registry_pgCodecs_viewTable_viewTableCodec.sqlType,
-      codec: registry_pgCodecs_viewTable_viewTableCodec,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions77
+      extensions: extensions127
     },
-    compound_key: registry_pgResources_compound_key_compound_key,
+    compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registry_pgCodecs_similarTable1_similarTable1Codec.sqlType,
-      codec: registry_pgCodecs_similarTable1_similarTable1Codec,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions79
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registry_pgCodecs_similarTable2_similarTable2Codec.sqlType,
-      codec: registry_pgCodecs_similarTable2_similarTable2Codec,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions80
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registry_pgCodecs_updatableView_updatableViewCodec.sqlType,
-      codec: registry_pgCodecs_updatableView_updatableViewCodec,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions81
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registry_pgCodecs_nullTestRecord_nullTestRecordCodec.sqlType,
-      codec: registry_pgCodecs_nullTestRecord_nullTestRecordCodec,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions82
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8186,10 +8184,10 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions133,
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registry_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
@@ -8197,30 +8195,30 @@ const registry = {
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registry_pgCodecs_uuidArray_uuidArrayCodec,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registry_pgCodecs_edgeCase_edgeCaseCodec.sqlType,
-      codec: registry_pgCodecs_edgeCase_edgeCaseCodec,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions85
+      extensions: extensions135
     },
-    left_arm: registry_pgResources_left_arm_left_arm,
+    left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
     authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
-    issue756: registry_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registry_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registry_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registry_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756: registryConfig_pgResources_issue756_issue756,
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
     authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
     authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
     types_mutation: {
@@ -8233,7 +8231,7 @@ const registry = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions90,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8246,7 +8244,7 @@ const registry = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8259,7 +8257,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8272,7 +8270,7 @@ const registry = {
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8282,10 +8280,10 @@ const registry = {
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8295,10 +8293,10 @@ const registry = {
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registry_pgCodecs_textArray_textArrayCodec,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8311,7 +8309,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8324,7 +8322,7 @@ const registry = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8334,10 +8332,10 @@ const registry = {
       from: fromCallback74,
       parameters: parameters74,
       isUnique: !false,
-      codec: registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
+      codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8347,10 +8345,10 @@ const registry = {
       from: fromCallback75,
       parameters: parameters75,
       isUnique: !false,
-      codec: registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
+      codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8363,7 +8361,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8376,7 +8374,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8389,7 +8387,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8399,26 +8397,26 @@ const registry = {
       from: fromCallback79,
       parameters: parameters79,
       isUnique: !false,
-      codec: registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
+      codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions153,
       description: undefined
     },
-    post: registry_pgResources_post_post,
+    post: registryConfig_pgResources_post_post,
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
     compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
     compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
     compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registry_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registry_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registry_pgResources_post_post, options_post_with_suffix),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
     mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
     query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
     compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
     compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
     post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registry_pgResources_post_post, options_post_many),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
@@ -8429,7 +8427,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8442,7 +8440,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions107,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8452,10 +8450,10 @@ const registry = {
       from: fromCallback82,
       parameters: parameters82,
       isUnique: !false,
-      codec: registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
+      codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions108,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8468,7 +8466,7 @@ const registry = {
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions109,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8478,10 +8476,10 @@ const registry = {
       from: fromCallback84,
       parameters: parameters84,
       isUnique: !false,
-      codec: registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
+      codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8494,7 +8492,7 @@ const registry = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8504,10 +8502,10 @@ const registry = {
       from: fromCallback86,
       parameters: parameters86,
       isUnique: !false,
-      codec: registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
+      codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8517,10 +8515,10 @@ const registry = {
       from: fromCallback87,
       parameters: parameters87,
       isUnique: !false,
-      codec: registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
+      codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8530,10 +8528,10 @@ const registry = {
       from: fromCallback88,
       parameters: parameters88,
       isUnique: !true,
-      codec: registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
+      codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8543,10 +8541,10 @@ const registry = {
       from: fromCallback89,
       parameters: parameters89,
       isUnique: !false,
-      codec: registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
+      codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions115,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8556,10 +8554,10 @@ const registry = {
       from: fromCallback90,
       parameters: parameters90,
       isUnique: !true,
-      codec: registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
+      codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions116,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8569,40 +8567,40 @@ const registry = {
       from: fromCallback91,
       parameters: parameters91,
       isUnique: !false,
-      codec: registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
+      codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions167,
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registry_pgResources_post_post, options_person_first_post),
-    person: registry_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registry_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registry_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registry_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registry_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registry_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registry_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registry_pgResources_person_person, options_person_friends),
-    types: registry_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person: registryConfig_pgResources_person_person,
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    types: registryConfig_pgResources_types_types,
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registry_pgCodecs_foreignKey_foreignKeyCodec,
-        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
+        localCodec: foreignKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
         remoteAttributes: ["person_id_1", "person_id_2"],
@@ -8616,8 +8614,8 @@ const registry = {
         }
       },
       personByMyPersonId: {
-        localCodec: registry_pgCodecs_foreignKey_foreignKeyCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: foreignKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8633,8 +8631,8 @@ const registry = {
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_postCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: postCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
         remoteAttributes: ["id"],
@@ -8648,8 +8646,8 @@ const registry = {
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_postCodec,
-        remoteResourceOptions: registry_pgResources_types_types,
+        localCodec: postCodec,
+        remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["smallint"],
@@ -8663,8 +8661,8 @@ const registry = {
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_postCodec,
-        remoteResourceOptions: registry_pgResources_types_types,
+        localCodec: postCodec,
+        remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8680,8 +8678,8 @@ const registry = {
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
-        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
+        localCodec: uniqueForeignKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
         remoteAttributes: ["person_id_1", "person_id_2"],
@@ -8697,8 +8695,8 @@ const registry = {
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registry_pgCodecs_authPayload_authPayloadCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: authPayloadCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8714,8 +8712,8 @@ const registry = {
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registry_pgCodecs_types_typesCodec,
-        remoteResourceOptions: registry_pgResources_post_post,
+        localCodec: typesCodec,
+        remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
         remoteAttributes: ["id"],
@@ -8729,8 +8727,8 @@ const registry = {
         }
       },
       postByMyId: {
-        localCodec: registry_pgCodecs_types_typesCodec,
-        remoteResourceOptions: registry_pgResources_post_post,
+        localCodec: typesCodec,
+        remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8746,8 +8744,8 @@ const registry = {
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: compoundKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
         remoteAttributes: ["id"],
@@ -8761,8 +8759,8 @@ const registry = {
         }
       },
       personByMyPersonId2: {
-        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: compoundKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
         remoteAttributes: ["id"],
@@ -8776,8 +8774,8 @@ const registry = {
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
-        remoteResourceOptions: registry_pgResources_foreign_key_foreign_key,
+        localCodec: compoundKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
         remoteAttributes: ["compound_key_1", "compound_key_2"],
@@ -8791,8 +8789,8 @@ const registry = {
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
-        remoteResourceOptions: registry_pgResources_unique_foreign_key_unique_foreign_key,
+        localCodec: compoundKeyCodec,
+        remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
         remoteAttributes: ["compound_key_1", "compound_key_2"],
@@ -8808,8 +8806,8 @@ const registry = {
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registry_pgCodecs_leftArm_leftArmCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: leftArmCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8825,8 +8823,8 @@ const registry = {
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_post_post,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["author_id"],
@@ -8840,8 +8838,8 @@ const registry = {
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_foreign_key_foreign_key,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8855,8 +8853,8 @@ const registry = {
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_person_secret_person_secret,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8872,8 +8870,8 @@ const registry = {
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_left_arm_left_arm,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8887,8 +8885,8 @@ const registry = {
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id_1"],
@@ -8902,8 +8900,8 @@ const registry = {
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_personCodec,
-        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
+        localCodec: personCodec,
+        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id_2"],
@@ -8919,8 +8917,8 @@ const registry = {
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registry_pgCodecs_personSecret_personSecretCodec,
-        remoteResourceOptions: registry_pgResources_person_person,
+        localCodec: personSecretCodec,
+        remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8937,26 +8935,25 @@ const registry = {
       }
     })
   })
-};
-const registry_registry = makeRegistry(registry);
-const pgResource_inputsPgResource = registry_registry.pgResources["inputs"];
-const pgResource_patchsPgResource = registry_registry.pgResources["patchs"];
-const pgResource_reservedPgResource = registry_registry.pgResources["reserved"];
-const pgResource_reservedPatchsPgResource = registry_registry.pgResources["reservedPatchs"];
-const pgResource_reserved_inputPgResource = registry_registry.pgResources["reserved_input"];
-const pgResource_default_valuePgResource = registry_registry.pgResources["default_value"];
-const pgResource_my_tablePgResource = registry_registry.pgResources["my_table"];
-const pgResource_person_secretPgResource = registry_registry.pgResources["person_secret"];
-const pgResource_view_tablePgResource = registry_registry.pgResources["view_table"];
-const pgResource_compound_keyPgResource = registry_registry.pgResources["compound_key"];
-const pgResource_similar_table_1PgResource = registry_registry.pgResources["similar_table_1"];
-const pgResource_similar_table_2PgResource = registry_registry.pgResources["similar_table_2"];
-const pgResource_null_test_recordPgResource = registry_registry.pgResources["null_test_record"];
-const pgResource_left_armPgResource = registry_registry.pgResources["left_arm"];
-const pgResource_issue756PgResource = registry_registry.pgResources["issue756"];
-const pgResource_postPgResource = registry_registry.pgResources["post"];
-const pgResource_personPgResource = registry_registry.pgResources["person"];
-const pgResource_typesPgResource = registry_registry.pgResources["types"];
+});
+const pgResource_inputsPgResource = registry.pgResources["inputs"];
+const pgResource_patchsPgResource = registry.pgResources["patchs"];
+const pgResource_reservedPgResource = registry.pgResources["reserved"];
+const pgResource_reservedPatchsPgResource = registry.pgResources["reservedPatchs"];
+const pgResource_reserved_inputPgResource = registry.pgResources["reserved_input"];
+const pgResource_default_valuePgResource = registry.pgResources["default_value"];
+const pgResource_my_tablePgResource = registry.pgResources["my_table"];
+const pgResource_person_secretPgResource = registry.pgResources["person_secret"];
+const pgResource_view_tablePgResource = registry.pgResources["view_table"];
+const pgResource_compound_keyPgResource = registry.pgResources["compound_key"];
+const pgResource_similar_table_1PgResource = registry.pgResources["similar_table_1"];
+const pgResource_similar_table_2PgResource = registry.pgResources["similar_table_2"];
+const pgResource_null_test_recordPgResource = registry.pgResources["null_test_record"];
+const pgResource_left_armPgResource = registry.pgResources["left_arm"];
+const pgResource_issue756PgResource = registry.pgResources["issue756"];
+const pgResource_postPgResource = registry.pgResources["post"];
+const pgResource_personPgResource = registry.pgResources["person"];
+const pgResource_typesPgResource = registry.pgResources["types"];
 const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
@@ -9303,8 +9300,8 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
     }
   }
 });
-const resource_no_primary_keyPgResource = registry_registry.pgResources["no_primary_key"];
-const resource_unique_foreign_keyPgResource = registry_registry.pgResources["unique_foreign_key"];
+const resource_no_primary_keyPgResource = registry.pgResources["no_primary_key"];
+const resource_unique_foreign_keyPgResource = registry.pgResources["unique_foreign_key"];
 const argDetailsSimple = [];
 const makeArgs = (args, path = []) => {
   const selectArgs = [];
@@ -9350,7 +9347,7 @@ const makeArgs = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_current_user_idPgResource = registry_registry.pgResources["current_user_id"];
+const resource_current_user_idPgResource = registry.pgResources["current_user_id"];
 const argDetailsSimple2 = [];
 const makeArgs2 = (args, path = []) => {
   const selectArgs = [];
@@ -9396,7 +9393,7 @@ const makeArgs2 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_outPgResource = registry_registry.pgResources["func_out"];
+const resource_func_outPgResource = registry.pgResources["func_out"];
 const argDetailsSimple3 = [];
 const makeArgs3 = (args, path = []) => {
   const selectArgs = [];
@@ -9442,7 +9439,7 @@ const makeArgs3 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_setofPgResource = registry_registry.pgResources["func_out_setof"];
+const resource_func_out_setofPgResource = registry.pgResources["func_out_setof"];
 const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
@@ -9511,7 +9508,7 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_unnamedPgResource = registry_registry.pgResources["func_out_unnamed"];
+const resource_func_out_unnamedPgResource = registry.pgResources["func_out_unnamed"];
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -9557,7 +9554,7 @@ const makeArgs5 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_no_args_queryPgResource = registry_registry.pgResources["no_args_query"];
+const resource_no_args_queryPgResource = registry.pgResources["no_args_query"];
 const argDetailsSimple6 = [];
 const makeArgs6 = (args, path = []) => {
   const selectArgs = [];
@@ -9603,7 +9600,7 @@ const makeArgs6 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_interval_setPgResource = registry_registry.pgResources["query_interval_set"];
+const resource_query_interval_setPgResource = registry.pgResources["query_interval_set"];
 const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
@@ -9668,7 +9665,7 @@ const makeArgs7 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_static_big_integerPgResource = registry_registry.pgResources["static_big_integer"];
+const resource_static_big_integerPgResource = registry.pgResources["static_big_integer"];
 const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
@@ -9739,7 +9736,7 @@ const makeArgs8 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_in_outPgResource = registry_registry.pgResources["func_in_out"];
+const resource_func_in_outPgResource = registry.pgResources["func_in_out"];
 const argDetailsSimple9 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9791,7 +9788,7 @@ const makeArgs9 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_returns_table_one_colPgResource = registry_registry.pgResources["func_returns_table_one_col"];
+const resource_func_returns_table_one_colPgResource = registry.pgResources["func_returns_table_one_col"];
 const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
@@ -9862,7 +9859,7 @@ const makeArgs10 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identityPgResource = registry_registry.pgResources["json_identity"];
+const resource_json_identityPgResource = registry.pgResources["json_identity"];
 const argDetailsSimple11 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -9914,7 +9911,7 @@ const makeArgs11 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identityPgResource = registry_registry.pgResources["jsonb_identity"];
+const resource_jsonb_identityPgResource = registry.pgResources["jsonb_identity"];
 const argDetailsSimple12 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -9972,7 +9969,7 @@ const makeArgs12 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_queryPgResource = registry_registry.pgResources["add_1_query"];
+const resource_add_1_queryPgResource = registry.pgResources["add_1_query"];
 const argDetailsSimple13 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10030,7 +10027,7 @@ const makeArgs13 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_queryPgResource = registry_registry.pgResources["add_2_query"];
+const resource_add_2_queryPgResource = registry.pgResources["add_2_query"];
 const argDetailsSimple14 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10088,7 +10085,7 @@ const makeArgs14 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_queryPgResource = registry_registry.pgResources["add_3_query"];
+const resource_add_3_queryPgResource = registry.pgResources["add_3_query"];
 const argDetailsSimple15 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10146,7 +10143,7 @@ const makeArgs15 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_queryPgResource = registry_registry.pgResources["add_4_query"];
+const resource_add_4_queryPgResource = registry.pgResources["add_4_query"];
 const argDetailsSimple16 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -10204,7 +10201,7 @@ const makeArgs16 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_in_inoutPgResource = registry_registry.pgResources["func_in_inout"];
+const resource_func_in_inoutPgResource = registry.pgResources["func_in_inout"];
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -10250,7 +10247,7 @@ const makeArgs17 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_outPgResource = registry_registry.pgResources["func_out_out"];
+const resource_func_out_outPgResource = registry.pgResources["func_out_out"];
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -10296,7 +10293,7 @@ const makeArgs18 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_setofPgResource = registry_registry.pgResources["func_out_out_setof"];
+const resource_func_out_out_setofPgResource = registry.pgResources["func_out_out_setof"];
 const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
@@ -10361,7 +10358,7 @@ const makeArgs19 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_unnamedPgResource = registry_registry.pgResources["func_out_out_unnamed"];
+const resource_func_out_out_unnamedPgResource = registry.pgResources["func_out_out_unnamed"];
 const argDetailsSimple20 = [];
 const makeArgs20 = (args, path = []) => {
   const selectArgs = [];
@@ -10407,7 +10404,7 @@ const makeArgs20 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_search_test_summariesPgResource = registry_registry.pgResources["search_test_summaries"];
+const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
 function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -10477,7 +10474,7 @@ const makeArgs21 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_1PgResource = registry_registry.pgResources["optional_missing_middle_1"];
+const resource_optional_missing_middle_1PgResource = registry.pgResources["optional_missing_middle_1"];
 const argDetailsSimple22 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10541,7 +10538,7 @@ const makeArgs22 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_2PgResource = registry_registry.pgResources["optional_missing_middle_2"];
+const resource_optional_missing_middle_2PgResource = registry.pgResources["optional_missing_middle_2"];
 const argDetailsSimple23 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10605,7 +10602,7 @@ const makeArgs23 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_3PgResource = registry_registry.pgResources["optional_missing_middle_3"];
+const resource_optional_missing_middle_3PgResource = registry.pgResources["optional_missing_middle_3"];
 const argDetailsSimple24 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10669,7 +10666,7 @@ const makeArgs24 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_4PgResource = registry_registry.pgResources["optional_missing_middle_4"];
+const resource_optional_missing_middle_4PgResource = registry.pgResources["optional_missing_middle_4"];
 const argDetailsSimple25 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10733,7 +10730,7 @@ const makeArgs25 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_5PgResource = registry_registry.pgResources["optional_missing_middle_5"];
+const resource_optional_missing_middle_5PgResource = registry.pgResources["optional_missing_middle_5"];
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -10779,7 +10776,7 @@ const makeArgs26 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_unnamed_out_out_unnamedPgResource = registry_registry.pgResources["func_out_unnamed_out_out_unnamed"];
+const resource_func_out_unnamed_out_out_unnamedPgResource = registry.pgResources["func_out_unnamed_out_out_unnamed"];
 const argDetailsSimple27 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -10831,7 +10828,7 @@ const makeArgs27 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_returns_table_multi_colPgResource = registry_registry.pgResources["func_returns_table_multi_col"];
+const resource_func_returns_table_multi_colPgResource = registry.pgResources["func_returns_table_multi_col"];
 const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
@@ -10914,7 +10911,7 @@ const makeArgs28 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_queryPgResource = registry_registry.pgResources["int_set_query"];
+const resource_int_set_queryPgResource = registry.pgResources["int_set_query"];
 const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
@@ -10979,7 +10976,7 @@ const makeArgs29 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_interval_arrayPgResource = registry_registry.pgResources["query_interval_array"];
+const resource_query_interval_arrayPgResource = registry.pgResources["query_interval_array"];
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {
   const selectArgs = [];
@@ -11025,7 +11022,7 @@ const makeArgs30 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_text_arrayPgResource = registry_registry.pgResources["query_text_array"];
+const resource_query_text_arrayPgResource = registry.pgResources["query_text_array"];
 const argDetailsSimple31 = [];
 const makeArgs31 = (args, path = []) => {
   const selectArgs = [];
@@ -11071,7 +11068,7 @@ const makeArgs31 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_table_without_grantsPgResource = registry_registry.pgResources["return_table_without_grants"];
+const resource_return_table_without_grantsPgResource = registry.pgResources["return_table_without_grants"];
 const argDetailsSimple32 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11093,7 +11090,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registry_pgCodecs_int4Array_int4ArrayCodec,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11105,7 +11102,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registry_pgCodecs_floatrange_floatrangeCodec,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11153,7 +11150,7 @@ const makeArgs32 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_queryPgResource = registry_registry.pgResources["types_query"];
+const resource_types_queryPgResource = registry.pgResources["types_query"];
 const argDetailsSimple33 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -11205,7 +11202,7 @@ const makeArgs33 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_compound_typePgResource = registry_registry.pgResources["func_out_out_compound_type"];
+const resource_func_out_out_compound_typePgResource = registry.pgResources["func_out_out_compound_type"];
 const argDetailsSimple34 = [{
   graphqlArgName: "leftArmId",
   postgresArgName: "left_arm_id",
@@ -11269,7 +11266,7 @@ const makeArgs34 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_output_two_rowsPgResource = registry_registry.pgResources["query_output_two_rows"];
+const resource_query_output_two_rowsPgResource = registry.pgResources["query_output_two_rows"];
 const argDetailsSimple35 = [];
 const makeArgs35 = (args, path = []) => {
   const selectArgs = [];
@@ -11315,7 +11312,7 @@ const makeArgs35 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_queryPgResource = registry_registry.pgResources["compound_type_set_query"];
+const resource_compound_type_set_queryPgResource = registry.pgResources["compound_type_set_query"];
 const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
@@ -11338,7 +11335,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11386,7 +11383,7 @@ const makeArgs36 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_queryPgResource = registry_registry.pgResources["compound_type_query"];
+const resource_compound_type_queryPgResource = registry.pgResources["compound_type_query"];
 const argDetailsSimple37 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -11438,11 +11435,11 @@ const makeArgs37 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_queryPgResource = registry_registry.pgResources["table_query"];
+const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11490,11 +11487,11 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_compound_type_arrayPgResource = registry_registry.pgResources["query_compound_type_array"];
+const resource_query_compound_type_arrayPgResource = registry.pgResources["query_compound_type_array"];
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11542,7 +11539,7 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_queryPgResource = registry_registry.pgResources["compound_type_array_query"];
+const resource_compound_type_array_queryPgResource = registry.pgResources["compound_type_array_query"];
 const argDetailsSimple40 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11600,7 +11597,7 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_complexPgResource = registry_registry.pgResources["func_out_complex"];
+const resource_func_out_complexPgResource = registry.pgResources["func_out_complex"];
 const argDetailsSimple41 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11658,7 +11655,7 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_complex_setofPgResource = registry_registry.pgResources["func_out_complex_setof"];
+const resource_func_out_complex_setofPgResource = registry.pgResources["func_out_complex_setof"];
 const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
@@ -11723,7 +11720,7 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_badly_behaved_functionPgResource = registry_registry.pgResources["badly_behaved_function"];
+const resource_badly_behaved_functionPgResource = registry.pgResources["badly_behaved_function"];
 const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
@@ -11788,7 +11785,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_tablePgResource = registry_registry.pgResources["func_out_table"];
+const resource_func_out_tablePgResource = registry.pgResources["func_out_table"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -11834,7 +11831,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_table_setofPgResource = registry_registry.pgResources["func_out_table_setof"];
+const resource_func_out_table_setofPgResource = registry.pgResources["func_out_table_setof"];
 const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
@@ -11899,7 +11896,7 @@ const makeArgs45 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_queryPgResource = registry_registry.pgResources["table_set_query"];
+const resource_table_set_queryPgResource = registry.pgResources["table_set_query"];
 const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
@@ -11982,7 +11979,7 @@ const makeArgs46 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_query_plpgsqlPgResource = registry_registry.pgResources["table_set_query_plpgsql"];
+const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_set_query_plpgsql"];
 const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
@@ -12047,7 +12044,7 @@ const makeArgs47 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connectionPgResource = registry_registry.pgResources["type_function_connection"];
+const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
@@ -12118,7 +12115,7 @@ const makeArgs48 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_functionPgResource = registry_registry.pgResources["type_function"];
+const resource_type_functionPgResource = registry.pgResources["type_function"];
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -12164,7 +12161,7 @@ const makeArgs49 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_listPgResource = registry_registry.pgResources["type_function_list"];
+const resource_type_function_listPgResource = registry.pgResources["type_function_list"];
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -12327,7 +12324,7 @@ const fetcher18 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Type);
-const resource_non_updatable_viewPgResource = registry_registry.pgResources["non_updatable_view"];
+const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
 function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12433,7 +12430,7 @@ function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
 function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_foreign_keyPgResource = registry_registry.pgResources["foreign_key"];
+const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
 function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12464,7 +12461,7 @@ function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
 function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_testviewPgResource = registry_registry.pgResources["testview"];
+const resource_testviewPgResource = registry.pgResources["testview"];
 function Query_allTestviews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12570,7 +12567,7 @@ function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
 function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_updatable_viewPgResource = registry_registry.pgResources["updatable_view"];
+const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
 function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12601,7 +12598,7 @@ function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
 function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_edge_casePgResource = registry_registry.pgResources["edge_case"];
+const resource_edge_casePgResource = registry.pgResources["edge_case"];
 function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12755,7 +12752,7 @@ const makeArgs50 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_outPgResource = registry_registry.pgResources["person_computed_out"];
+const resource_person_computed_outPgResource = registry.pgResources["person_computed_out"];
 const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
@@ -12801,7 +12798,7 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_namePgResource = registry_registry.pgResources["person_first_name"];
+const resource_person_first_namePgResource = registry.pgResources["person_first_name"];
 const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
@@ -12847,7 +12844,7 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_out_outPgResource = registry_registry.pgResources["person_computed_out_out"];
+const resource_person_computed_out_outPgResource = registry.pgResources["person_computed_out_out"];
 const argDetailsSimple53 = [{
   graphqlArgName: "ino",
   postgresArgName: "ino",
@@ -12899,7 +12896,7 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_inoutPgResource = registry_registry.pgResources["person_computed_inout"];
+const resource_person_computed_inoutPgResource = registry.pgResources["person_computed_inout"];
 const argDetailsSimple54 = [{
   graphqlArgName: "ino",
   postgresArgName: "ino",
@@ -12951,11 +12948,11 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_inout_outPgResource = registry_registry.pgResources["person_computed_inout_out"];
+const resource_person_computed_inout_outPgResource = registry.pgResources["person_computed_inout_out"];
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: personCodecSpec_personAttributes_email_codec_emailCodec,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -13003,7 +13000,7 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_existsPgResource = registry_registry.pgResources["person_exists"];
+const resource_person_existsPgResource = registry.pgResources["person_exists"];
 const argDetailsSimple56 = [];
 const makeArgs56 = (args, path = []) => {
   const selectArgs = [];
@@ -13049,7 +13046,7 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inout_outPgResource = registry_registry.pgResources["person_computed_first_arg_inout_out"];
+const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -13107,7 +13104,7 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry_registry.pgResources["person_computed_complex"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -13153,7 +13150,7 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry_registry.pgResources["person_first_post"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -13199,7 +13196,7 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry_registry.pgResources["person_computed_first_arg_inout"];
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -13245,7 +13242,7 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry_registry.pgResources["person_friends"];
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
 const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13340,7 +13337,7 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry_registry.pgResources["person_type_function_connection"];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
 const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13441,7 +13438,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry_registry.pgResources["person_type_function"];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -13487,8 +13484,8 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry_registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry_registry.pgResources["frmcdc_wrappedUrl"];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
 function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -13549,7 +13546,7 @@ function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
 function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_frmcdc_compoundTypePgResource = registry_registry.pgResources["frmcdc_compoundType"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -13595,7 +13592,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry_registry.pgResources["compound_type_computed_field"];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
 function Interval_secondsPlan($r) {
   return access($r, ["seconds"]);
 }
@@ -13659,7 +13656,7 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry_registry.pgResources["post_computed_interval_set"];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
 const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13754,7 +13751,7 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry_registry.pgResources["post_computed_interval_array"];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
 const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
@@ -13800,7 +13797,7 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry_registry.pgResources["post_computed_text_array"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple68 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -13852,7 +13849,7 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry_registry.pgResources["post_computed_with_optional_arg"];
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
 const argDetailsSimple69 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -13904,7 +13901,7 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry_registry.pgResources["post_computed_with_required_arg"];
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
 const argDetailsSimple70 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -13962,7 +13959,7 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry_registry.pgResources["post_headline_trimmed"];
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
 const argDetailsSimple71 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -14020,7 +14017,7 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry_registry.pgResources["post_headline_trimmed_no_defaults"];
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
 const argDetailsSimple72 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -14078,11 +14075,11 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry_registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -14130,8 +14127,8 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_compound_type_arrayPgResource = registry_registry.pgResources["post_computed_compound_type_array"];
-const resource_frmcdc_comptypePgResource = registry_registry.pgResources["frmcdc_comptype"];
+const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
+const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -14173,7 +14170,7 @@ function TypesConnection_pageInfoPlan($connection) {
   // TYPES: why is this a TypeScript issue without the 'any'?
   return $connection.pageInfo();
 }
-const resource_frmcdc_nestedCompoundTypePgResource = registry_registry.pgResources["frmcdc_nestedCompoundType"];
+const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
 function PeopleConnection_nodesPlan($connection) {
   return $connection.nodes();
 }
@@ -14519,7 +14516,7 @@ const makeArgs74 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_edge_case_computedPgResource = registry_registry.pgResources["edge_case_computed"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 function LeftArmsConnection_nodesPlan($connection) {
   return $connection.nodes();
 }
@@ -14585,7 +14582,7 @@ const makeArgs75 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_outPgResource = registry_registry.pgResources["mutation_out"];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
 function Mutation_mutationOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14634,7 +14631,7 @@ const makeArgs76 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_setofPgResource = registry_registry.pgResources["mutation_out_setof"];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
 function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14683,7 +14680,7 @@ const makeArgs77 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamedPgResource = registry_registry.pgResources["mutation_out_unnamed"];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
 function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14732,7 +14729,7 @@ const makeArgs78 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_no_args_mutationPgResource = registry_registry.pgResources["no_args_mutation"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 function Mutation_noArgsMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14781,7 +14778,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry_registry.pgResources["return_void_mutation"];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
 function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14830,7 +14827,7 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry_registry.pgResources["mutation_interval_set"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14885,7 +14882,7 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry_registry.pgResources["mutation_in_out"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 function Mutation_mutationInOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14940,7 +14937,7 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry_registry.pgResources["mutation_returns_table_one_col"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14995,7 +14992,7 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry_registry.pgResources["json_identity_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15050,7 +15047,7 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry_registry.pgResources["jsonb_identity_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15105,7 +15102,7 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry_registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15160,7 +15157,7 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry_registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15221,7 +15218,7 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry_registry.pgResources["add_1_mutation"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 function Mutation_add1Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15282,7 +15279,7 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry_registry.pgResources["add_2_mutation"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 function Mutation_add2Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15343,7 +15340,7 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry_registry.pgResources["add_3_mutation"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 function Mutation_add3Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15404,7 +15401,7 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry_registry.pgResources["add_4_mutation"];
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
 function Mutation_add4Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15465,7 +15462,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry_registry.pgResources["add_4_mutation_error"];
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
 function Mutation_add4MutationError_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15526,7 +15523,7 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry_registry.pgResources["mult_1"];
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
 function Mutation_mult1_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15587,7 +15584,7 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry_registry.pgResources["mult_2"];
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
 function Mutation_mult2_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15648,7 +15645,7 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry_registry.pgResources["mult_3"];
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
 function Mutation_mult3_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15709,7 +15706,7 @@ const makeArgs95 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_4PgResource = registry_registry.pgResources["mult_4"];
+const resource_mult_4PgResource = registry.pgResources["mult_4"];
 function Mutation_mult4_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15770,7 +15767,7 @@ const makeArgs96 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry_registry.pgResources["mutation_in_inout"];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
 function Mutation_mutationInInout_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15819,7 +15816,7 @@ const makeArgs97 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry_registry.pgResources["mutation_out_out"];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
 function Mutation_mutationOutOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15868,7 +15865,7 @@ const makeArgs98 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry_registry.pgResources["mutation_out_out_setof"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15917,7 +15914,7 @@ const makeArgs99 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry_registry.pgResources["mutation_out_out_unnamed"];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
 function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15984,7 +15981,7 @@ const makeArgs100 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry_registry.pgResources["int_set_mutation"];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
 function Mutation_intSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16033,7 +16030,7 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry_registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16088,14 +16085,14 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry_registry.pgResources["mutation_returns_table_multi_col"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registry_pgCodecs_guid_guidCodec,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16143,7 +16140,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry_registry.pgResources["guid_fn"];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
 function Mutation_guidFn_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16192,7 +16189,7 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry_registry.pgResources["mutation_interval_array"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16241,14 +16238,14 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry_registry.pgResources["mutation_text_array"];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
 function Mutation_mutationTextArray_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registry_pgCodecs_textArray_textArrayCodec,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16308,7 +16305,7 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry_registry.pgResources["list_bde_mutation"];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
 function Mutation_listBdeMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16357,7 +16354,7 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry_registry.pgResources["authenticate_fail"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 function Mutation_authenticateFail_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16424,14 +16421,14 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry_registry.pgResources["authenticate"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 function Mutation_authenticate_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registry_pgCodecs_leftArm_leftArmCodec,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16479,7 +16476,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry_registry.pgResources["left_arm_identity"];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
 function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16528,7 +16525,7 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry_registry.pgResources["issue756_mutation"];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
 function Mutation_issue756Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16577,7 +16574,7 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry_registry.pgResources["issue756_set_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16644,7 +16641,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry_registry.pgResources["authenticate_many"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 function Mutation_authenticateMany_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16711,7 +16708,7 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry_registry.pgResources["authenticate_payload"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 function Mutation_authenticatePayload_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16736,7 +16733,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registry_pgCodecs_int4Array_int4ArrayCodec,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16748,7 +16745,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registry_pgCodecs_floatrange_floatrangeCodec,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16796,7 +16793,7 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry_registry.pgResources["types_mutation"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 function Mutation_typesMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16851,14 +16848,14 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry_registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16906,14 +16903,14 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry_registry.pgResources["compound_type_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16961,7 +16958,7 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry_registry.pgResources["compound_type_set_mutation"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17016,14 +17013,14 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry_registry.pgResources["table_mutation"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 function Mutation_tableMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_postCodec,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17077,14 +17074,14 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry_registry.pgResources["post_with_suffix"];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
 function Mutation_postWithSuffix_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17132,14 +17129,14 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry_registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
 function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundTypeCodec,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17187,14 +17184,14 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry_registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
 function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registry_pgCodecs_postArray_postArrayCodec,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -17242,7 +17239,7 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry_registry.pgResources["post_many"];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
 function Mutation_postMany_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17303,7 +17300,7 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry_registry.pgResources["mutation_out_complex"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17364,7 +17361,7 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry_registry.pgResources["mutation_out_complex_setof"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17413,7 +17410,7 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry_registry.pgResources["mutation_out_table"];
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
 function Mutation_mutationOutTable_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17462,7 +17459,7 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry_registry.pgResources["mutation_out_table_setof"];
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
 function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17511,7 +17508,7 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry_registry.pgResources["table_set_mutation"];
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
 function Mutation_tableSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17560,7 +17557,7 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry_registry.pgResources["type_function_connection_mutation"];
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
 function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17615,7 +17612,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry_registry.pgResources["type_function_mutation"];
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
 function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17664,7 +17661,7 @@ const makeArgs130 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_list_mutationPgResource = registry_registry.pgResources["type_function_list_mutation"];
+const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
 function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -18463,7 +18460,7 @@ function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
 function AuthenticatePayloadPayload_queryPlan() {
   return rootValue();
 }
-const resource_frmcdc_jwtTokenPgResource = registry_registry.pgResources["frmcdc_jwtToken"];
+const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
 function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
   $input.set("clientMutationId", val.get());
 }
@@ -33835,7 +33832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_types_typesCodec.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33851,7 +33848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_types_typesCodec.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35139,7 +35136,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35162,7 +35159,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35185,7 +35182,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35208,7 +35205,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35231,7 +35228,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35254,7 +35251,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35277,7 +35274,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35300,7 +35297,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35323,7 +35320,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35346,7 +35343,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35369,7 +35366,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35392,7 +35389,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35415,7 +35412,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35438,7 +35435,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35461,7 +35458,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35484,7 +35481,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35507,7 +35504,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35530,7 +35527,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35553,7 +35550,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35576,7 +35573,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35599,7 +35596,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35622,7 +35619,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35645,7 +35642,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35668,7 +35665,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35691,7 +35688,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35714,7 +35711,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35737,7 +35734,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35760,7 +35757,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35783,7 +35780,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35806,7 +35803,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35829,7 +35826,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35852,7 +35849,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35875,7 +35872,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35898,7 +35895,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35921,7 +35918,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35944,7 +35941,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35967,7 +35964,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35990,7 +35987,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36013,7 +36010,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36036,7 +36033,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36059,7 +36056,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36082,7 +36079,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36105,7 +36102,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36128,7 +36125,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36151,7 +36148,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36174,7 +36171,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36197,7 +36194,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36342,7 +36339,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_personCodec.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36358,7 +36355,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_personCodec.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36773,7 +36770,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_postCodec.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36789,7 +36786,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_postCodec.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36955,7 +36952,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36978,7 +36975,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -37001,7 +36998,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37024,7 +37021,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37047,7 +37044,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37070,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37274,7 +37271,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37297,7 +37294,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37320,7 +37317,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37396,7 +37393,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_compoundKey_compoundKeyCodec.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37412,7 +37409,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_compoundKey_compoundKeyCodec.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37544,7 +37541,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37567,7 +37564,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37590,7 +37587,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38028,7 +38025,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38051,7 +38048,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38074,7 +38071,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38097,7 +38094,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38120,7 +38117,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38143,7 +38140,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38166,7 +38163,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38189,7 +38186,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38212,7 +38209,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38235,7 +38232,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38258,7 +38255,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38370,7 +38367,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewCodecSpec_nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38404,7 +38401,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_inputs_inputsCodec.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38420,7 +38417,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_inputs_inputsCodec.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38484,7 +38481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsCodecSpec_inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38518,7 +38515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_patchs_patchsCodec.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38534,7 +38531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_patchs_patchsCodec.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38598,7 +38595,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsCodecSpec_patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38632,7 +38629,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reserved_reservedCodec.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38648,7 +38645,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reserved_reservedCodec.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38712,7 +38709,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedCodecSpec_reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38746,7 +38743,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reservedPatchs_reservedPatchsCodec.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38762,7 +38759,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reservedPatchs_reservedPatchsCodec.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38826,7 +38823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsCodecSpec_reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38860,7 +38857,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reservedInput_reservedInputCodec.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38876,7 +38873,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_reservedInput_reservedInputCodec.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38940,7 +38937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputCodecSpec_reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38974,7 +38971,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_defaultValue_defaultValueCodec.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38990,7 +38987,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_defaultValue_defaultValueCodec.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39088,7 +39085,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueCodecSpec_defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39111,7 +39108,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueCodecSpec_defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39227,7 +39224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyCodecSpec_noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39250,7 +39247,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyCodecSpec_noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39412,7 +39409,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39435,7 +39432,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39458,7 +39455,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39492,7 +39489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_myTable_myTableCodec.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39508,7 +39505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_myTable_myTableCodec.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39606,7 +39603,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableCodecSpec_myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39629,7 +39626,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableCodecSpec_myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39663,7 +39660,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_personSecret_personSecretCodec.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39679,7 +39676,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_personSecret_personSecretCodec.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39777,7 +39774,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretCodecSpec_personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39800,7 +39797,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretCodecSpec_personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39834,7 +39831,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_viewTable_viewTableCodec.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39850,7 +39847,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_viewTable_viewTableCodec.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39982,7 +39979,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40005,7 +40002,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40028,7 +40025,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40062,7 +40059,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_similarTable1_similarTable1Codec.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40078,7 +40075,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_similarTable1_similarTable1Codec.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40244,7 +40241,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40267,7 +40264,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40290,7 +40287,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40313,7 +40310,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40347,7 +40344,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_similarTable2_similarTable2Codec.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40363,7 +40360,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_similarTable2_similarTable2Codec.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40529,7 +40526,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40552,7 +40549,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40575,7 +40572,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40598,7 +40595,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40797,7 +40794,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40820,7 +40817,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40843,7 +40840,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40866,7 +40863,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40900,7 +40897,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_nullTestRecord_nullTestRecordCodec.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40916,7 +40913,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_nullTestRecord_nullTestRecordCodec.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41082,7 +41079,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41105,7 +41102,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41128,7 +41125,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41151,7 +41148,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41347,7 +41344,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41370,7 +41367,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41393,7 +41390,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41427,7 +41424,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_leftArm_leftArmCodec.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41443,7 +41440,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_leftArm_leftArmCodec.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41609,7 +41606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41632,7 +41629,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41655,7 +41652,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41678,7 +41675,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41712,7 +41709,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_issue756_issue756Codec.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41728,7 +41725,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registry_pgCodecs_issue756_issue756Codec.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41826,7 +41823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756CodecSpec_issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41849,7 +41846,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756CodecSpec_issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -65,7 +65,7 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
+const registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   name: "FuncOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: Object.assign(Object.create(null), {
@@ -113,7 +113,7 @@ const attributes2 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
+const registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes2,
@@ -144,7 +144,7 @@ const attributes3 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
+const registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes3,
@@ -175,7 +175,7 @@ const attributes4 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
+const registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes4,
@@ -206,7 +206,7 @@ const attributes5 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
+const registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes5,
@@ -237,7 +237,7 @@ const attributes6 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
+const registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes6,
@@ -268,7 +268,7 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
+const registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes7,
@@ -307,7 +307,7 @@ const attributes8 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
+const registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes8,
@@ -338,7 +338,7 @@ const attributes9 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
+const registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes9,
@@ -377,7 +377,7 @@ const attributes10 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
+const registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes10,
@@ -408,7 +408,7 @@ const attributes11 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
+const registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
   attributes: attributes11,
@@ -421,20 +421,21 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
-  description: undefined,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "guid"
-    },
-    tags: Object.create(null)
+const guidCodec = {
+  pg: {
+    serviceName: "main",
+    schemaName: "b",
+    name: "guid"
   },
+  tags: Object.create(null)
+};
+const guidCodec2 = sql.identifier(...["b", "guid"]);
+const registry_pgCodecs_guid_guidCodec = domainOfCodec(TYPES.varchar, "guid", guidCodec2, {
+  description: undefined,
+  extensions: guidCodec,
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +443,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const registry_pgCodecs_intervalArray_intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +457,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const registry_pgCodecs_textArray_textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewCodecSpec_nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +474,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const nonUpdatableViewCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +484,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewCodecSpec2 = sql.identifier(...parts2);
+const nonUpdatableViewCodec_nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewCodecSpec2,
+  attributes: nonUpdatableViewCodecSpec_nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: nonUpdatableViewCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodec_nonUpdatableViewCodecSpec);
+const inputsCodecSpec_inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -504,7 +505,7 @@ const attributes13 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
+const inputsCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -514,17 +515,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
+const inputsCodecSpec2 = sql.identifier(...parts3);
+const inputsCodec_inputsCodecSpec = {
   name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
+  identifier: inputsCodecSpec2,
+  attributes: inputsCodecSpec_inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions5,
+  extensions: inputsCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const registry_pgCodecs_inputs_inputsCodec = recordCodec(inputsCodec_inputsCodecSpec);
+const patchsCodecSpec_patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -535,7 +536,7 @@ const attributes14 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
+const patchsCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -545,17 +546,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
+const patchsCodecSpec2 = sql.identifier(...parts4);
+const patchsCodec_patchsCodecSpec = {
   name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
+  identifier: patchsCodecSpec2,
+  attributes: patchsCodecSpec_patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions6,
+  extensions: patchsCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const registry_pgCodecs_patchs_patchsCodec = recordCodec(patchsCodec_patchsCodecSpec);
+const reservedCodecSpec_reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -566,7 +567,7 @@ const attributes15 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
+const reservedCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -576,17 +577,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
+const reservedCodecSpec2 = sql.identifier(...parts5);
+const reservedCodec_reservedCodecSpec = {
   name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
+  identifier: reservedCodecSpec2,
+  attributes: reservedCodecSpec_reservedAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: reservedCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
+const registry_pgCodecs_reserved_reservedCodec = recordCodec(reservedCodec_reservedCodecSpec);
+const reservedPatchsCodecSpec_reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -597,7 +598,7 @@ const attributes16 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
+const reservedPatchsCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -607,17 +608,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
+const reservedPatchsCodecSpec2 = sql.identifier(...parts6);
+const reservedPatchsCodec_reservedPatchsCodecSpec = {
   name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
+  identifier: reservedPatchsCodecSpec2,
+  attributes: reservedPatchsCodecSpec_reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
+  extensions: reservedPatchsCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
+const registry_pgCodecs_reservedPatchs_reservedPatchsCodec = recordCodec(reservedPatchsCodec_reservedPatchsCodecSpec);
+const reservedInputCodecSpec_reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -628,7 +629,7 @@ const attributes17 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
+const reservedInputCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -638,17 +639,17 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputCodecSpec2 = sql.identifier(...parts7);
+const reservedInputCodec_reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputCodecSpec2,
+  attributes: reservedInputCodecSpec_reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: reservedInputCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const registry_pgCodecs_reservedInput_reservedInputCodec = recordCodec(reservedInputCodec_reservedInputCodecSpec);
+const defaultValueCodecSpec_defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +669,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const defaultValueCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +679,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueCodecSpec2 = sql.identifier(...parts8);
+const defaultValueCodec_defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueCodecSpec2,
+  attributes: defaultValueCodecSpec_defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: defaultValueCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const registry_pgCodecs_defaultValue_defaultValueCodec = recordCodec(defaultValueCodec_defaultValueCodecSpec);
+const foreignKeyCodecSpec_foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +718,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const foreignKeyCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +728,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyCodecSpec2 = sql.identifier(...parts9);
+const foreignKeyCodec_foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyCodecSpec2,
+  attributes: foreignKeyCodecSpec_foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: foreignKeyCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const registry_pgCodecs_foreignKey_foreignKeyCodec = recordCodec(foreignKeyCodec_foreignKeyCodecSpec);
+const noPrimaryKeyCodecSpec_noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +758,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const noPrimaryKeyCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +768,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyCodecSpec2 = sql.identifier(...parts10);
+const noPrimaryKeyCodec_noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyCodecSpec2,
+  attributes: noPrimaryKeyCodecSpec_noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: noPrimaryKeyCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodec_noPrimaryKeyCodecSpec);
+const testviewCodecSpec_testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +807,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const testviewCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +817,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewCodecSpec2 = sql.identifier(...parts11);
+const testviewCodec_testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewCodecSpec2,
+  attributes: testviewCodecSpec_testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: testviewCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const registry_pgCodecs_testview_testviewCodec = recordCodec(testviewCodec_testviewCodecSpec);
+const uniqueForeignKeyCodecSpec_uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +847,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const uniqueForeignKeyCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +860,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyCodecSpec2 = sql.identifier(...parts12);
+const uniqueForeignKeyCodec_uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyCodecSpec2,
+  attributes: uniqueForeignKeyCodecSpec_uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: uniqueForeignKeyCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodec_uniqueForeignKeyCodecSpec);
+const myTableCodecSpec_myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +890,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const myTableCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +900,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableCodecSpec2 = sql.identifier(...parts13);
+const myTableCodec_myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableCodecSpec2,
+  attributes: myTableCodecSpec_myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: myTableCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const registry_pgCodecs_myTable_myTableCodec = recordCodec(myTableCodec_myTableCodecSpec);
+const personSecretCodecSpec_personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +932,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const personSecretCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +944,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretCodecSpec2 = sql.identifier(...parts14);
+const personSecretCodec_personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretCodecSpec2,
+  attributes: personSecretCodecSpec_personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: personSecretCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const registry_pgCodecs_personSecret_personSecretCodec = recordCodec(personSecretCodec_personSecretCodecSpec);
+const viewTableCodecSpec_viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +983,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const viewTableCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +993,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableCodecSpec2 = sql.identifier(...parts15);
+const viewTableCodec_viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableCodecSpec2,
+  attributes: viewTableCodecSpec_viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: viewTableCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const registry_pgCodecs_viewTable_viewTableCodec = recordCodec(viewTableCodec_viewTableCodecSpec);
+const compoundKeyCodecSpec_compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1032,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const compoundKeyCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1042,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyCodecSpec2 = sql.identifier(...parts16);
+const compoundKeyCodec_compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyCodecSpec2,
+  attributes: compoundKeyCodecSpec_compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: compoundKeyCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const registry_pgCodecs_compoundKey_compoundKeyCodec = recordCodec(compoundKeyCodec_compoundKeyCodecSpec);
+const similarTable1CodecSpec_similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1090,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const similarTable1CodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1100,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1CodecSpec2 = sql.identifier(...parts17);
+const similarTable1Codec_similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1CodecSpec2,
+  attributes: similarTable1CodecSpec_similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: similarTable1CodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const registry_pgCodecs_similarTable1_similarTable1Codec = recordCodec(similarTable1Codec_similarTable1CodecSpec);
+const similarTable2CodecSpec_similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1148,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const similarTable2CodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1158,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2CodecSpec2 = sql.identifier(...parts18);
+const similarTable2Codec_similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2CodecSpec2,
+  attributes: similarTable2CodecSpec_similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: similarTable2CodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const registry_pgCodecs_similarTable2_similarTable2Codec = recordCodec(similarTable2Codec_similarTable2CodecSpec);
+const updatableViewCodecSpec_updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1206,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const updatableViewCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1219,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewCodecSpec2 = sql.identifier(...parts19);
+const updatableViewCodec_updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewCodecSpec2,
+  attributes: updatableViewCodecSpec_updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: updatableViewCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const registry_pgCodecs_updatableView_updatableViewCodec = recordCodec(updatableViewCodec_updatableViewCodecSpec);
+const nullTestRecordCodecSpec_nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1267,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const nullTestRecordCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1277,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordCodecSpec2 = sql.identifier(...parts20);
+const nullTestRecordCodec_nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordCodecSpec2,
+  attributes: nullTestRecordCodecSpec_nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: nullTestRecordCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const registry_pgCodecs_nullTestRecord_nullTestRecordCodec = recordCodec(nullTestRecordCodec_nullTestRecordCodecSpec);
+const uuidArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1295,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const registry_pgCodecs_uuidArray_uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseCodecSpec_edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1330,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const edgeCaseCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1340,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseCodecSpec2 = sql.identifier(...parts21);
+const edgeCaseCodec_edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseCodecSpec2,
+  attributes: edgeCaseCodecSpec_edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: edgeCaseCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const registry_pgCodecs_edgeCase_edgeCaseCodec = recordCodec(edgeCaseCodec_edgeCaseCodecSpec);
+const leftArmCodecSpec_leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1388,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const leftArmCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1398,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmCodecSpec2 = sql.identifier(...parts22);
+const leftArmCodec_leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmCodecSpec2,
+  attributes: leftArmCodecSpec_leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: leftArmCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const registry_pgCodecs_leftArm_leftArmCodec = recordCodec(leftArmCodec_leftArmCodecSpec);
+const jwtTokenCodecSpec_jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1455,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const jwtTokenCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1465,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenCodecSpec2 = sql.identifier(...parts23);
+const jwtTokenCodec_jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenCodecSpec2,
+  attributes: jwtTokenCodecSpec_jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: jwtTokenCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const registry_pgCodecs_jwtToken_jwtTokenCodec = recordCodec(jwtTokenCodec_jwtTokenCodecSpec);
+const notNullTimestampCodec = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1484,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampCodec2 = sql.identifier(...parts24);
+const issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampCodec2, {
   description: undefined,
-  extensions: extensions27,
+  extensions: notNullTimestampCodec,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756CodecSpec_issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1502,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1510,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const issue756CodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1520,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756CodecSpec2 = sql.identifier(...parts25);
+const issue756Codec_issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756CodecSpec2,
+  attributes: issue756CodecSpec_issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: issue756CodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const registry_pgCodecs_issue756_issue756Codec = recordCodec(issue756Codec_issue756CodecSpec);
+const authPayloadCodecSpec_authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: registry_pgCodecs_jwtToken_jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1559,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const authPayloadCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1571,18 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadCodecSpec2 = sql.identifier(...parts26);
+const authPayloadCodec_authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadCodecSpec2,
+  attributes: authPayloadCodecSpec_authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: authPayloadCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const registry_pgCodecs_authPayload_authPayloadCodec = recordCodec(authPayloadCodec_authPayloadCodecSpec);
+const colorCodec = ["red", "green", "blue"];
+const colorCodec2 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1591,16 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec3 = sql.identifier(...parts27);
+const compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
-  values: ["red", "green", "blue"],
+  identifier: colorCodec3,
+  values: colorCodec,
   description: undefined,
-  extensions: extensions30
+  extensions: colorCodec2
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const enumCapsCodec = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
+const enumCapsCodec2 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1609,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const enumCapsCodec3 = sql.identifier(...parts28);
+const compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
-  values: enumLabels2,
+  identifier: enumCapsCodec3,
+  values: enumCapsCodec,
   description: undefined,
-  extensions: extensions31
+  extensions: enumCapsCodec2
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const enumWithEmptyStringCodec = ["", "one", "two"];
+const enumWithEmptyStringCodec2 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1627,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const enumWithEmptyStringCodec3 = sql.identifier(...parts29);
+const compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
-  values: enumLabels3,
+  identifier: enumWithEmptyStringCodec3,
+  values: enumWithEmptyStringCodec,
   description: undefined,
-  extensions: extensions32
+  extensions: enumWithEmptyStringCodec2
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeCodecSpec_compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1656,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1674,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1683,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1709,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const compoundTypeCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1719,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeCodecSpec2 = sql.identifier(...parts30);
+const compoundTypeCodec_compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeCodecSpec2,
+  attributes: compoundTypeCodecSpec_compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: compoundTypeCodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const attributes_o2_codec_compoundTypeCodec = recordCodec(compoundTypeCodec_compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,17 +1740,17 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
+const registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1760,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,17 +1771,17 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
+const registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1791,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1797,8 +1799,8 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const anEnumCodec = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
+const anEnumCodec2 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1809,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const anEnumCodec3 = sql.identifier(...parts31);
+const anEnumArrayCodec_anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
-  values: enumLabels4,
+  identifier: anEnumCodec3,
+  values: anEnumCodec,
   description: undefined,
-  extensions: extensions35
+  extensions: anEnumCodec2
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec = listOfCodec(anEnumArrayCodec_anEnumCodec, {
+  extensions: anEnumArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1831,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeCodecSpec_comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1851,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const comptypeCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1861,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeCodecSpec2 = sql.identifier(...parts32);
+const comptypeCodec_comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeCodecSpec2,
+  attributes: comptypeCodecSpec_comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: comptypeCodecSpec,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeArrayCodec_comptypeCodec = recordCodec(comptypeCodec_comptypeCodecSpec);
+const postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec = listOfCodec(comptypeArrayCodec_comptypeCodec, {
+  extensions: comptypeArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postCodecSpec_postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1916,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1925,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1933,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const postCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1943,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postCodecSpec2 = sql.identifier(...parts33);
+const postCodec_postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postCodecSpec2,
+  attributes: postCodecSpec_postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: postCodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const attributes_post_codec_postCodec = recordCodec(postCodec_postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1964,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: registry_pgCodecs_leftArm_leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,17 +1972,17 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: attributes_post_codec_postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
     }
   }
 });
-const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
+const registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1992,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2008,10 +2010,10 @@ const attributes41 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
+const registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2023,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2039,10 +2041,10 @@ const attributes42 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
+const registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2054,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const emailCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2063,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailCodec2 = sql.identifier(...parts34);
+const personCodecSpec_personAttributes_email_codec_emailCodec = domainOfCodec(TYPES.text, "email", emailCodec2, {
   description: undefined,
-  extensions: extensions39,
+  extensions: emailCodec,
   notNull: false
 });
-const extensions40 = {
+const notNullUrlCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2078,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlCodec2 = sql.identifier(...parts35);
+const wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlCodec2, {
   description: undefined,
-  extensions: extensions40,
+  extensions: notNullUrlCodec,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlCodecSpec_wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2095,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const wrappedUrlCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2105,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlCodecSpec2 = sql.identifier(...parts36);
+const wrappedUrlCodec_wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlCodecSpec2,
+  attributes: wrappedUrlCodecSpec_wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: wrappedUrlCodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const personCodecSpec_personAttributes_site_codec_wrappedUrlCodec = recordCodec(wrappedUrlCodec_wrappedUrlCodecSpec);
+const personCodecSpec_personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2138,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: registry_pgCodecs_textArray_textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2156,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: personCodecSpec_personAttributes_email_codec_emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2165,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: personCodecSpec_personAttributes_site_codec_wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2220,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const personCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2230,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personCodecSpec2 = sql.identifier(...parts37);
+const personCodec_personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personCodecSpec2,
+  attributes: personCodecSpec_personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: personCodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const attributes_person_codec_personCodec = recordCodec(personCodec_personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2256,10 +2258,10 @@ const attributes43 = Object.assign(Object.create(null), {
     }
   }
 });
-const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
+const registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2271,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2282,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,17 +2290,17 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
+const registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2310,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2321,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,17 +2329,17 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
+const registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2349,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2360,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,17 +2368,17 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
+const registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2388,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2399,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,17 +2407,17 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
     }
   }
 });
-const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
+const registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2427,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2438,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,17 +2446,17 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: attributes_person_codec_personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
     }
   }
 });
-const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
+const registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2466,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2474,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec = listOfCodec(compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec, {
+  extensions: colorArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const anIntCodec = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2489,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntCodec2 = sql.identifier(...parts38);
+const typesCodecSpec_typesAttributes_domain_codec_anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntCodec2, {
   description: undefined,
-  extensions: extensions44,
+  extensions: anIntCodec,
   notNull: false
 });
-const extensions45 = {
+const anotherIntCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2504,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntCodec2 = sql.identifier(...parts39);
+const typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec = domainOfCodec(typesCodecSpec_typesAttributes_domain_codec_anIntCodec, "anotherInt", anotherIntCodec2, {
   description: undefined,
-  extensions: extensions45,
+  extensions: anotherIntCodec,
   notNull: false
 });
-const extensions46 = {
+const numrangeCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2519,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const numrangeCodec2 = sql.identifier(...parts40);
+const typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", numrangeCodec2, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: numrangeCodec
 });
-const extensions47 = {
+const daterangeCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2533,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const daterangeCodec2 = sql.identifier(...parts41);
+const typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec = rangeOfCodec(TYPES.date, "daterange", daterangeCodec2, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: daterangeCodec
 });
-const extensions48 = {
+const anIntRangeCodec = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2547,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const anIntRangeCodec2 = sql.identifier(...parts42);
+const typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec = rangeOfCodec(typesCodecSpec_typesAttributes_domain_codec_anIntCodec, "anIntRange", anIntRangeCodec2, {
   description: undefined,
-  extensions: extensions48
+  extensions: anIntRangeCodec
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2564,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2581,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const nestedCompoundTypeCodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2591,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeCodecSpec2 = sql.identifier(...parts43);
+const nestedCompoundTypeCodec_nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeCodecSpec2,
+  attributes: nestedCompoundTypeCodecSpec_nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: nestedCompoundTypeCodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodec_nestedCompoundTypeCodecSpec);
+const textArrayDomainCodec = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2610,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainCodec2 = sql.identifier(...parts44);
+const typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec = domainOfCodec(registry_pgCodecs_textArray_textArrayCodec, "textArrayDomain", textArrayDomainCodec2, {
   description: undefined,
-  extensions: extensions50,
+  extensions: textArrayDomainCodec,
   notNull: false
 });
-const extensions51 = {
+const int8ArrayDomainCodec = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2624,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2632,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayDomainCodec_int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainCodec2 = sql.identifier(...parts45);
+const typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec = domainOfCodec(int8ArrayDomainCodec_int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainCodec2, {
   description: undefined,
-  extensions: extensions51,
+  extensions: int8ArrayDomainCodec,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2653,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesCodecSpec_typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2671,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesCodecSpec_typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesCodecSpec_typesAttributes_ltree_codec_ltree);
+const typesCodecSpec_typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2738,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2747,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2756,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: typesCodecSpec_typesAttributes_domain_codec_anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2765,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2774,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: registry_pgCodecs_textArray_textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2801,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2810,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2819,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2828,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2891,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2909,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2918,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2927,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: attributes_o2_codec_compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2936,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3062,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3071,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3089,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3098,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesCodecSpec_typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3107,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesCodecSpec_typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3115,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const typesCodecSpec = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3127,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesCodecSpec2 = sql.identifier(...parts46);
+const typesCodec_typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesCodecSpec2,
+  attributes: typesCodecSpec_typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: typesCodecSpec,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const registry_pgCodecs_types_typesCodec = recordCodec(typesCodec_typesCodecSpec);
+const compoundTypeArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3145,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3153,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3161,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3169,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const registry_pgCodecs_int4Array_int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const floatrangeCodec = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3184,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const floatrangeCodec2 = sql.identifier(...parts47);
+const registry_pgCodecs_floatrange_floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", floatrangeCodec2, {
   description: undefined,
-  extensions: extensions59
+  extensions: floatrangeCodec
 });
-const extensions60 = {
+const postArrayCodec = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3197,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const registry_pgCodecs_postArray_postArrayCodec = listOfCodec(attributes_post_codec_postCodec, {
+  extensions: postArrayCodec,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2CodecSpec_tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3232,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const tablefuncCrosstab2CodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3242,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2CodecSpec2 = sql.identifier(...parts48);
+const tablefuncCrosstab2Codec_tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2CodecSpec2,
+  attributes: tablefuncCrosstab2CodecSpec_tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: tablefuncCrosstab2CodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3CodecSpec_tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3289,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const tablefuncCrosstab3CodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3299,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3CodecSpec2 = sql.identifier(...parts49);
+const tablefuncCrosstab3Codec_tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3CodecSpec2,
+  attributes: tablefuncCrosstab3CodecSpec_tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: tablefuncCrosstab3CodecSpec,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4CodecSpec_tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3355,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const tablefuncCrosstab4CodecSpec = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,28 +3365,18 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4CodecSpec2 = sql.identifier(...parts50);
+const tablefuncCrosstab4Codec_tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4CodecSpec2,
+  attributes: tablefuncCrosstab4CodecSpec_tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: tablefuncCrosstab4CodecSpec,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent = sql.identifier(...parts51);
+const extensions2 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3388,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent2 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions3 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3403,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent3 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions4 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3417,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3432,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent5 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3447,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent6 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent6}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3461,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent7 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent7}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions8 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3475,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent8 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions9 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3489,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent9 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions10 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3503,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions11 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3517,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions12 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3531,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3545,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions14 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3560,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions15 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3580,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3600,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3620,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions18 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3639,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions19 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3659,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3678,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3697,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3716,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3735,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3754,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions25 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3773,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3792,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3805,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3816,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3829,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3840,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3853,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3864,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3877,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3888,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3901,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3912,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3925,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3936,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3949,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3960,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3973,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3984,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +3997,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4008,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4021,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4032,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4045,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4056,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4069,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4080,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4093,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4105,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4118,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4129,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4143,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4157,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4172,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4185,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4196,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4210,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4224,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4239,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4253,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4271,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4282,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4300,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4311,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4329,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4340,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4358,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4369,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4387,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4398,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4412,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4431,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4449,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4460,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4478,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4489,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4503,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4522,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: registry_pgCodecs_guid_guidCodec
 }];
-const extensions123 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4541,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4555,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4569,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4583,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4597,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions65 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4614,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions66 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4631,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4648,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions68 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4665,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions69 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4682,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions70 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4699,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4717,18 +4709,18 @@ const extensions134 = {
   tags: {}
 };
 const uniques8 = [];
-const registryConfig_pgResources_foreign_key_foreign_key = {
+const registry_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: registry_pgCodecs_foreignKey_foreignKeyCodec.sqlType,
+  codec: registry_pgCodecs_foreignKey_foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions71
 };
-const extensions135 = {
+const extensions72 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4737,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions73 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4747,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions74 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4756,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: uniqueForeignKeyCodecSpec.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4775,18 +4767,18 @@ const uniques11 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
+const registry_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec.sqlType,
+  codec: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions74
 };
-const extensions138 = {
+const extensions75 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4795,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions76 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4822,18 +4814,18 @@ const uniques13 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_person_secret_person_secret = {
+const registry_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: registry_pgCodecs_personSecret_personSecretCodec.sqlType,
+  codec: registry_pgCodecs_personSecret_personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions76
 };
-const extensions140 = {
+const extensions77 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4842,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions78 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4867,18 +4859,18 @@ const uniques15 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_compound_key_compound_key = {
+const registry_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: registry_pgCodecs_compoundKey_compoundKeyCodec.sqlType,
+  codec: registry_pgCodecs_compoundKey_compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions78
 };
-const extensions142 = {
+const extensions79 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4887,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions80 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4904,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions81 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4926,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions82 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4943,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4954,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: registry_pgCodecs_edgeCase_edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent65 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4986,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +4997,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: registry_pgCodecs_textArray_textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5015,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions85 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5025,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions86 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5057,24 +5049,24 @@ const uniques21 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_left_arm_left_arm = {
+const registry_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: registry_pgCodecs_leftArm_leftArmCodec.sqlType,
+  codec: registry_pgCodecs_leftArm_leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions86
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent67 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5084,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions87 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5100,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: registry_pgCodecs_jwtToken_jwtTokenCodec.sqlType,
+  codec: registry_pgCodecs_jwtToken_jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions87
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent68 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5146,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions88 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5171,30 +5163,30 @@ const uniques23 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_issue756_issue756 = {
+const registry_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: registry_pgCodecs_issue756_issue756Codec.sqlType,
+  codec: registry_pgCodecs_issue756_issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions88
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent69 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: registry_pgCodecs_leftArm_leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5209,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent70 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5233,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent71 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5257,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent72 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5296,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent73 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5334,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions89 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5351,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: registry_pgCodecs_authPayload_authPayloadCodec.sqlType,
+  codec: registry_pgCodecs_authPayload_authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions89
 };
-const extensions153 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5369,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5390,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: registry_pgCodecs_int4Array_int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5400,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: registry_pgCodecs_floatrange_floatrangeCodec
 }];
-const extensions154 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5413,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent75 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5434,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: registry_pgCodecs_int4Array_int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5444,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: registry_pgCodecs_floatrange_floatrangeCodec
 }];
-const extensions155 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5457,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent76 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: attributes_o2_codec_compoundTypeCodec
 }];
-const extensions156 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5476,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent77 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }];
-const extensions157 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5495,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent78 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }];
-const extensions158 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5514,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent79 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }];
-const extensions159 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5535,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent80 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5561,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent81 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5585,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5604,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5623,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5641,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5652,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5670,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5681,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: attributes_post_codec_postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5699,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5710,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5728,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions104 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5753,24 +5745,24 @@ const uniques25 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_post_post = {
+const registry_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: attributes_post_codec_postCodec.sqlType,
+  codec: attributes_post_codec_postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions104
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent88 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5780,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions105 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5796,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: attributes_o2_codec_compoundTypeCodec.sqlType,
+  codec: attributes_o2_codec_compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions105
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent89 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5833,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent90 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5862,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent91 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5891,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent92 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5928,12 +5920,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent93 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,18 +5949,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent94 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: attributes_post_codec_postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5992,18 +5984,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent95 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6021,18 +6013,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent96 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6042,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent97 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6071,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent98 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,23 +6100,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent99 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: attributes_post_codec_postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: attributes_o2_codec_compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6142,18 +6134,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent100 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: registry_pgCodecs_postArray_postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6170,7 +6162,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6185,15 +6177,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent101 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }];
-const extensions170 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,15 +6197,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent102 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }];
-const extensions171 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6224,15 +6216,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent103 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }];
-const extensions172 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6244,20 +6236,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent104 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6268,20 +6260,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent105 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6293,20 +6285,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent106 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: personCodecSpec_personAttributes_email_codec_emailCodec
 }];
-const extensions175 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6317,15 +6309,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent107 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }];
-const extensions176 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6336,8 +6328,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent108 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6349,7 +6341,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions114 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6360,8 +6352,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6373,7 +6365,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions115 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6384,8 +6376,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6397,7 +6389,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions116 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6408,8 +6400,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6421,7 +6413,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions117 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6432,13 +6424,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: attributes_person_codec_personCodec
 }, {
   name: "a",
   required: true,
@@ -6451,18 +6443,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent113 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6479,7 +6471,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions118 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6503,24 +6495,24 @@ const uniques27 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_person_person = {
+const registry_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: attributes_person_codec_personCodec.sqlType,
+  codec: attributes_person_codec_personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions118
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent114 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6540,12 +6532,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent115 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6564,12 +6556,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent116 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6588,12 +6580,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent117 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6612,12 +6604,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent118 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6628,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent119 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,12 +6652,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent120 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6686,12 +6678,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent121 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6710,18 +6702,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent122 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6740,18 +6732,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent123 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6769,7 +6761,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions119 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6777,7 +6769,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: typesCodecSpec.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6788,24 +6780,24 @@ const uniques28 = [{
     tags: Object.create(null)
   }
 }];
-const registryConfig_pgResources_types_types = {
+const registry_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: registry_pgCodecs_types_typesCodec.sqlType,
+  codec: registry_pgCodecs_types_typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions119
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent124 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6824,12 +6816,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent125 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6848,12 +6840,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent126 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6877,12 +6869,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent127 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,18 +6898,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent128 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6935,18 +6927,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent129 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }, {
     name: "id",
     required: true,
@@ -6969,12 +6961,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent130 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6993,12 +6985,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent131 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7017,18 +7009,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent132 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: attributes_person_codec_personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7045,7 +7037,7 @@ const options_person_type_function_list = {
   },
   description: undefined
 };
-const registry = makeRegistry({
+const registry = {
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
     void: TYPES.void,
@@ -7053,95 +7045,95 @@ const registry = makeRegistry({
     int8: TYPES.bigint,
     json: TYPES.json,
     jsonb: TYPES.jsonb,
-    FuncOutOutRecord: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
+    FuncOutOutRecord: registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
     text: TYPES.text,
-    FuncOutOutSetofRecord: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
-    FuncOutOutUnnamedRecord: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
-    MutationOutOutRecord: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
-    MutationOutOutSetofRecord: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
-    MutationOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
-    SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
-    FuncOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
-    FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
-    MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
-    MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    FuncOutOutSetofRecord: registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
+    FuncOutOutUnnamedRecord: registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
+    MutationOutOutRecord: registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
+    MutationOutOutSetofRecord: registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
+    MutationOutOutUnnamedRecord: registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
+    SearchTestSummariesRecord: registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
+    FuncOutUnnamedOutOutUnnamedRecord: registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
+    FuncReturnsTableMultiColRecord: registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
+    MutationOutUnnamedOutOutUnnamedRecord: registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
+    MutationReturnsTableMultiColRecord: registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
+    guid: registry_pgCodecs_guid_guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: registry_pgCodecs_intervalArray_intervalArrayCodec,
+    textArray: registry_pgCodecs_textArray_textArrayCodec,
+    nonUpdatableView: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec,
+    inputs: registry_pgCodecs_inputs_inputsCodec,
+    patchs: registry_pgCodecs_patchs_patchsCodec,
+    reserved: registry_pgCodecs_reserved_reservedCodec,
+    reservedPatchs: registry_pgCodecs_reservedPatchs_reservedPatchsCodec,
+    reservedInput: registry_pgCodecs_reservedInput_reservedInputCodec,
+    defaultValue: registry_pgCodecs_defaultValue_defaultValueCodec,
+    foreignKey: registry_pgCodecs_foreignKey_foreignKeyCodec,
+    noPrimaryKey: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec,
+    testview: registry_pgCodecs_testview_testviewCodec,
+    uniqueForeignKey: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
+    myTable: registry_pgCodecs_myTable_myTableCodec,
+    personSecret: registry_pgCodecs_personSecret_personSecretCodec,
+    viewTable: registry_pgCodecs_viewTable_viewTableCodec,
+    compoundKey: registry_pgCodecs_compoundKey_compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: registry_pgCodecs_similarTable1_similarTable1Codec,
+    similarTable2: registry_pgCodecs_similarTable2_similarTable2Codec,
+    updatableView: registry_pgCodecs_updatableView_updatableViewCodec,
+    nullTestRecord: registry_pgCodecs_nullTestRecord_nullTestRecordCodec,
+    uuidArray: registry_pgCodecs_uuidArray_uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: registry_pgCodecs_edgeCase_edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: registry_pgCodecs_leftArm_leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: registry_pgCodecs_jwtToken_jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: registry_pgCodecs_issue756_issue756Codec,
+    notNullTimestamp: issue756CodecSpec_issue756Attributes_ts_codec_notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
-    FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
-    MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
-    QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
-    PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
-    PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
-    PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    authPayload: registry_pgCodecs_authPayload_authPayloadCodec,
+    FuncOutOutCompoundTypeRecord: registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
+    compoundType: attributes_o2_codec_compoundTypeCodec,
+    color: compoundTypeCodecSpec_compoundTypeAttributes_c_codec_colorCodec,
+    enumCaps: compoundTypeCodecSpec_compoundTypeAttributes_e_codec_enumCapsCodec,
+    enumWithEmptyString: compoundTypeCodecSpec_compoundTypeAttributes_f_codec_enumWithEmptyStringCodec,
+    MutationOutOutCompoundTypeRecord: registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
+    QueryOutputTwoRowsRecord: registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
+    post: attributes_post_codec_postCodec,
+    anEnumArray: postCodecSpec_postAttributes_enums_codec_anEnumArrayCodec,
+    anEnum: anEnumArrayCodec_anEnumCodec,
+    comptypeArray: postCodecSpec_postAttributes_comptypes_codec_comptypeArrayCodec,
+    comptype: comptypeArrayCodec_comptypeCodec,
+    PersonComputedOutOutRecord: registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
+    PersonComputedInoutOutRecord: registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
+    PersonComputedFirstArgInoutOutRecord: registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
+    person: attributes_person_codec_personCodec,
+    email: personCodecSpec_personAttributes_email_codec_emailCodec,
+    wrappedUrl: personCodecSpec_personAttributes_site_codec_wrappedUrlCodec,
+    notNullUrl: wrappedUrlCodecSpec_wrappedUrlAttributes_url_codec_notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr,
     timestamp: TYPES.timestamp,
-    FuncOutComplexRecord: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
-    FuncOutComplexSetofRecord: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
-    MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
-    MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
-    PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    FuncOutComplexRecord: registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
+    FuncOutComplexSetofRecord: registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
+    MutationOutComplexRecord: registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
+    MutationOutComplexSetofRecord: registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
+    PersonComputedComplexRecord: registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
+    types: registry_pgCodecs_types_typesCodec,
+    colorArray: typesCodecSpec_typesAttributes_enum_array_codec_colorArrayCodec,
+    anInt: typesCodecSpec_typesAttributes_domain_codec_anIntCodec,
+    anotherInt: typesCodecSpec_typesAttributes_domain2_codec_anotherIntCodec,
+    numrange: typesCodecSpec_typesAttributes_nullable_range_codec_numrangeCodec,
+    daterange: typesCodecSpec_typesAttributes_daterange_codec_daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: typesCodecSpec_typesAttributes_an_int_range_codec_anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: typesCodecSpec_typesAttributes_nested_compound_type_codec_nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7151,38 +7143,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: typesCodecSpec_typesAttributes_text_array_domain_codec_textArrayDomainCodec,
+    int8ArrayDomain: typesCodecSpec_typesAttributes_int8_array_domain_codec_int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: typesCodecSpec_typesAttributes_bytea_array_codec_byteaArrayCodec,
+    ltree: typesCodecSpec_typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesCodecSpec_typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundTypeCodec, {
+      extensions: compoundTypeArrayCodec,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(registry_pgCodecs_jwtToken_jwtTokenCodec, {
+      extensions: jwtTokenArrayCodec,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(registry_pgCodecs_types_typesCodec, {
+      extensions: typesArrayCodec,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: registry_pgCodecs_int4Array_int4ArrayCodec,
+    floatrange: registry_pgCodecs_floatrange_floatrangeCodec,
+    postArray: registry_pgCodecs_postArray_postArrayCodec,
+    int8Array: int8ArrayDomainCodec_int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2Codec_tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3Codec_tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4Codec_tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7190,14 +7182,23 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
@@ -7210,7 +7211,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions2,
       description: undefined
     },
     func_out_setof: {
@@ -7223,7 +7224,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions3,
       description: undefined
     },
     func_out_unnamed: {
@@ -7236,7 +7237,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions4,
       description: undefined
     },
     mutation_out: {
@@ -7249,7 +7250,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions5,
       description: undefined
     },
     mutation_out_setof: {
@@ -7262,7 +7263,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions6,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7275,7 +7276,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions7,
       description: undefined
     },
     no_args_mutation: {
@@ -7288,7 +7289,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions8,
       description: undefined
     },
     no_args_query: {
@@ -7301,7 +7302,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions9,
       description: undefined
     },
     return_void_mutation: {
@@ -7314,7 +7315,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions10,
       description: undefined
     },
     mutation_interval_set: {
@@ -7327,7 +7328,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions11,
       description: undefined
     },
     query_interval_set: {
@@ -7340,7 +7341,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions12,
       description: undefined
     },
     static_big_integer: {
@@ -7353,7 +7354,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions13,
       description: undefined
     },
     func_in_out: {
@@ -7366,7 +7367,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions14,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7379,7 +7380,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions15,
       description: undefined
     },
     mutation_in_out: {
@@ -7392,7 +7393,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions16,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7405,7 +7406,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions17,
       description: undefined
     },
     assert_something: {
@@ -7418,7 +7419,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions18,
       description: undefined
     },
     assert_something_nx: {
@@ -7431,7 +7432,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions19,
       description: undefined
     },
     json_identity: {
@@ -7444,7 +7445,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions20,
       description: undefined
     },
     json_identity_mutation: {
@@ -7457,7 +7458,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions21,
       description: undefined
     },
     jsonb_identity: {
@@ -7470,7 +7471,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions22,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7483,7 +7484,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions23,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7496,7 +7497,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions24,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7509,7 +7510,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions25,
       description: undefined
     },
     add_1_mutation: {
@@ -7522,7 +7523,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions26,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7535,7 +7536,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions27,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7548,7 +7549,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions28,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7561,7 +7562,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions29,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7574,7 +7575,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions30,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7587,7 +7588,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions31,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7600,7 +7601,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions32,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7613,7 +7614,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions33,
       description: undefined
     },
     add_4_query: {
@@ -7626,7 +7627,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions34,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7639,7 +7640,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions35,
       description: undefined
     },
     mult_2: {
@@ -7652,7 +7653,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions36,
       description: undefined
     },
     mult_3: {
@@ -7665,7 +7666,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions37,
       description: undefined
     },
     mult_4: {
@@ -7678,7 +7679,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions38,
       description: undefined
     },
     func_in_inout: {
@@ -7691,7 +7692,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions39,
       description: undefined
     },
     func_out_out: {
@@ -7701,10 +7702,10 @@ const registry = makeRegistry({
       from: fromCallback40,
       parameters: parameters40,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
+      codec: registry_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions40,
       description: undefined
     },
     func_out_out_setof: {
@@ -7714,10 +7715,10 @@ const registry = makeRegistry({
       from: fromCallback41,
       parameters: parameters41,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
+      codec: registry_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions41,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7727,10 +7728,10 @@ const registry = makeRegistry({
       from: fromCallback42,
       parameters: parameters42,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
+      codec: registry_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions42,
       description: undefined
     },
     mutation_in_inout: {
@@ -7743,7 +7744,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions43,
       description: undefined
     },
     mutation_out_out: {
@@ -7753,10 +7754,10 @@ const registry = makeRegistry({
       from: fromCallback44,
       parameters: parameters44,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
+      codec: registry_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions44,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7766,10 +7767,10 @@ const registry = makeRegistry({
       from: fromCallback45,
       parameters: parameters45,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
+      codec: registry_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions45,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7779,10 +7780,10 @@ const registry = makeRegistry({
       from: fromCallback46,
       parameters: parameters46,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
+      codec: registry_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions46,
       description: undefined
     },
     search_test_summaries: {
@@ -7792,10 +7793,10 @@ const registry = makeRegistry({
       from: fromCallback47,
       parameters: parameters47,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
+      codec: registry_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions47,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7808,7 +7809,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions48,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7821,7 +7822,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions49,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7834,7 +7835,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions50,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7847,7 +7848,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions51,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7860,7 +7861,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions52,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7870,10 +7871,10 @@ const registry = makeRegistry({
       from: fromCallback53,
       parameters: parameters53,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
+      codec: registry_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions53,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7883,10 +7884,10 @@ const registry = makeRegistry({
       from: fromCallback54,
       parameters: parameters54,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
+      codec: registry_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions54,
       description: undefined
     },
     int_set_mutation: {
@@ -7899,7 +7900,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions55,
       description: undefined
     },
     int_set_query: {
@@ -7912,7 +7913,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7922,10 +7923,10 @@ const registry = makeRegistry({
       from: fromCallback57,
       parameters: parameters57,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
+      codec: registry_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions57,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7935,10 +7936,10 @@ const registry = makeRegistry({
       from: fromCallback58,
       parameters: parameters58,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
+      codec: registry_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions58,
       description: undefined
     },
     guid_fn: {
@@ -7948,10 +7949,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: registry_pgCodecs_guid_guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions59,
       description: undefined
     },
     mutation_interval_array: {
@@ -7961,10 +7962,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions60,
       description: undefined
     },
     query_interval_array: {
@@ -7974,10 +7975,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions61,
       description: undefined
     },
     mutation_text_array: {
@@ -7987,10 +7988,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: registry_pgCodecs_textArray_textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions62,
       description: undefined
     },
     query_text_array: {
@@ -8000,180 +8001,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: registry_pgCodecs_textArray_textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions63,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec.sqlType,
+      codec: registry_pgCodecs_nonUpdatableView_nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions64
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: registry_pgCodecs_inputs_inputsCodec.sqlType,
+      codec: registry_pgCodecs_inputs_inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions65
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: registry_pgCodecs_patchs_patchsCodec.sqlType,
+      codec: registry_pgCodecs_patchs_patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions66
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: registry_pgCodecs_reserved_reservedCodec.sqlType,
+      codec: registry_pgCodecs_reserved_reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions67
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: registry_pgCodecs_reservedPatchs_reservedPatchsCodec.sqlType,
+      codec: registry_pgCodecs_reservedPatchs_reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions68
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: registry_pgCodecs_reservedInput_reservedInputCodec.sqlType,
+      codec: registry_pgCodecs_reservedInput_reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions69
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: registry_pgCodecs_defaultValue_defaultValueCodec.sqlType,
+      codec: registry_pgCodecs_defaultValue_defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions70
     },
-    foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
+    foreign_key: registry_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec.sqlType,
+      codec: registry_pgCodecs_noPrimaryKey_noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions72
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: registry_pgCodecs_testview_testviewCodec.sqlType,
+      codec: registry_pgCodecs_testview_testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions73
     },
-    unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
+    unique_foreign_key: registry_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: registry_pgCodecs_myTable_myTableCodec.sqlType,
+      codec: registry_pgCodecs_myTable_myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions75
     },
-    person_secret: registryConfig_pgResources_person_secret_person_secret,
+    person_secret: registry_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: registry_pgCodecs_viewTable_viewTableCodec.sqlType,
+      codec: registry_pgCodecs_viewTable_viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions77
     },
-    compound_key: registryConfig_pgResources_compound_key_compound_key,
+    compound_key: registry_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: registry_pgCodecs_similarTable1_similarTable1Codec.sqlType,
+      codec: registry_pgCodecs_similarTable1_similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions79
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: registry_pgCodecs_similarTable2_similarTable2Codec.sqlType,
+      codec: registry_pgCodecs_similarTable2_similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions80
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: registry_pgCodecs_updatableView_updatableViewCodec.sqlType,
+      codec: registry_pgCodecs_updatableView_updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions81
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: registry_pgCodecs_nullTestRecord_nullTestRecordCodec.sqlType,
+      codec: registry_pgCodecs_nullTestRecord_nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions82
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8185,10 +8186,10 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions83,
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registry_pgResources_compound_key_compound_key, options_return_table_without_grants),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
@@ -8196,30 +8197,30 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: registry_pgCodecs_uuidArray_uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions84,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: registry_pgCodecs_edgeCase_edgeCaseCodec.sqlType,
+      codec: registry_pgCodecs_edgeCase_edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions85
     },
-    left_arm: registryConfig_pgResources_left_arm_left_arm,
+    left_arm: registry_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
     authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
-    issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756: registry_pgResources_issue756_issue756,
+    left_arm_identity: PgResource.functionResourceOptions(registry_pgResources_left_arm_left_arm, options_left_arm_identity),
+    issue756_mutation: PgResource.functionResourceOptions(registry_pgResources_issue756_issue756, options_issue756_mutation),
+    issue756_set_mutation: PgResource.functionResourceOptions(registry_pgResources_issue756_issue756, options_issue756_set_mutation),
     authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
     authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
     types_mutation: {
@@ -8232,7 +8233,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions90,
       description: undefined
     },
     types_query: {
@@ -8245,7 +8246,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions91,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8258,7 +8259,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions92,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8271,7 +8272,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions93,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8281,10 +8282,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: registry_pgCodecs_intervalArray_intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions94,
       description: undefined
     },
     post_computed_text_array: {
@@ -8294,10 +8295,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: registry_pgCodecs_textArray_textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions95,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8310,7 +8311,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions96,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8323,7 +8324,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions97,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8333,10 +8334,10 @@ const registry = makeRegistry({
       from: fromCallback74,
       parameters: parameters74,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
+      codec: registry_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions98,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8346,10 +8347,10 @@ const registry = makeRegistry({
       from: fromCallback75,
       parameters: parameters75,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
+      codec: registry_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions99,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8362,7 +8363,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions100,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8375,7 +8376,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions101,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8388,7 +8389,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions102,
       description: undefined
     },
     query_output_two_rows: {
@@ -8398,26 +8399,26 @@ const registry = makeRegistry({
       from: fromCallback79,
       parameters: parameters79,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
+      codec: registry_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions103,
       description: undefined
     },
-    post: registryConfig_pgResources_post_post,
+    post: registry_pgResources_post_post,
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
     compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
     compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
     compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
+    table_mutation: PgResource.functionResourceOptions(registry_pgResources_post_post, options_table_mutation),
+    table_query: PgResource.functionResourceOptions(registry_pgResources_post_post, options_table_query),
+    post_with_suffix: PgResource.functionResourceOptions(registry_pgResources_post_post, options_post_with_suffix),
     mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
     query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
     compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
     compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
     post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    post_many: PgResource.functionResourceOptions(registry_pgResources_post_post, options_post_many),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
@@ -8428,7 +8429,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions106,
       description: undefined
     },
     person_first_name: {
@@ -8441,7 +8442,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions107,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8451,10 +8452,10 @@ const registry = makeRegistry({
       from: fromCallback82,
       parameters: parameters82,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
+      codec: registry_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions108,
       description: undefined
     },
     person_computed_inout: {
@@ -8467,7 +8468,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions109,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8477,10 +8478,10 @@ const registry = makeRegistry({
       from: fromCallback84,
       parameters: parameters84,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
+      codec: registry_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions110,
       description: undefined
     },
     person_exists: {
@@ -8493,7 +8494,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions111,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8503,10 +8504,10 @@ const registry = makeRegistry({
       from: fromCallback86,
       parameters: parameters86,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
+      codec: registry_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions112,
       description: undefined
     },
     func_out_complex: {
@@ -8516,10 +8517,10 @@ const registry = makeRegistry({
       from: fromCallback87,
       parameters: parameters87,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
+      codec: registry_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions113,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8529,10 +8530,10 @@ const registry = makeRegistry({
       from: fromCallback88,
       parameters: parameters88,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
+      codec: registry_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions114,
       description: undefined
     },
     mutation_out_complex: {
@@ -8542,10 +8543,10 @@ const registry = makeRegistry({
       from: fromCallback89,
       parameters: parameters89,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
+      codec: registry_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions115,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8555,10 +8556,10 @@ const registry = makeRegistry({
       from: fromCallback90,
       parameters: parameters90,
       isUnique: !true,
-      codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
+      codec: registry_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions116,
       description: undefined
     },
     person_computed_complex: {
@@ -8568,40 +8569,40 @@ const registry = makeRegistry({
       from: fromCallback91,
       parameters: parameters91,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
+      codec: registry_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions117,
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
-    person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions(registry_pgResources_post_post, options_person_first_post),
+    person: registry_pgResources_person_person,
+    badly_behaved_function: PgResource.functionResourceOptions(registry_pgResources_person_person, options_badly_behaved_function),
+    func_out_table: PgResource.functionResourceOptions(registry_pgResources_person_person, options_func_out_table),
+    func_out_table_setof: PgResource.functionResourceOptions(registry_pgResources_person_person, options_func_out_table_setof),
+    mutation_out_table: PgResource.functionResourceOptions(registry_pgResources_person_person, options_mutation_out_table),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registry_pgResources_person_person, options_mutation_out_table_setof),
+    table_set_mutation: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_mutation),
+    table_set_query: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_query),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registry_pgResources_person_person, options_table_set_query_plpgsql),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registry_pgResources_person_person, options_person_computed_first_arg_inout),
+    person_friends: PgResource.functionResourceOptions(registry_pgResources_person_person, options_person_friends),
+    types: registry_pgResources_types_types,
+    type_function_connection: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_connection),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_connection_mutation),
+    type_function: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function),
+    type_function_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_mutation),
+    person_type_function_connection: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function_connection),
+    person_type_function: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function),
+    type_function_list: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_list),
+    type_function_list_mutation: PgResource.functionResourceOptions(registry_pgResources_types_types, options_type_function_list_mutation),
+    person_type_function_list: PgResource.functionResourceOptions(registry_pgResources_types_types, options_person_type_function_list)
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
-        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
+        localCodec: registry_pgCodecs_foreignKey_foreignKeyCodec,
+        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
         remoteAttributes: ["person_id_1", "person_id_2"],
@@ -8615,8 +8616,8 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_foreignKey_foreignKeyCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8632,8 +8633,8 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: attributes_post_codec_postCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
         remoteAttributes: ["id"],
@@ -8647,8 +8648,8 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
-        remoteResourceOptions: registryConfig_pgResources_types_types,
+        localCodec: attributes_post_codec_postCodec,
+        remoteResourceOptions: registry_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["smallint"],
@@ -8662,8 +8663,8 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
-        remoteResourceOptions: registryConfig_pgResources_types_types,
+        localCodec: attributes_post_codec_postCodec,
+        remoteResourceOptions: registry_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8679,8 +8680,8 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
+        localCodec: registry_pgCodecs_uniqueForeignKey_uniqueForeignKeyCodec,
+        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
         remoteAttributes: ["person_id_1", "person_id_2"],
@@ -8696,8 +8697,8 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_authPayload_authPayloadCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8713,8 +8714,8 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
-        remoteResourceOptions: registryConfig_pgResources_post_post,
+        localCodec: registry_pgCodecs_types_typesCodec,
+        remoteResourceOptions: registry_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
         remoteAttributes: ["id"],
@@ -8728,8 +8729,8 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
-        remoteResourceOptions: registryConfig_pgResources_post_post,
+        localCodec: registry_pgCodecs_types_typesCodec,
+        remoteResourceOptions: registry_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["id"],
@@ -8745,8 +8746,8 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
         remoteAttributes: ["id"],
@@ -8760,8 +8761,8 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
         remoteAttributes: ["id"],
@@ -8775,8 +8776,8 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
-        remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
+        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
+        remoteResourceOptions: registry_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
         remoteAttributes: ["compound_key_1", "compound_key_2"],
@@ -8790,8 +8791,8 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
-        remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
+        localCodec: registry_pgCodecs_compoundKey_compoundKeyCodec,
+        remoteResourceOptions: registry_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
         remoteAttributes: ["compound_key_1", "compound_key_2"],
@@ -8807,8 +8808,8 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_leftArm_leftArmCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8824,8 +8825,8 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_post_post,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["author_id"],
@@ -8839,8 +8840,8 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8854,8 +8855,8 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8871,8 +8872,8 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id"],
@@ -8886,8 +8887,8 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id_1"],
@@ -8901,8 +8902,8 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
-        remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
+        localCodec: attributes_person_codec_personCodec,
+        remoteResourceOptions: registry_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
         remoteAttributes: ["person_id_2"],
@@ -8918,8 +8919,8 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
-        remoteResourceOptions: registryConfig_pgResources_person_person,
+        localCodec: registry_pgCodecs_personSecret_personSecretCodec,
+        remoteResourceOptions: registry_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
         remoteAttributes: ["id"],
@@ -8936,25 +8937,26 @@ const registry = makeRegistry({
       }
     })
   })
-});
-const pgResource_inputsPgResource = registry.pgResources["inputs"];
-const pgResource_patchsPgResource = registry.pgResources["patchs"];
-const pgResource_reservedPgResource = registry.pgResources["reserved"];
-const pgResource_reservedPatchsPgResource = registry.pgResources["reservedPatchs"];
-const pgResource_reserved_inputPgResource = registry.pgResources["reserved_input"];
-const pgResource_default_valuePgResource = registry.pgResources["default_value"];
-const pgResource_my_tablePgResource = registry.pgResources["my_table"];
-const pgResource_person_secretPgResource = registry.pgResources["person_secret"];
-const pgResource_view_tablePgResource = registry.pgResources["view_table"];
-const pgResource_compound_keyPgResource = registry.pgResources["compound_key"];
-const pgResource_similar_table_1PgResource = registry.pgResources["similar_table_1"];
-const pgResource_similar_table_2PgResource = registry.pgResources["similar_table_2"];
-const pgResource_null_test_recordPgResource = registry.pgResources["null_test_record"];
-const pgResource_left_armPgResource = registry.pgResources["left_arm"];
-const pgResource_issue756PgResource = registry.pgResources["issue756"];
-const pgResource_postPgResource = registry.pgResources["post"];
-const pgResource_personPgResource = registry.pgResources["person"];
-const pgResource_typesPgResource = registry.pgResources["types"];
+};
+const registry_registry = makeRegistry(registry);
+const pgResource_inputsPgResource = registry_registry.pgResources["inputs"];
+const pgResource_patchsPgResource = registry_registry.pgResources["patchs"];
+const pgResource_reservedPgResource = registry_registry.pgResources["reserved"];
+const pgResource_reservedPatchsPgResource = registry_registry.pgResources["reservedPatchs"];
+const pgResource_reserved_inputPgResource = registry_registry.pgResources["reserved_input"];
+const pgResource_default_valuePgResource = registry_registry.pgResources["default_value"];
+const pgResource_my_tablePgResource = registry_registry.pgResources["my_table"];
+const pgResource_person_secretPgResource = registry_registry.pgResources["person_secret"];
+const pgResource_view_tablePgResource = registry_registry.pgResources["view_table"];
+const pgResource_compound_keyPgResource = registry_registry.pgResources["compound_key"];
+const pgResource_similar_table_1PgResource = registry_registry.pgResources["similar_table_1"];
+const pgResource_similar_table_2PgResource = registry_registry.pgResources["similar_table_2"];
+const pgResource_null_test_recordPgResource = registry_registry.pgResources["null_test_record"];
+const pgResource_left_armPgResource = registry_registry.pgResources["left_arm"];
+const pgResource_issue756PgResource = registry_registry.pgResources["issue756"];
+const pgResource_postPgResource = registry_registry.pgResources["post"];
+const pgResource_personPgResource = registry_registry.pgResources["person"];
+const pgResource_typesPgResource = registry_registry.pgResources["types"];
 const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
@@ -9301,8 +9303,8 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
     }
   }
 });
-const resource_no_primary_keyPgResource = registry.pgResources["no_primary_key"];
-const resource_unique_foreign_keyPgResource = registry.pgResources["unique_foreign_key"];
+const resource_no_primary_keyPgResource = registry_registry.pgResources["no_primary_key"];
+const resource_unique_foreign_keyPgResource = registry_registry.pgResources["unique_foreign_key"];
 const argDetailsSimple = [];
 const makeArgs = (args, path = []) => {
   const selectArgs = [];
@@ -9348,7 +9350,7 @@ const makeArgs = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_current_user_idPgResource = registry.pgResources["current_user_id"];
+const resource_current_user_idPgResource = registry_registry.pgResources["current_user_id"];
 const argDetailsSimple2 = [];
 const makeArgs2 = (args, path = []) => {
   const selectArgs = [];
@@ -9394,7 +9396,7 @@ const makeArgs2 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_outPgResource = registry.pgResources["func_out"];
+const resource_func_outPgResource = registry_registry.pgResources["func_out"];
 const argDetailsSimple3 = [];
 const makeArgs3 = (args, path = []) => {
   const selectArgs = [];
@@ -9440,7 +9442,7 @@ const makeArgs3 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_setofPgResource = registry.pgResources["func_out_setof"];
+const resource_func_out_setofPgResource = registry_registry.pgResources["func_out_setof"];
 const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
@@ -9509,7 +9511,7 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_unnamedPgResource = registry.pgResources["func_out_unnamed"];
+const resource_func_out_unnamedPgResource = registry_registry.pgResources["func_out_unnamed"];
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -9555,7 +9557,7 @@ const makeArgs5 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_no_args_queryPgResource = registry.pgResources["no_args_query"];
+const resource_no_args_queryPgResource = registry_registry.pgResources["no_args_query"];
 const argDetailsSimple6 = [];
 const makeArgs6 = (args, path = []) => {
   const selectArgs = [];
@@ -9601,7 +9603,7 @@ const makeArgs6 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_interval_setPgResource = registry.pgResources["query_interval_set"];
+const resource_query_interval_setPgResource = registry_registry.pgResources["query_interval_set"];
 const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
@@ -9666,7 +9668,7 @@ const makeArgs7 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_static_big_integerPgResource = registry.pgResources["static_big_integer"];
+const resource_static_big_integerPgResource = registry_registry.pgResources["static_big_integer"];
 const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
@@ -9737,7 +9739,7 @@ const makeArgs8 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_in_outPgResource = registry.pgResources["func_in_out"];
+const resource_func_in_outPgResource = registry_registry.pgResources["func_in_out"];
 const argDetailsSimple9 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9789,7 +9791,7 @@ const makeArgs9 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_returns_table_one_colPgResource = registry.pgResources["func_returns_table_one_col"];
+const resource_func_returns_table_one_colPgResource = registry_registry.pgResources["func_returns_table_one_col"];
 const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
@@ -9860,7 +9862,7 @@ const makeArgs10 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identityPgResource = registry.pgResources["json_identity"];
+const resource_json_identityPgResource = registry_registry.pgResources["json_identity"];
 const argDetailsSimple11 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -9912,7 +9914,7 @@ const makeArgs11 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identityPgResource = registry.pgResources["jsonb_identity"];
+const resource_jsonb_identityPgResource = registry_registry.pgResources["jsonb_identity"];
 const argDetailsSimple12 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -9970,7 +9972,7 @@ const makeArgs12 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_queryPgResource = registry.pgResources["add_1_query"];
+const resource_add_1_queryPgResource = registry_registry.pgResources["add_1_query"];
 const argDetailsSimple13 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10028,7 +10030,7 @@ const makeArgs13 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_queryPgResource = registry.pgResources["add_2_query"];
+const resource_add_2_queryPgResource = registry_registry.pgResources["add_2_query"];
 const argDetailsSimple14 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10086,7 +10088,7 @@ const makeArgs14 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_queryPgResource = registry.pgResources["add_3_query"];
+const resource_add_3_queryPgResource = registry_registry.pgResources["add_3_query"];
 const argDetailsSimple15 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10144,7 +10146,7 @@ const makeArgs15 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_queryPgResource = registry.pgResources["add_4_query"];
+const resource_add_4_queryPgResource = registry_registry.pgResources["add_4_query"];
 const argDetailsSimple16 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -10202,7 +10204,7 @@ const makeArgs16 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_in_inoutPgResource = registry.pgResources["func_in_inout"];
+const resource_func_in_inoutPgResource = registry_registry.pgResources["func_in_inout"];
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -10248,7 +10250,7 @@ const makeArgs17 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_outPgResource = registry.pgResources["func_out_out"];
+const resource_func_out_outPgResource = registry_registry.pgResources["func_out_out"];
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -10294,7 +10296,7 @@ const makeArgs18 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_setofPgResource = registry.pgResources["func_out_out_setof"];
+const resource_func_out_out_setofPgResource = registry_registry.pgResources["func_out_out_setof"];
 const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
@@ -10359,7 +10361,7 @@ const makeArgs19 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_unnamedPgResource = registry.pgResources["func_out_out_unnamed"];
+const resource_func_out_out_unnamedPgResource = registry_registry.pgResources["func_out_out_unnamed"];
 const argDetailsSimple20 = [];
 const makeArgs20 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,7 +10407,7 @@ const makeArgs20 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
+const resource_search_test_summariesPgResource = registry_registry.pgResources["search_test_summaries"];
 function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -10475,7 +10477,7 @@ const makeArgs21 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_1PgResource = registry.pgResources["optional_missing_middle_1"];
+const resource_optional_missing_middle_1PgResource = registry_registry.pgResources["optional_missing_middle_1"];
 const argDetailsSimple22 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10539,7 +10541,7 @@ const makeArgs22 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_2PgResource = registry.pgResources["optional_missing_middle_2"];
+const resource_optional_missing_middle_2PgResource = registry_registry.pgResources["optional_missing_middle_2"];
 const argDetailsSimple23 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10603,7 +10605,7 @@ const makeArgs23 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_3PgResource = registry.pgResources["optional_missing_middle_3"];
+const resource_optional_missing_middle_3PgResource = registry_registry.pgResources["optional_missing_middle_3"];
 const argDetailsSimple24 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10667,7 +10669,7 @@ const makeArgs24 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_4PgResource = registry.pgResources["optional_missing_middle_4"];
+const resource_optional_missing_middle_4PgResource = registry_registry.pgResources["optional_missing_middle_4"];
 const argDetailsSimple25 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -10731,7 +10733,7 @@ const makeArgs25 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_optional_missing_middle_5PgResource = registry.pgResources["optional_missing_middle_5"];
+const resource_optional_missing_middle_5PgResource = registry_registry.pgResources["optional_missing_middle_5"];
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -10777,7 +10779,7 @@ const makeArgs26 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_unnamed_out_out_unnamedPgResource = registry.pgResources["func_out_unnamed_out_out_unnamed"];
+const resource_func_out_unnamed_out_out_unnamedPgResource = registry_registry.pgResources["func_out_unnamed_out_out_unnamed"];
 const argDetailsSimple27 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -10829,7 +10831,7 @@ const makeArgs27 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_returns_table_multi_colPgResource = registry.pgResources["func_returns_table_multi_col"];
+const resource_func_returns_table_multi_colPgResource = registry_registry.pgResources["func_returns_table_multi_col"];
 const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
@@ -10912,7 +10914,7 @@ const makeArgs28 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_queryPgResource = registry.pgResources["int_set_query"];
+const resource_int_set_queryPgResource = registry_registry.pgResources["int_set_query"];
 const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
@@ -10977,7 +10979,7 @@ const makeArgs29 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_interval_arrayPgResource = registry.pgResources["query_interval_array"];
+const resource_query_interval_arrayPgResource = registry_registry.pgResources["query_interval_array"];
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {
   const selectArgs = [];
@@ -11023,7 +11025,7 @@ const makeArgs30 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_text_arrayPgResource = registry.pgResources["query_text_array"];
+const resource_query_text_arrayPgResource = registry_registry.pgResources["query_text_array"];
 const argDetailsSimple31 = [];
 const makeArgs31 = (args, path = []) => {
   const selectArgs = [];
@@ -11069,7 +11071,7 @@ const makeArgs31 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_table_without_grantsPgResource = registry.pgResources["return_table_without_grants"];
+const resource_return_table_without_grantsPgResource = registry_registry.pgResources["return_table_without_grants"];
 const argDetailsSimple32 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11091,7 +11093,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: registry_pgCodecs_int4Array_int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11103,7 +11105,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: registry_pgCodecs_floatrange_floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11151,7 +11153,7 @@ const makeArgs32 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_queryPgResource = registry.pgResources["types_query"];
+const resource_types_queryPgResource = registry_registry.pgResources["types_query"];
 const argDetailsSimple33 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -11203,7 +11205,7 @@ const makeArgs33 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_out_compound_typePgResource = registry.pgResources["func_out_out_compound_type"];
+const resource_func_out_out_compound_typePgResource = registry_registry.pgResources["func_out_out_compound_type"];
 const argDetailsSimple34 = [{
   graphqlArgName: "leftArmId",
   postgresArgName: "left_arm_id",
@@ -11267,7 +11269,7 @@ const makeArgs34 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_output_two_rowsPgResource = registry.pgResources["query_output_two_rows"];
+const resource_query_output_two_rowsPgResource = registry_registry.pgResources["query_output_two_rows"];
 const argDetailsSimple35 = [];
 const makeArgs35 = (args, path = []) => {
   const selectArgs = [];
@@ -11313,7 +11315,7 @@ const makeArgs35 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_queryPgResource = registry.pgResources["compound_type_set_query"];
+const resource_compound_type_set_queryPgResource = registry_registry.pgResources["compound_type_set_query"];
 const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
@@ -11336,7 +11338,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11384,7 +11386,7 @@ const makeArgs36 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_queryPgResource = registry.pgResources["compound_type_query"];
+const resource_compound_type_queryPgResource = registry_registry.pgResources["compound_type_query"];
 const argDetailsSimple37 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -11436,11 +11438,11 @@ const makeArgs37 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_queryPgResource = registry.pgResources["table_query"];
+const resource_table_queryPgResource = registry_registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11488,11 +11490,11 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_query_compound_type_arrayPgResource = registry.pgResources["query_compound_type_array"];
+const resource_query_compound_type_arrayPgResource = registry_registry.pgResources["query_compound_type_array"];
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11540,7 +11542,7 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_queryPgResource = registry.pgResources["compound_type_array_query"];
+const resource_compound_type_array_queryPgResource = registry_registry.pgResources["compound_type_array_query"];
 const argDetailsSimple40 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11598,7 +11600,7 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_complexPgResource = registry.pgResources["func_out_complex"];
+const resource_func_out_complexPgResource = registry_registry.pgResources["func_out_complex"];
 const argDetailsSimple41 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -11656,7 +11658,7 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_complex_setofPgResource = registry.pgResources["func_out_complex_setof"];
+const resource_func_out_complex_setofPgResource = registry_registry.pgResources["func_out_complex_setof"];
 const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
@@ -11721,7 +11723,7 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_badly_behaved_functionPgResource = registry.pgResources["badly_behaved_function"];
+const resource_badly_behaved_functionPgResource = registry_registry.pgResources["badly_behaved_function"];
 const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
@@ -11786,7 +11788,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_tablePgResource = registry.pgResources["func_out_table"];
+const resource_func_out_tablePgResource = registry_registry.pgResources["func_out_table"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -11832,7 +11834,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_func_out_table_setofPgResource = registry.pgResources["func_out_table_setof"];
+const resource_func_out_table_setofPgResource = registry_registry.pgResources["func_out_table_setof"];
 const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
@@ -11897,7 +11899,7 @@ const makeArgs45 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_queryPgResource = registry.pgResources["table_set_query"];
+const resource_table_set_queryPgResource = registry_registry.pgResources["table_set_query"];
 const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
@@ -11980,7 +11982,7 @@ const makeArgs46 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_set_query_plpgsql"];
+const resource_table_set_query_plpgsqlPgResource = registry_registry.pgResources["table_set_query_plpgsql"];
 const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
@@ -12045,7 +12047,7 @@ const makeArgs47 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
+const resource_type_function_connectionPgResource = registry_registry.pgResources["type_function_connection"];
 const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
@@ -12116,7 +12118,7 @@ const makeArgs48 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_functionPgResource = registry.pgResources["type_function"];
+const resource_type_functionPgResource = registry_registry.pgResources["type_function"];
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -12162,7 +12164,7 @@ const makeArgs49 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_listPgResource = registry.pgResources["type_function_list"];
+const resource_type_function_listPgResource = registry_registry.pgResources["type_function_list"];
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -12325,7 +12327,7 @@ const fetcher18 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Type);
-const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
+const resource_non_updatable_viewPgResource = registry_registry.pgResources["non_updatable_view"];
 function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12431,7 +12433,7 @@ function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
 function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
+const resource_foreign_keyPgResource = registry_registry.pgResources["foreign_key"];
 function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12462,7 +12464,7 @@ function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
 function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_testviewPgResource = registry.pgResources["testview"];
+const resource_testviewPgResource = registry_registry.pgResources["testview"];
 function Query_allTestviews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12568,7 +12570,7 @@ function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
 function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
+const resource_updatable_viewPgResource = registry_registry.pgResources["updatable_view"];
 function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12599,7 +12601,7 @@ function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
 function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_edge_casePgResource = registry.pgResources["edge_case"];
+const resource_edge_casePgResource = registry_registry.pgResources["edge_case"];
 function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -12753,7 +12755,7 @@ const makeArgs50 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_outPgResource = registry.pgResources["person_computed_out"];
+const resource_person_computed_outPgResource = registry_registry.pgResources["person_computed_out"];
 const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
@@ -12799,7 +12801,7 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_namePgResource = registry.pgResources["person_first_name"];
+const resource_person_first_namePgResource = registry_registry.pgResources["person_first_name"];
 const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
@@ -12845,7 +12847,7 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_out_outPgResource = registry.pgResources["person_computed_out_out"];
+const resource_person_computed_out_outPgResource = registry_registry.pgResources["person_computed_out_out"];
 const argDetailsSimple53 = [{
   graphqlArgName: "ino",
   postgresArgName: "ino",
@@ -12897,7 +12899,7 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_inoutPgResource = registry.pgResources["person_computed_inout"];
+const resource_person_computed_inoutPgResource = registry_registry.pgResources["person_computed_inout"];
 const argDetailsSimple54 = [{
   graphqlArgName: "ino",
   postgresArgName: "ino",
@@ -12949,11 +12951,11 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_inout_outPgResource = registry.pgResources["person_computed_inout_out"];
+const resource_person_computed_inout_outPgResource = registry_registry.pgResources["person_computed_inout_out"];
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: personCodecSpec_personAttributes_email_codec_emailCodec,
   required: true,
   fetcher: null
 }];
@@ -13001,7 +13003,7 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_existsPgResource = registry.pgResources["person_exists"];
+const resource_person_existsPgResource = registry_registry.pgResources["person_exists"];
 const argDetailsSimple56 = [];
 const makeArgs56 = (args, path = []) => {
   const selectArgs = [];
@@ -13047,7 +13049,7 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
+const resource_person_computed_first_arg_inout_outPgResource = registry_registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -13105,7 +13107,7 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
+const resource_person_computed_complexPgResource = registry_registry.pgResources["person_computed_complex"];
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -13151,7 +13153,7 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
+const resource_person_first_postPgResource = registry_registry.pgResources["person_first_post"];
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -13197,7 +13199,7 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const resource_person_computed_first_arg_inoutPgResource = registry_registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -13243,7 +13245,7 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const resource_person_friendsPgResource = registry_registry.pgResources["person_friends"];
 const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13338,7 +13340,7 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const resource_person_type_function_connectionPgResource = registry_registry.pgResources["person_type_function_connection"];
 const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13439,7 +13441,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_type_functionPgResource = registry_registry.pgResources["person_type_function"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -13485,8 +13487,8 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_person_type_function_listPgResource = registry_registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry_registry.pgResources["frmcdc_wrappedUrl"];
 function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -13547,7 +13549,7 @@ function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
 function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_frmcdc_compoundTypePgResource = registry_registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -13593,7 +13595,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+const resource_compound_type_computed_fieldPgResource = registry_registry.pgResources["compound_type_computed_field"];
 function Interval_secondsPlan($r) {
   return access($r, ["seconds"]);
 }
@@ -13657,7 +13659,7 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const resource_post_computed_interval_setPgResource = registry_registry.pgResources["post_computed_interval_set"];
 const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13752,7 +13754,7 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const resource_post_computed_interval_arrayPgResource = registry_registry.pgResources["post_computed_interval_array"];
 const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
@@ -13798,7 +13800,7 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
+const resource_post_computed_text_arrayPgResource = registry_registry.pgResources["post_computed_text_array"];
 const argDetailsSimple68 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -13850,7 +13852,7 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const resource_post_computed_with_optional_argPgResource = registry_registry.pgResources["post_computed_with_optional_arg"];
 const argDetailsSimple69 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -13902,7 +13904,7 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const resource_post_computed_with_required_argPgResource = registry_registry.pgResources["post_computed_with_required_arg"];
 const argDetailsSimple70 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -13960,7 +13962,7 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const resource_post_headline_trimmedPgResource = registry_registry.pgResources["post_headline_trimmed"];
 const argDetailsSimple71 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -14018,7 +14020,7 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const resource_post_headline_trimmed_no_defaultsPgResource = registry_registry.pgResources["post_headline_trimmed_no_defaults"];
 const argDetailsSimple72 = [{
   graphqlArgName: "length",
   postgresArgName: "length",
@@ -14076,11 +14078,11 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_headline_trimmed_strictPgResource = registry_registry.pgResources["post_headline_trimmed_strict"];
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -14128,8 +14130,8 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
-const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
+const resource_post_computed_compound_type_arrayPgResource = registry_registry.pgResources["post_computed_compound_type_array"];
+const resource_frmcdc_comptypePgResource = registry_registry.pgResources["frmcdc_comptype"];
 function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
   $connection.setFirst(arg.getRaw());
 }
@@ -14171,7 +14173,7 @@ function TypesConnection_pageInfoPlan($connection) {
   // TYPES: why is this a TypeScript issue without the 'any'?
   return $connection.pageInfo();
 }
-const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+const resource_frmcdc_nestedCompoundTypePgResource = registry_registry.pgResources["frmcdc_nestedCompoundType"];
 function PeopleConnection_nodesPlan($connection) {
   return $connection.nodes();
 }
@@ -14517,7 +14519,7 @@ const makeArgs74 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const resource_edge_case_computedPgResource = registry_registry.pgResources["edge_case_computed"];
 function LeftArmsConnection_nodesPlan($connection) {
   return $connection.nodes();
 }
@@ -14583,7 +14585,7 @@ const makeArgs75 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const resource_mutation_outPgResource = registry_registry.pgResources["mutation_out"];
 function Mutation_mutationOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14632,7 +14634,7 @@ const makeArgs76 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const resource_mutation_out_setofPgResource = registry_registry.pgResources["mutation_out_setof"];
 function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14681,7 +14683,7 @@ const makeArgs77 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const resource_mutation_out_unnamedPgResource = registry_registry.pgResources["mutation_out_unnamed"];
 function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14730,7 +14732,7 @@ const makeArgs78 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const resource_no_args_mutationPgResource = registry_registry.pgResources["no_args_mutation"];
 function Mutation_noArgsMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14779,7 +14781,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_return_void_mutationPgResource = registry_registry.pgResources["return_void_mutation"];
 function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14828,7 +14830,7 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
+const resource_mutation_interval_setPgResource = registry_registry.pgResources["mutation_interval_set"];
 function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14883,7 +14885,7 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
+const resource_mutation_in_outPgResource = registry_registry.pgResources["mutation_in_out"];
 function Mutation_mutationInOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14938,7 +14940,7 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const resource_mutation_returns_table_one_colPgResource = registry_registry.pgResources["mutation_returns_table_one_col"];
 function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
   return $object;
 }
@@ -14993,7 +14995,7 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const resource_json_identity_mutationPgResource = registry_registry.pgResources["json_identity_mutation"];
 function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15048,7 +15050,7 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry_registry.pgResources["jsonb_identity_mutation"];
 function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15103,7 +15105,7 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry_registry.pgResources["jsonb_identity_mutation_plpgsql"];
 function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15158,7 +15160,7 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry_registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15219,7 +15221,7 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_add_1_mutationPgResource = registry_registry.pgResources["add_1_mutation"];
 function Mutation_add1Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15280,7 +15282,7 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_add_2_mutationPgResource = registry_registry.pgResources["add_2_mutation"];
 function Mutation_add2Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15341,7 +15343,7 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_add_3_mutationPgResource = registry_registry.pgResources["add_3_mutation"];
 function Mutation_add3Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15402,7 +15404,7 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_add_4_mutationPgResource = registry_registry.pgResources["add_4_mutation"];
 function Mutation_add4Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15463,7 +15465,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_add_4_mutation_errorPgResource = registry_registry.pgResources["add_4_mutation_error"];
 function Mutation_add4MutationError_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15524,7 +15526,7 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_mult_1PgResource = registry_registry.pgResources["mult_1"];
 function Mutation_mult1_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15585,7 +15587,7 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_mult_2PgResource = registry_registry.pgResources["mult_2"];
 function Mutation_mult2_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15646,7 +15648,7 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_mult_3PgResource = registry_registry.pgResources["mult_3"];
 function Mutation_mult3_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15707,7 +15709,7 @@ const makeArgs95 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_4PgResource = registry.pgResources["mult_4"];
+const resource_mult_4PgResource = registry_registry.pgResources["mult_4"];
 function Mutation_mult4_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15768,7 +15770,7 @@ const makeArgs96 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const resource_mutation_in_inoutPgResource = registry_registry.pgResources["mutation_in_inout"];
 function Mutation_mutationInInout_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15817,7 +15819,7 @@ const makeArgs97 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const resource_mutation_out_outPgResource = registry_registry.pgResources["mutation_out_out"];
 function Mutation_mutationOutOut_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15866,7 +15868,7 @@ const makeArgs98 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
+const resource_mutation_out_out_setofPgResource = registry_registry.pgResources["mutation_out_out_setof"];
 function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15915,7 +15917,7 @@ const makeArgs99 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_mutation_out_out_unnamedPgResource = registry_registry.pgResources["mutation_out_out_unnamed"];
 function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -15982,7 +15984,7 @@ const makeArgs100 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const resource_int_set_mutationPgResource = registry_registry.pgResources["int_set_mutation"];
 function Mutation_intSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16031,7 +16033,7 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry_registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16086,14 +16088,14 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
+const resource_mutation_returns_table_multi_colPgResource = registry_registry.pgResources["mutation_returns_table_multi_col"];
 function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: registry_pgCodecs_guid_guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16141,7 +16143,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_guid_fnPgResource = registry_registry.pgResources["guid_fn"];
 function Mutation_guidFn_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16190,7 +16192,7 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
+const resource_mutation_interval_arrayPgResource = registry_registry.pgResources["mutation_interval_array"];
 function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16239,14 +16241,14 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const resource_mutation_text_arrayPgResource = registry_registry.pgResources["mutation_text_array"];
 function Mutation_mutationTextArray_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: registry_pgCodecs_textArray_textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16306,7 +16308,7 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const resource_list_bde_mutationPgResource = registry_registry.pgResources["list_bde_mutation"];
 function Mutation_listBdeMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16355,7 +16357,7 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_authenticate_failPgResource = registry_registry.pgResources["authenticate_fail"];
 function Mutation_authenticateFail_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16422,14 +16424,14 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
+const resource_authenticatePgResource = registry_registry.pgResources["authenticate"];
 function Mutation_authenticate_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: registry_pgCodecs_leftArm_leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16477,7 +16479,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_left_arm_identityPgResource = registry_registry.pgResources["left_arm_identity"];
 function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16526,7 +16528,7 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const resource_issue756_mutationPgResource = registry_registry.pgResources["issue756_mutation"];
 function Mutation_issue756Mutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16575,7 +16577,7 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const resource_issue756_set_mutationPgResource = registry_registry.pgResources["issue756_set_mutation"];
 function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16642,7 +16644,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_manyPgResource = registry_registry.pgResources["authenticate_many"];
 function Mutation_authenticateMany_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16709,7 +16711,7 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticate_payloadPgResource = registry_registry.pgResources["authenticate_payload"];
 function Mutation_authenticatePayload_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16734,7 +16736,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: registry_pgCodecs_int4Array_int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16746,7 +16748,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: registry_pgCodecs_floatrange_floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16794,7 +16796,7 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_types_mutationPgResource = registry_registry.pgResources["types_mutation"];
 function Mutation_typesMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -16849,14 +16851,14 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_out_out_compound_typePgResource = registry_registry.pgResources["mutation_out_out_compound_type"];
 function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16904,14 +16906,14 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_compound_type_mutationPgResource = registry_registry.pgResources["compound_type_mutation"];
 function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16959,7 +16961,7 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_compound_type_set_mutationPgResource = registry_registry.pgResources["compound_type_set_mutation"];
 function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17014,14 +17016,14 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_table_mutationPgResource = registry_registry.pgResources["table_mutation"];
 function Mutation_tableMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: attributes_post_codec_postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17075,14 +17077,14 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_post_with_suffixPgResource = registry_registry.pgResources["post_with_suffix"];
 function Mutation_postWithSuffix_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17130,14 +17132,14 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_compound_type_arrayPgResource = registry_registry.pgResources["mutation_compound_type_array"];
 function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: attributes_o2_codec_compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17185,14 +17187,14 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_array_mutationPgResource = registry_registry.pgResources["compound_type_array_mutation"];
 function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
   return $object;
 }
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: registry_pgCodecs_postArray_postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -17240,7 +17242,7 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_post_manyPgResource = registry_registry.pgResources["post_many"];
 function Mutation_postMany_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17301,7 +17303,7 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_mutation_out_complexPgResource = registry_registry.pgResources["mutation_out_complex"];
 function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17362,7 +17364,7 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const resource_mutation_out_complex_setofPgResource = registry_registry.pgResources["mutation_out_complex_setof"];
 function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17411,7 +17413,7 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const resource_mutation_out_tablePgResource = registry_registry.pgResources["mutation_out_table"];
 function Mutation_mutationOutTable_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17460,7 +17462,7 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const resource_mutation_out_table_setofPgResource = registry_registry.pgResources["mutation_out_table_setof"];
 function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17509,7 +17511,7 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const resource_table_set_mutationPgResource = registry_registry.pgResources["table_set_mutation"];
 function Mutation_tableSetMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17558,7 +17560,7 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_type_function_connection_mutationPgResource = registry_registry.pgResources["type_function_connection_mutation"];
 function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17613,7 +17615,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_type_function_mutationPgResource = registry_registry.pgResources["type_function_mutation"];
 function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -17662,7 +17664,7 @@ const makeArgs130 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
+const resource_type_function_list_mutationPgResource = registry_registry.pgResources["type_function_list_mutation"];
 function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
   return $object;
 }
@@ -18461,7 +18463,7 @@ function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
 function AuthenticatePayloadPayload_queryPlan() {
   return rootValue();
 }
-const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
+const resource_frmcdc_jwtTokenPgResource = registry_registry.pgResources["frmcdc_jwtToken"];
 function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
   $input.set("clientMutationId", val.get());
 }
@@ -33833,7 +33835,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = registry_pgCodecs_types_typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33849,7 +33851,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = registry_pgCodecs_types_typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35137,7 +35139,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35160,7 +35162,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35183,7 +35185,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35206,7 +35208,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35229,7 +35231,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35252,7 +35254,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35275,7 +35277,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35298,7 +35300,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35321,7 +35323,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35344,7 +35346,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35367,7 +35369,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35390,7 +35392,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35413,7 +35415,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35436,7 +35438,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35459,7 +35461,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35482,7 +35484,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35505,7 +35507,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35528,7 +35530,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35551,7 +35553,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35574,7 +35576,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35597,7 +35599,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35620,7 +35622,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35643,7 +35645,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35666,7 +35668,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35689,7 +35691,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35712,7 +35714,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35735,7 +35737,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35758,7 +35760,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35781,7 +35783,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35804,7 +35806,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35827,7 +35829,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35850,7 +35852,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35873,7 +35875,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35896,7 +35898,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35919,7 +35921,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35942,7 +35944,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35965,7 +35967,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35988,7 +35990,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36011,7 +36013,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36034,7 +36036,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36057,7 +36059,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36080,7 +36082,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36103,7 +36105,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36126,7 +36128,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36149,7 +36151,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36172,7 +36174,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36195,7 +36197,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesCodecSpec_typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36340,7 +36342,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = attributes_person_codec_personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36356,7 +36358,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = attributes_person_codec_personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36771,7 +36773,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = attributes_post_codec_postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36787,7 +36789,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = attributes_post_codec_postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36953,7 +36955,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.id.codec)}`;
             }
           });
         }
@@ -36976,7 +36978,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.headline.codec)}`;
             }
           });
         }
@@ -36999,7 +37001,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.body.codec)}`;
             }
           });
         }
@@ -37022,7 +37024,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37045,7 +37047,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37068,7 +37070,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postCodecSpec_postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37272,7 +37274,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37295,7 +37297,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37318,7 +37320,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyCodecSpec_foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37394,7 +37396,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = registry_pgCodecs_compoundKey_compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37410,7 +37412,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = registry_pgCodecs_compoundKey_compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37542,7 +37544,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37565,7 +37567,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37588,7 +37590,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyCodecSpec_compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38026,7 +38028,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.id.codec)}`;
             }
           });
         }
@@ -38049,7 +38051,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38072,7 +38074,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38095,7 +38097,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.about.codec)}`;
             }
           });
         }
@@ -38118,7 +38120,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.email.codec)}`;
             }
           });
         }
@@ -38141,7 +38143,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.site.codec)}`;
             }
           });
         }
@@ -38164,7 +38166,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.config.codec)}`;
             }
           });
         }
@@ -38187,7 +38189,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38210,7 +38212,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38233,7 +38235,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38256,7 +38258,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personCodecSpec_personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38368,7 +38370,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewCodecSpec_nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38402,7 +38404,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = registry_pgCodecs_inputs_inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38418,7 +38420,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = registry_pgCodecs_inputs_inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38482,7 +38484,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsCodecSpec_inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38516,7 +38518,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = registry_pgCodecs_patchs_patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38532,7 +38534,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = registry_pgCodecs_patchs_patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38596,7 +38598,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsCodecSpec_patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38630,7 +38632,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = registry_pgCodecs_reserved_reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38646,7 +38648,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = registry_pgCodecs_reserved_reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38710,7 +38712,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedCodecSpec_reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38744,7 +38746,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = registry_pgCodecs_reservedPatchs_reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38760,7 +38762,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = registry_pgCodecs_reservedPatchs_reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38824,7 +38826,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsCodecSpec_reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38858,7 +38860,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = registry_pgCodecs_reservedInput_reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38874,7 +38876,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = registry_pgCodecs_reservedInput_reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38938,7 +38940,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputCodecSpec_reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38972,7 +38974,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = registry_pgCodecs_defaultValue_defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38988,7 +38990,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = registry_pgCodecs_defaultValue_defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39086,7 +39088,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueCodecSpec_defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39109,7 +39111,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueCodecSpec_defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39225,7 +39227,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyCodecSpec_noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39248,7 +39250,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyCodecSpec_noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39410,7 +39412,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39433,7 +39435,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39456,7 +39458,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewCodecSpec_testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39490,7 +39492,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = registry_pgCodecs_myTable_myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39506,7 +39508,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = registry_pgCodecs_myTable_myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39604,7 +39606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableCodecSpec_myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39627,7 +39629,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableCodecSpec_myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39661,7 +39663,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = registry_pgCodecs_personSecret_personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39677,7 +39679,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = registry_pgCodecs_personSecret_personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39775,7 +39777,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretCodecSpec_personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39798,7 +39800,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretCodecSpec_personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39832,7 +39834,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = registry_pgCodecs_viewTable_viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39848,7 +39850,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = registry_pgCodecs_viewTable_viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39980,7 +39982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40003,7 +40005,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40026,7 +40028,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableCodecSpec_viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40060,7 +40062,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = registry_pgCodecs_similarTable1_similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40076,7 +40078,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = registry_pgCodecs_similarTable1_similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40242,7 +40244,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40265,7 +40267,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40288,7 +40290,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40311,7 +40313,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1CodecSpec_similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40345,7 +40347,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = registry_pgCodecs_similarTable2_similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40361,7 +40363,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = registry_pgCodecs_similarTable2_similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40527,7 +40529,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40550,7 +40552,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40573,7 +40575,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40596,7 +40598,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2CodecSpec_similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40795,7 +40797,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40818,7 +40820,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40841,7 +40843,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40864,7 +40866,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewCodecSpec_updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40898,7 +40900,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = registry_pgCodecs_nullTestRecord_nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40914,7 +40916,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = registry_pgCodecs_nullTestRecord_nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41080,7 +41082,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41103,7 +41105,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41126,7 +41128,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41149,7 +41151,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordCodecSpec_nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41345,7 +41347,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41368,7 +41370,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41391,7 +41393,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseCodecSpec_edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41425,7 +41427,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = registry_pgCodecs_leftArm_leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41441,7 +41443,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = registry_pgCodecs_leftArm_leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41607,7 +41609,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41630,7 +41632,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41653,7 +41655,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41676,7 +41678,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmCodecSpec_leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41710,7 +41712,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = registry_pgCodecs_issue756_issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41726,7 +41728,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = registry_pgCodecs_issue756_issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41824,7 +41826,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756CodecSpec_issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41847,7 +41849,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756CodecSpec_issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const fileAttributes = Object.assign(Object.create(null), {
@@ -85,10 +78,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const fileIdentifier = sql.identifier(...["inheritence", "file"]);
-const fileCodecSpec = {
+const fileCodec = recordCodec({
   name: "file",
-  identifier: fileIdentifier,
+  identifier: sql.identifier("inheritence", "file"),
   attributes: fileAttributes,
   description: undefined,
   extensions: {
@@ -101,8 +93,7 @@ const fileCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const fileCodec = recordCodec(fileCodecSpec);
+});
 const userAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -123,26 +114,22 @@ const userAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "inheritence",
-    name: "user"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["inheritence", "user"];
-const userIdentifier = sql.identifier(...parts2);
-const userCodecSpec = {
+const userCodec = recordCodec({
   name: "user",
-  identifier: userIdentifier,
+  identifier: sql.identifier("inheritence", "user"),
   attributes: userAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "inheritence",
+      name: "user"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const userCodec = recordCodec(userCodecSpec);
+});
 const userFileAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -172,35 +159,22 @@ const userFileAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "inheritence",
-    name: "user_file"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["inheritence", "user_file"];
-const userFileIdentifier = sql.identifier(...parts3);
-const userFileCodecSpec = {
+const userFileCodec = recordCodec({
   name: "userFile",
-  identifier: userFileIdentifier,
+  identifier: sql.identifier("inheritence", "user_file"),
   attributes: userFileAttributes,
   description: undefined,
-  extensions: extensions3,
-  executor: executor_mainPgExecutor
-};
-const userFileCodec = recordCodec(userFileCodecSpec);
-const extensions4 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "inheritence",
-    name: "file"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "inheritence",
+      name: "user_file"
+    },
+    tags: Object.create(null)
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -209,15 +183,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions5 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "inheritence",
-    name: "user"
-  },
-  tags: {}
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -235,16 +200,15 @@ const registryConfig_pgResources_user_user = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions5
-};
-const extensions6 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "inheritence",
-    name: "user_file"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "inheritence",
+      name: "user"
+    },
+    tags: {}
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -263,7 +227,15 @@ const registryConfig_pgResources_user_file_user_file = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions6
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "inheritence",
+      name: "user_file"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -285,7 +257,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions4
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "inheritence",
+          name: "file"
+        },
+        tags: {}
+      }
     },
     user: registryConfig_pgResources_user_user,
     user_file: registryConfig_pgResources_user_file_user_file
@@ -432,21 +412,6 @@ const fetcher3 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.UserFile);
-function Query_allFiles_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFiles_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFiles_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFiles_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFiles_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -465,318 +430,30 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allUsers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUsers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUsers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUsers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUsers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allUserFiles_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUserFiles_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUserFiles_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUserFiles_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUserFiles_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function User_userFilesByUserId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function User_userFilesByUserId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function User_userFilesByUserId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function User_userFilesByUserId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function User_userFilesByUserId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function UserFilesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UserFilesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UserFilesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function FilesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UsersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UsersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UsersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createFile_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUserFile_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.File, $nodeId);
 };
-function Mutation_updateFile_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFileById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.User, $nodeId);
 };
-function Mutation_updateUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateUserById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.UserFile, $nodeId);
 };
-function Mutation_updateUserFile_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateUserFileById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.File, $nodeId);
 };
-function Mutation_deleteFile_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFileById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.User, $nodeId);
 };
-function Mutation_deleteUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteUserById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.UserFile, $nodeId);
 };
-function Mutation_deleteUserFile_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteUserFileById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilePayload_filePlan($object) {
-  return $object.get("result");
-}
-function CreateFilePayload_queryPlan() {
-  return rootValue();
-}
-function CreateFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFileInput_file_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function CreateUserPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUserInput_user_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUserFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUserFilePayload_userFilePlan($object) {
-  return $object.get("result");
-}
-function CreateUserFilePayload_queryPlan() {
-  return rootValue();
-}
-function CreateUserFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUserFileInput_userFile_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilePayload_filePlan($object) {
-  return $object.get("result");
-}
-function UpdateFilePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFileInput_filePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFileByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFileByIdInput_filePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function UpdateUserPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserInput_userPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserByIdInput_userPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateUserFilePayload_userFilePlan($object) {
-  return $object.get("result");
-}
-function UpdateUserFilePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateUserFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserFileInput_userFilePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserFileByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserFileByIdInput_userFilePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilePayload_filePlan($object) {
-  return $object.get("result");
-}
-function DeleteFilePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFileByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function DeleteUserPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUserByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUserFilePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteUserFilePayload_userFilePlan($object) {
-  return $object.get("result");
-}
-function DeleteUserFilePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteUserFileInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUserFileByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -1745,7 +1422,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -1822,23 +1501,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFiles_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFiles_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFiles_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFiles_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFiles_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1865,23 +1554,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1908,23 +1607,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUserFiles_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUserFiles_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUserFiles_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUserFiles_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUserFiles_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1980,23 +1689,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_userFilesByUserId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_userFilesByUserId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_userFilesByUserId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_userFilesByUserId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_userFilesByUserId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2019,9 +1738,16 @@ export const plans = {
   },
   UserFilesConnection: {
     __assertStep: ConnectionStep,
-    nodes: UserFilesConnection_nodesPlan,
-    edges: UserFilesConnection_edgesPlan,
-    pageInfo: UserFilesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -2058,8 +1784,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -2279,9 +2009,16 @@ export const plans = {
   },
   FilesConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilesConnection_nodesPlan,
-    edges: FilesConnection_edgesPlan,
-    pageInfo: FilesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -2450,9 +2187,16 @@ export const plans = {
   },
   UsersConnection: {
     __assertStep: ConnectionStep,
-    nodes: UsersConnection_nodesPlan,
-    edges: UsersConnection_edgesPlan,
-    pageInfo: UsersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -2632,7 +2376,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2647,7 +2393,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2662,7 +2410,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUserFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2676,7 +2426,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2692,7 +2444,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFileById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2706,7 +2460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2722,7 +2478,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUserById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2736,7 +2494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUserFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2752,7 +2512,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUserFileById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2766,7 +2528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2782,7 +2546,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFileById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2796,7 +2562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2812,7 +2580,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUserById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2826,7 +2596,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUserFile_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2842,16 +2614,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUserFileById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateFilePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilePayload_clientMutationIdPlan,
-    file: CreateFilePayload_filePlan,
-    query: CreateFilePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    file($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     fileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2886,11 +2666,16 @@ export const plans = {
   },
   CreateFileInput: {
     clientMutationId: {
-      applyPlan: CreateFileInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     file: {
-      applyPlan: CreateFileInput_file_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2912,9 +2697,15 @@ export const plans = {
   },
   CreateUserPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUserPayload_clientMutationIdPlan,
-    user: CreateUserPayload_userPlan,
-    query: CreateUserPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2949,11 +2740,16 @@ export const plans = {
   },
   CreateUserInput: {
     clientMutationId: {
-      applyPlan: CreateUserInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     user: {
-      applyPlan: CreateUserInput_user_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2975,9 +2771,15 @@ export const plans = {
   },
   CreateUserFilePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUserFilePayload_clientMutationIdPlan,
-    userFile: CreateUserFilePayload_userFilePlan,
-    query: CreateUserFilePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    userFile($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userFileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3017,11 +2819,16 @@ export const plans = {
   },
   CreateUserFileInput: {
     clientMutationId: {
-      applyPlan: CreateUserFileInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     userFile: {
-      applyPlan: CreateUserFileInput_userFile_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -3050,9 +2857,15 @@ export const plans = {
   },
   UpdateFilePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilePayload_clientMutationIdPlan,
-    file: UpdateFilePayload_filePlan,
-    query: UpdateFilePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    file($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     fileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3087,11 +2900,16 @@ export const plans = {
   },
   UpdateFileInput: {
     clientMutationId: {
-      applyPlan: UpdateFileInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filePatch: {
-      applyPlan: UpdateFileInput_filePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilePatch: {
@@ -3112,18 +2930,29 @@ export const plans = {
   },
   UpdateFileByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateFileByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     filePatch: {
-      applyPlan: UpdateFileByIdInput_filePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateUserPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateUserPayload_clientMutationIdPlan,
-    user: UpdateUserPayload_userPlan,
-    query: UpdateUserPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3158,11 +2987,16 @@ export const plans = {
   },
   UpdateUserInput: {
     clientMutationId: {
-      applyPlan: UpdateUserInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     userPatch: {
-      applyPlan: UpdateUserInput_userPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UserPatch: {
@@ -3183,18 +3017,29 @@ export const plans = {
   },
   UpdateUserByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateUserByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     userPatch: {
-      applyPlan: UpdateUserByIdInput_userPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateUserFilePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateUserFilePayload_clientMutationIdPlan,
-    userFile: UpdateUserFilePayload_userFilePlan,
-    query: UpdateUserFilePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    userFile($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userFileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3234,11 +3079,16 @@ export const plans = {
   },
   UpdateUserFileInput: {
     clientMutationId: {
-      applyPlan: UpdateUserFileInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     userFilePatch: {
-      applyPlan: UpdateUserFileInput_userFilePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UserFilePatch: {
@@ -3266,23 +3116,34 @@ export const plans = {
   },
   UpdateUserFileByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateUserFileByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     userFilePatch: {
-      applyPlan: UpdateUserFileByIdInput_userFilePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilePayload_clientMutationIdPlan,
-    file: DeleteFilePayload_filePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    file($object) {
+      return $object.get("result");
+    },
     deletedFileId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.File.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     fileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3317,26 +3178,36 @@ export const plans = {
   },
   DeleteFileInput: {
     clientMutationId: {
-      applyPlan: DeleteFileInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFileByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteFileByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteUserPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteUserPayload_clientMutationIdPlan,
-    user: DeleteUserPayload_userPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
     deletedUserId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.User.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteUserPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3371,26 +3242,36 @@ export const plans = {
   },
   DeleteUserInput: {
     clientMutationId: {
-      applyPlan: DeleteUserInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteUserByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteUserByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteUserFilePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteUserFilePayload_clientMutationIdPlan,
-    userFile: DeleteUserFilePayload_userFilePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    userFile($object) {
+      return $object.get("result");
+    },
     deletedUserFileId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.UserFile.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteUserFilePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     userFileEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3430,13 +3311,17 @@ export const plans = {
   },
   DeleteUserFileInput: {
     clientMutationId: {
-      applyPlan: DeleteUserFileInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteUserFileByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteUserFileByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const fileAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -85,10 +85,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_file = {
+const fileIdentifier = sql.identifier(...["inheritence", "file"]);
+const fileCodecSpec = {
   name: "file",
-  identifier: sql.identifier(...["inheritence", "file"]),
-  attributes,
+  identifier: fileIdentifier,
+  attributes: fileAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -101,8 +102,8 @@ const spec_file = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_file_file = recordCodec(spec_file);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const fileCodec = recordCodec(fileCodecSpec);
+const userAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -132,17 +133,17 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["inheritence", "user"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_user = {
+const userIdentifier = sql.identifier(...parts2);
+const userCodecSpec = {
   name: "user",
-  identifier: sqlIdent2,
-  attributes: attributes_object_Object_,
+  identifier: userIdentifier,
+  attributes: userAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_user_user = recordCodec(spec_user);
-const attributes2 = Object.assign(Object.create(null), {
+const userCodec = recordCodec(userCodecSpec);
+const userFileAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -181,16 +182,16 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["inheritence", "user_file"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_userFile = {
+const userFileIdentifier = sql.identifier(...parts3);
+const userFileCodecSpec = {
   name: "userFile",
-  identifier: sqlIdent3,
-  attributes: attributes2,
+  identifier: userFileIdentifier,
+  attributes: userFileAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_userFile_userFile = recordCodec(spec_userFile);
+const userFileCodec = recordCodec(userFileCodecSpec);
 const extensions4 = {
   description: undefined,
   pg: {
@@ -229,8 +230,8 @@ const registryConfig_pgResources_user_user = {
   executor: executor_mainPgExecutor,
   name: "user",
   identifier: "main.inheritence.user",
-  from: registryConfig_pgCodecs_user_user.sqlType,
-  codec: registryConfig_pgCodecs_user_user,
+  from: userCodec.sqlType,
+  codec: userCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -257,8 +258,8 @@ const registryConfig_pgResources_user_file_user_file = {
   executor: executor_mainPgExecutor,
   name: "user_file",
   identifier: "main.inheritence.user_file",
-  from: registryConfig_pgCodecs_userFile_userFile.sqlType,
-  codec: registryConfig_pgCodecs_userFile_userFile,
+  from: userFileCodec.sqlType,
+  codec: userFileCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -270,17 +271,17 @@ const registry = makeRegistry({
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
-    file: registryConfig_pgCodecs_file_file,
-    user: registryConfig_pgCodecs_user_user,
-    userFile: registryConfig_pgCodecs_userFile_userFile
+    file: fileCodec,
+    user: userCodec,
+    userFile: userFileCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     file: {
       executor: executor_mainPgExecutor,
       name: "file",
       identifier: "main.inheritence.file",
-      from: registryConfig_pgCodecs_file_file.sqlType,
-      codec: registryConfig_pgCodecs_file_file,
+      from: fileCodec.sqlType,
+      codec: fileCodec,
       uniques,
       isVirtual: false,
       description: undefined,
@@ -292,7 +293,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     user: Object.assign(Object.create(null), {
       userFilesByTheirUserId: {
-        localCodec: registryConfig_pgCodecs_user_user,
+        localCodec: userCodec,
         remoteResourceOptions: registryConfig_pgResources_user_file_user_file,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -309,7 +310,7 @@ const registry = makeRegistry({
     }),
     userFile: Object.assign(Object.create(null), {
       userByMyUserId: {
-        localCodec: registryConfig_pgCodecs_userFile_userFile,
+        localCodec: userFileCodec,
         remoteResourceOptions: registryConfig_pgResources_user_user,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["user_id"],
@@ -2073,7 +2074,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_userFile_userFile.attributes[attributeName];
+          const attribute = userFileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2089,7 +2090,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_userFile_userFile.attributes[attributeName];
+          const attribute = userFileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2221,7 +2222,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), userFileAttributes.id.codec)}`;
             }
           });
         }
@@ -2244,7 +2245,7 @@ export const plans = {
             type: "attribute",
             attribute: "filename",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.filename.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), userFileAttributes.filename.codec)}`;
             }
           });
         }
@@ -2267,7 +2268,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.user_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), userFileAttributes.user_id.codec)}`;
             }
           });
         }
@@ -2301,7 +2302,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_file_file.attributes[attributeName];
+          const attribute = fileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2317,7 +2318,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_file_file.attributes[attributeName];
+          const attribute = fileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2415,7 +2416,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), fileAttributes.id.codec)}`;
             }
           });
         }
@@ -2438,7 +2439,7 @@ export const plans = {
             type: "attribute",
             attribute: "filename",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.filename.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), fileAttributes.filename.codec)}`;
             }
           });
         }
@@ -2472,7 +2473,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_user_user.attributes[attributeName];
+          const attribute = userCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2488,7 +2489,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_user_user.attributes[attributeName];
+          const attribute = userCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2586,7 +2587,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), userAttributes.id.codec)}`;
             }
           });
         }
@@ -2609,7 +2610,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), userAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -68,7 +68,7 @@ const fileAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -92,7 +92,7 @@ const fileCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const userAttributes = Object.assign(Object.create(null), {
   id: {
@@ -128,7 +128,7 @@ const userCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const userFileAttributes = Object.assign(Object.create(null), {
   id: {
@@ -173,9 +173,9 @@ const userFileCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const fileUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -183,7 +183,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const userUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -192,12 +192,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_user_user = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "user",
   identifier: "main.inheritence.user",
   from: userCodec.sqlType,
   codec: userCodec,
-  uniques: uniques2,
+  uniques: userUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -210,21 +210,21 @@ const registryConfig_pgResources_user_user = {
     tags: {}
   }
 };
-const uniques3 = [{
+const user_fileUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
   extensions: {
-    tags: uniques[0].extensions.tags
+    tags: fileUniques[0].extensions.tags
   }
 }];
 const registryConfig_pgResources_user_file_user_file = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "user_file",
   identifier: "main.inheritence.user_file",
   from: userFileCodec.sqlType,
   codec: userFileCodec,
-  uniques: uniques3,
+  uniques: user_fileUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -249,12 +249,12 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     file: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "file",
       identifier: "main.inheritence.file",
       from: fileCodec.sqlType,
       codec: fileCodec,
-      uniques,
+      uniques: fileUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -1803,7 +1803,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        user_fileUniques[0].attributes.forEach(attributeName => {
           const attribute = userFileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1819,7 +1819,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        user_fileUniques[0].attributes.forEach(attributeName => {
           const attribute = userFileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2038,7 +2038,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        fileUniques[0].attributes.forEach(attributeName => {
           const attribute = fileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2054,7 +2054,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        fileUniques[0].attributes.forEach(attributeName => {
           const attribute = fileCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2216,7 +2216,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        userUniques[0].attributes.forEach(attributeName => {
           const attribute = userCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2232,7 +2232,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        userUniques[0].attributes.forEach(attributeName => {
           const attribute = userCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2642,7 +2642,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2716,7 +2716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = userUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2790,7 +2790,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = user_fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2876,7 +2876,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2963,7 +2963,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = userUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3050,7 +3050,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = user_fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3154,7 +3154,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3218,7 +3218,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = userUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3282,7 +3282,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = user_fileUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const extensions2 = {
+const workhoursArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "nested_arrays",
@@ -63,7 +63,7 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const extensions3 = {
+const extensions2 = {
   pg: {
     serviceName: "main",
     schemaName: "nested_arrays",
@@ -71,7 +71,7 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const extensions4 = {
+const workHourArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "nested_arrays",
@@ -79,7 +79,7 @@ const extensions4 = {
   },
   tags: Object.create(null)
 };
-const extensions5 = {
+const extensions3 = {
   pg: {
     serviceName: "main",
     schemaName: "nested_arrays",
@@ -87,7 +87,7 @@ const extensions5 = {
   },
   tags: Object.create(null)
 };
-const attributes2 = Object.assign(Object.create(null), {
+const workHourPartsAttributes = Object.assign(Object.create(null), {
   from_hours: {
     description: undefined,
     codec: TYPES.int2,
@@ -135,7 +135,7 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const extensions6 = {
+const extensions4 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -144,44 +144,45 @@ const extensions6 = {
   },
   tags: Object.create(null)
 };
-const spec_workHourParts = {
+const workHourPartsIdentifier = sql.identifier(...["nested_arrays", "work_hour_parts"]);
+const workHourPartsCodecSpec = {
   name: "workHourParts",
-  identifier: sql.identifier(...["nested_arrays", "work_hour_parts"]),
-  attributes: attributes2,
+  identifier: workHourPartsIdentifier,
+  attributes: workHourPartsAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const innerCodec_workHourParts = recordCodec(spec_workHourParts);
+const workHourPartsCodec = recordCodec(workHourPartsCodecSpec);
 const parts2 = ["nested_arrays", "work_hour"];
-const sqlIdent2 = sql.identifier(...parts2);
-const innerCodec_workHour = domainOfCodec(innerCodec_workHourParts, "workHour", sqlIdent2, {
+const workHourIdentifier = sql.identifier(...parts2);
+const workHourCodec = domainOfCodec(workHourPartsCodec, "workHour", workHourIdentifier, {
   description: undefined,
-  extensions: extensions5,
+  extensions: extensions3,
   notNull: true
 });
-const innerCodec_workHourArray = listOfCodec(innerCodec_workHour, {
-  extensions: extensions4,
+const workHourArrayCodec = listOfCodec(workHourCodec, {
+  extensions: workHourArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "workHourArray"
 });
 const parts3 = ["nested_arrays", "workhours"];
-const sqlIdent3 = sql.identifier(...parts3);
-const innerCodec_workhours = domainOfCodec(innerCodec_workHourArray, "workhours", sqlIdent3, {
+const workhoursIdentifier = sql.identifier(...parts3);
+const workhoursCodec = domainOfCodec(workHourArrayCodec, "workhours", workhoursIdentifier, {
   description: undefined,
-  extensions: extensions3,
+  extensions: extensions2,
   notNull: true
 });
-const innerCodec_workhoursArray = listOfCodec(innerCodec_workhours, {
-  extensions: extensions2,
+const workhoursArrayCodec = listOfCodec(workhoursCodec, {
+  extensions: workhoursArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "workhoursArray"
 });
 const parts4 = ["nested_arrays", "working_hours"];
-const sqlIdent4 = sql.identifier(...parts4);
-const attributes_v_codec_workingHours = domainOfCodec(innerCodec_workhoursArray, "workingHours", sqlIdent4, {
+const workingHoursIdentifier = sql.identifier(...parts4);
+const workingHoursCodec = domainOfCodec(workhoursArrayCodec, "workingHours", workingHoursIdentifier, {
   description: "Mo, Tu, We, Th, Fr, Sa, Su, Ho",
   extensions: {
     pg: {
@@ -193,7 +194,7 @@ const attributes_v_codec_workingHours = domainOfCodec(innerCodec_workhoursArray,
   },
   notNull: false
 });
-const attributes = Object.assign(Object.create(null), {
+const tAttributes = Object.assign(Object.create(null), {
   k: {
     description: undefined,
     codec: TYPES.int,
@@ -205,7 +206,7 @@ const attributes = Object.assign(Object.create(null), {
   },
   v: {
     description: undefined,
-    codec: attributes_v_codec_workingHours,
+    codec: workingHoursCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -213,7 +214,7 @@ const attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
+const extensions5 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -223,17 +224,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts5 = ["nested_arrays", "t"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_t = {
+const tIdentifier = sql.identifier(...parts5);
+const tCodecSpec = {
   name: "t",
-  identifier: sqlIdent5,
-  attributes,
+  identifier: tIdentifier,
+  attributes: tAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_t_t = recordCodec(spec_t);
-const extensions8 = {
+const tCodec = recordCodec(tCodecSpec);
+const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "nested_arrays",
@@ -244,8 +245,8 @@ const extensions8 = {
   }
 };
 const parts6 = ["nested_arrays", "check_work_hours"];
-const sqlIdent6 = sql.identifier(...parts6);
-const extensions9 = {
+const sqlIdent = sql.identifier(...parts6);
+const extensions7 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -265,18 +266,18 @@ const uniques = [{
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     bool: TYPES.boolean,
-    t: registryConfig_pgCodecs_t_t,
+    t: tCodec,
     int4: TYPES.int,
-    workingHours: attributes_v_codec_workingHours,
-    workhours: innerCodec_workhours,
-    workHour: innerCodec_workHour,
-    workHourParts: innerCodec_workHourParts,
+    workingHours: workingHoursCodec,
+    workhours: workhoursCodec,
+    workHour: workHourCodec,
+    workHourParts: workHourPartsCodec,
     int2: TYPES.int2,
     text: TYPES.text,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    workHourArray: innerCodec_workHourArray,
-    workhoursArray: innerCodec_workhoursArray
+    workHourArray: workHourArrayCodec,
+    workhoursArray: workhoursArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     check_work_hours: {
@@ -284,31 +285,31 @@ const registry = makeRegistry({
       name: "check_work_hours",
       identifier: "main.nested_arrays.check_work_hours(nested_arrays._work_hour)",
       from(...args) {
-        return sql`${sqlIdent6}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "wh",
         required: true,
         notNull: true,
-        codec: innerCodec_workHourArray
+        codec: workHourArrayCodec
       }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions8,
+      extensions: extensions6,
       description: undefined
     },
     t: {
       executor: executor_mainPgExecutor,
       name: "t",
       identifier: "main.nested_arrays.t",
-      from: registryConfig_pgCodecs_t_t.sqlType,
-      codec: registryConfig_pgCodecs_t_t,
+      from: tCodec.sqlType,
+      codec: tCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions9
+      extensions: extensions7
     }
   }),
   pgRelations: Object.create(null)
@@ -339,7 +340,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
 const argDetailsSimple = [{
   graphqlArgName: "wh",
   postgresArgName: "wh",
-  pgCodec: innerCodec_workHourArray,
+  pgCodec: workHourArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -1077,7 +1078,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_t_t.attributes[attributeName];
+          const attribute = tCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1093,7 +1094,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_t_t.attributes[attributeName];
+          const attribute = tCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1157,7 +1158,7 @@ export const plans = {
             type: "attribute",
             attribute: "k",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.k.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tAttributes.k.codec)}`;
             }
           });
         }
@@ -1180,7 +1181,7 @@ export const plans = {
             type: "attribute",
             attribute: "v",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.v.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tAttributes.v.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, each, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,99 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const workhoursArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "_workhours"
-  },
-  tags: Object.create(null)
-};
-const extensions2 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "workhours"
-  },
-  tags: Object.create(null)
-};
-const workHourArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "_work_hour"
-  },
-  tags: Object.create(null)
-};
-const extensions3 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "work_hour"
-  },
-  tags: Object.create(null)
-};
-const workHourPartsAttributes = Object.assign(Object.create(null), {
-  from_hours: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  from_minutes: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  to_hours: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  to_minutes: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -135,54 +58,110 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const extensions4 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "work_hour_parts"
-  },
-  tags: Object.create(null)
-};
-const workHourPartsIdentifier = sql.identifier(...["nested_arrays", "work_hour_parts"]);
-const workHourPartsCodecSpec = {
+const workHourPartsCodec = recordCodec({
   name: "workHourParts",
-  identifier: workHourPartsIdentifier,
-  attributes: workHourPartsAttributes,
+  identifier: sql.identifier("nested_arrays", "work_hour_parts"),
+  attributes: Object.assign(Object.create(null), {
+    from_hours: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    from_minutes: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    to_hours: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    to_minutes: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "work_hour_parts"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const workHourPartsCodec = recordCodec(workHourPartsCodecSpec);
-const parts2 = ["nested_arrays", "work_hour"];
-const workHourIdentifier = sql.identifier(...parts2);
-const workHourCodec = domainOfCodec(workHourPartsCodec, "workHour", workHourIdentifier, {
+});
+const workHourCodec = domainOfCodec(workHourPartsCodec, "workHour", sql.identifier("nested_arrays", "work_hour"), {
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "work_hour"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const workHourArrayCodec = listOfCodec(workHourCodec, {
-  extensions: workHourArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "_work_hour"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "workHourArray"
 });
-const parts3 = ["nested_arrays", "workhours"];
-const workhoursIdentifier = sql.identifier(...parts3);
-const workhoursCodec = domainOfCodec(workHourArrayCodec, "workhours", workhoursIdentifier, {
+const workhoursCodec = domainOfCodec(workHourArrayCodec, "workhours", sql.identifier("nested_arrays", "workhours"), {
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "workhours"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const workhoursArrayCodec = listOfCodec(workhoursCodec, {
-  extensions: workhoursArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "_workhours"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "workhoursArray"
 });
-const parts4 = ["nested_arrays", "working_hours"];
-const workingHoursIdentifier = sql.identifier(...parts4);
-const workingHoursCodec = domainOfCodec(workhoursArrayCodec, "workingHours", workingHoursIdentifier, {
+const workingHoursCodec = domainOfCodec(workhoursArrayCodec, "workingHours", sql.identifier("nested_arrays", "working_hours"), {
   description: "Mo, Tu, We, Th, Fr, Sa, Su, Ho",
   extensions: {
     pg: {
@@ -214,47 +193,23 @@ const tAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "t"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["nested_arrays", "t"];
-const tIdentifier = sql.identifier(...parts5);
-const tCodecSpec = {
+const tCodec = recordCodec({
   name: "t",
-  identifier: tIdentifier,
+  identifier: sql.identifier("nested_arrays", "t"),
   attributes: tAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "nested_arrays",
+      name: "t"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tCodec = recordCodec(tCodecSpec);
-const extensions6 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "check_work_hours"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts6 = ["nested_arrays", "check_work_hours"];
-const sqlIdent = sql.identifier(...parts6);
-const extensions7 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "nested_arrays",
-    name: "t"
-  },
-  tags: {}
-};
+});
+const sqlIdent = sql.identifier("nested_arrays", "check_work_hours");
 const uniques = [{
   isPrimary: true,
   attributes: ["k"],
@@ -297,7 +252,16 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions6,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "nested_arrays",
+          name: "check_work_hours"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     t: {
@@ -309,7 +273,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions7
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "nested_arrays",
+          name: "t"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -415,21 +387,6 @@ const fetcher = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.T);
-function Query_allTs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -449,99 +406,14 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   });
 };
 const resource_frmcdc_workHourPgResource = registry.pgResources["frmcdc_workHour"];
-function TSConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TSConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TSConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Mutation_createT_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.T, $nodeId);
 };
-function Mutation_updateT_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTByK_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.T, $nodeId);
 };
-function Mutation_deleteT_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTByK_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateTPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTPayload_tPlan($object) {
-  return $object.get("result");
-}
-function CreateTPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTInput_t_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTPayload_tPlan($object) {
-  return $object.get("result");
-}
-function UpdateTPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTInput_tPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTByKInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTByKInput_tPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteTPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTPayload_tPlan($object) {
-  return $object.get("result");
-}
-function DeleteTPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTByKInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -894,7 +766,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -942,23 +816,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1044,9 +928,16 @@ export const plans = {
   },
   TSConnection: {
     __assertStep: ConnectionStep,
-    nodes: TSConnection_nodesPlan,
-    edges: TSConnection_edgesPlan,
-    pageInfo: TSConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1062,8 +953,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1203,7 +1098,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createT_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1217,7 +1114,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateT_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1233,7 +1132,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTByK_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1247,7 +1148,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteT_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1263,16 +1166,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTByK_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateTPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTPayload_clientMutationIdPlan,
-    t: CreateTPayload_tPlan,
-    query: CreateTPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    t($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1307,11 +1218,16 @@ export const plans = {
   },
   CreateTInput: {
     clientMutationId: {
-      applyPlan: CreateTInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     t: {
-      applyPlan: CreateTInput_t_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -1333,9 +1249,15 @@ export const plans = {
   },
   UpdateTPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTPayload_clientMutationIdPlan,
-    t: UpdateTPayload_tPlan,
-    query: UpdateTPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    t($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1370,11 +1292,16 @@ export const plans = {
   },
   UpdateTInput: {
     clientMutationId: {
-      applyPlan: UpdateTInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tPatch: {
-      applyPlan: UpdateTInput_tPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TPatch: {
@@ -1395,23 +1322,34 @@ export const plans = {
   },
   UpdateTByKInput: {
     clientMutationId: {
-      applyPlan: UpdateTByKInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     k: undefined,
     tPatch: {
-      applyPlan: UpdateTByKInput_tPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteTPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTPayload_clientMutationIdPlan,
-    t: DeleteTPayload_tPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    t($object) {
+      return $object.get("result");
+    },
     deletedTId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.T.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1446,13 +1384,17 @@ export const plans = {
   },
   DeleteTInput: {
     clientMutationId: {
-      applyPlan: DeleteTInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTByKInput: {
     clientMutationId: {
-      applyPlan: DeleteTByKInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     k: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -109,7 +109,7 @@ const workHourPartsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const workHourCodec = domainOfCodec(workHourPartsCodec, "workHour", sql.identifier("nested_arrays", "work_hour"), {
   description: undefined,
@@ -207,10 +207,10 @@ const tCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("nested_arrays", "check_work_hours");
-const uniques = [{
+const check_work_hoursFunctionIdentifer = sql.identifier("nested_arrays", "check_work_hours");
+const tUniques = [{
   isPrimary: true,
   attributes: ["k"],
   description: undefined,
@@ -236,11 +236,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     check_work_hours: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "check_work_hours",
       identifier: "main.nested_arrays.check_work_hours(nested_arrays._work_hour)",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${check_work_hoursFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "wh",
@@ -265,12 +265,12 @@ const registry = makeRegistry({
       description: undefined
     },
     t: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "t",
       identifier: "main.nested_arrays.t",
       from: tCodec.sqlType,
       codec: tCodec,
-      uniques,
+      uniques: tUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -972,7 +972,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        tUniques[0].attributes.forEach(attributeName => {
           const attribute = tCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -988,7 +988,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        tUniques[0].attributes.forEach(attributeName => {
           const attribute = tCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1194,7 +1194,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = tUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1268,7 +1268,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = tUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1360,7 +1360,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = tUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,32 +3371,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3412,12 +3412,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3430,17 +3430,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3449,12 +3449,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3469,15 +3469,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3729,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,16 +3791,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3820,11 +3820,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3944,11 +3944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3968,11 +3968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3992,11 +3992,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4016,11 +4016,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4040,11 +4040,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4088,11 +4088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4112,11 +4112,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4142,11 +4142,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4172,11 +4172,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4202,11 +4202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4232,11 +4232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4261,11 +4261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4291,11 +4291,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4320,11 +4320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4349,11 +4349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4378,11 +4378,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4407,11 +4407,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4436,11 +4436,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4465,11 +4465,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4499,11 +4499,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4533,11 +4533,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4567,11 +4567,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4635,11 +4635,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4669,11 +4669,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4703,11 +4703,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4737,11 +4737,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4771,11 +4771,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4805,11 +4805,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4839,11 +4839,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4873,11 +4873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4907,11 +4907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4942,11 +4942,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4966,11 +4966,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4990,11 +4990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5014,11 +5014,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5049,11 +5049,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5073,11 +5073,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5121,11 +5121,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5146,11 +5146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5185,11 +5185,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5224,11 +5224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5263,11 +5263,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5302,11 +5302,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5341,11 +5341,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5365,11 +5365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5394,11 +5394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5433,11 +5433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5472,11 +5472,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5496,11 +5496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5525,11 +5525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5578,11 +5578,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5602,11 +5602,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5626,11 +5626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5650,7 +5650,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5671,12 +5671,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5690,12 +5690,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5709,12 +5709,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5728,12 +5728,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5747,12 +5747,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5766,12 +5766,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5786,7 +5786,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5812,7 +5812,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5832,12 +5832,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5852,12 +5852,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5872,12 +5872,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5891,12 +5891,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5910,7 +5910,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5941,12 +5941,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5960,11 +5960,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5992,7 +5992,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6011,11 +6011,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6050,7 +6050,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6073,7 +6073,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6095,7 +6095,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6133,7 +6133,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6165,7 +6165,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6187,7 +6187,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6209,7 +6209,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6243,7 +6243,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6267,7 +6267,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6301,11 +6301,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6355,11 +6355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6409,11 +6409,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6438,11 +6438,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6467,11 +6467,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6496,11 +6496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6525,11 +6525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6561,11 +6561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6597,11 +6597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6626,11 +6626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6655,11 +6655,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6694,11 +6694,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6733,11 +6733,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6772,11 +6772,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6815,7 +6815,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6837,7 +6837,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6864,7 +6864,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6891,7 +6891,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6918,7 +6918,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6945,7 +6945,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6972,7 +6972,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7005,7 +7005,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7032,7 +7032,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7059,7 +7059,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7113,7 +7113,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7145,7 +7145,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7169,11 +7169,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7232,11 +7232,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7261,11 +7261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7330,11 +7330,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7394,11 +7394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7428,11 +7428,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7462,11 +7462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7496,11 +7496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7530,11 +7530,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7572,7 +7572,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7623,7 +7623,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7645,7 +7645,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7667,7 +7667,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7689,7 +7689,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7757,7 +7757,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7779,7 +7779,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7836,7 +7836,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7858,7 +7858,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7880,7 +7880,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7907,7 +7907,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7961,7 +7961,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7993,7 +7993,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8015,7 +8015,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8037,7 +8037,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30651,7 +30651,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30667,7 +30667,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33165,7 +33165,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33181,7 +33181,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33603,7 +33603,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33619,7 +33619,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34240,7 +34240,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34256,7 +34256,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35325,7 +35325,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35341,7 +35341,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35446,7 +35446,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35462,7 +35462,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35567,7 +35567,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35583,7 +35583,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35688,7 +35688,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35704,7 +35704,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35809,7 +35809,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35825,7 +35825,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35930,7 +35930,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35946,7 +35946,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36469,7 +36469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36485,7 +36485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36647,7 +36647,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36663,7 +36663,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36825,7 +36825,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36841,7 +36841,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37060,7 +37060,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37076,7 +37076,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37352,7 +37352,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37368,7 +37368,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37919,7 +37919,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37935,7 +37935,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38460,7 +38460,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38476,7 +38476,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38752,7 +38752,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38768,7 +38768,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42380,7 +42380,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42467,7 +42467,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42716,7 +42716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42773,7 +42773,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43030,7 +43030,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43141,7 +43141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43223,7 +43223,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43290,7 +43290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43357,7 +43357,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43424,7 +43424,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43491,7 +43491,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43558,7 +43558,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43786,7 +43786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43860,7 +43860,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43939,7 +43939,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44020,7 +44020,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44111,7 +44111,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44199,7 +44199,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44344,7 +44344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44482,7 +44482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44575,7 +44575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44649,7 +44649,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44712,7 +44712,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44849,7 +44849,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45262,7 +45262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45342,7 +45342,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45422,7 +45422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45502,7 +45502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45582,7 +45582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45662,7 +45662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45791,7 +45791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45878,7 +45878,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45970,7 +45970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46064,7 +46064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46169,7 +46169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46270,7 +46270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46371,7 +46371,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46472,7 +46472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46592,7 +46592,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46679,7 +46679,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46799,7 +46799,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46963,7 +46963,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47394,7 +47394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47458,7 +47458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47522,7 +47522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47586,7 +47586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47650,7 +47650,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47714,7 +47714,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47798,7 +47798,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47862,7 +47862,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47931,7 +47931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47995,7 +47995,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48070,7 +48070,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48134,7 +48134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48198,7 +48198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48262,7 +48262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48339,7 +48339,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48403,7 +48403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48472,7 +48472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48544,7 +48544,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,732 +3339,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6511,274 +3420,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6796,254 +3457,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7158,19 +3592,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7179,9 +3634,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7196,813 +3807,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8014,7 +5658,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8025,7 +5679,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8036,7 +5698,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8047,7 +5717,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8058,7 +5736,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8069,7 +5755,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8080,7 +5774,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8089,10 +5791,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8100,10 +5817,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8115,7 +5840,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8127,7 +5860,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8139,7 +5880,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8150,7 +5899,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8158,10 +5915,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8172,33 +5949,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8207,394 +6055,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9444,25 +8909,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9605,21 +9051,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9670,21 +9101,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9793,21 +9209,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10298,21 +9699,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,12 +9791,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10833,21 +10213,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10916,21 +10281,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11317,21 +10667,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11660,21 +10995,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11725,21 +11045,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11836,21 +11141,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11901,21 +11191,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11984,21 +11259,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12049,21 +11309,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12325,385 +11570,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13277,21 +12147,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13372,21 +12227,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13486,66 +12326,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13593,24 +12373,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13691,21 +12453,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14129,348 +12876,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14517,26 +12923,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14583,9 +12969,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,9 +13015,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14681,9 +13061,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14730,9 +13107,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14779,9 +13153,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14828,9 +13199,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14883,9 +13251,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14938,9 +13303,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14993,9 +13355,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15048,9 +13407,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15103,9 +13459,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15158,9 +13511,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15219,9 +13569,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15280,9 +13627,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15341,9 +13685,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15402,9 +13743,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15463,9 +13801,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15524,9 +13859,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15585,9 +13917,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15646,9 +13975,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15707,9 +14033,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15768,9 +14091,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15817,9 +14137,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15866,9 +14183,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15915,9 +14229,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15982,9 +14293,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16031,9 +14339,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16086,9 +14391,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16141,9 +14443,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16190,9 +14489,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16239,9 +14535,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16306,9 +14599,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16355,9 +14645,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16422,9 +14709,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16477,9 +14761,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16526,9 +14807,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16575,9 +14853,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16642,9 +14917,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16709,9 +14981,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16794,9 +15063,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16849,9 +15115,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16904,9 +15167,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16959,9 +15219,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17014,9 +15271,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17075,9 +15329,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17130,9 +15381,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17185,9 +15433,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17240,9 +15485,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17301,9 +15543,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17362,9 +15601,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17411,9 +15647,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17460,9 +15693,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17509,9 +15739,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17558,9 +15785,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17613,9 +15837,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17662,2061 +15883,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29823,7 +26134,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30069,27 +26382,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30109,23 +26435,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30137,23 +26473,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30175,23 +26521,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30275,23 +26631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30307,11 +26673,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30383,23 +26753,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30414,23 +26794,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30488,23 +26878,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30564,23 +26964,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30592,23 +27002,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30624,23 +27044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30652,23 +27082,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30696,23 +27136,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30724,23 +27174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30926,23 +27386,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30969,23 +27439,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31012,23 +27492,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31055,23 +27545,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31098,23 +27598,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31141,23 +27651,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31184,23 +27704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31227,23 +27757,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31270,23 +27810,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31313,23 +27863,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31356,23 +27916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31399,23 +27969,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31442,23 +28022,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31485,23 +28075,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31528,23 +28128,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31571,23 +28181,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31614,23 +28234,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31657,23 +28287,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31700,23 +28340,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31743,23 +28393,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31786,23 +28446,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31829,23 +28499,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31872,23 +28552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31915,23 +28605,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32075,23 +28775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32493,23 +29203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32530,23 +29250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32672,23 +29402,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32718,23 +29458,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32774,23 +29524,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32820,23 +29580,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33004,12 +29774,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33025,23 +29807,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33386,23 +30178,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33430,9 +30232,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33448,8 +30257,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33590,9 +30403,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36256,9 +33076,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36717,9 +33544,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37109,9 +33943,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37370,9 +34211,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37697,9 +34545,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37715,9 +34570,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37733,9 +34595,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37751,9 +34620,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37778,9 +34654,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37835,9 +34718,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37862,9 +34752,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37927,9 +34824,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37969,9 +34873,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38290,9 +35201,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38378,9 +35296,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38492,9 +35417,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38606,9 +35538,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38720,9 +35659,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38834,9 +35780,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38948,9 +35901,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39119,9 +36079,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39258,9 +36225,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39466,9 +36440,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39637,9 +36618,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39808,9 +36796,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40036,9 +37031,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40321,9 +37323,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40606,9 +37615,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40874,9 +37890,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41159,9 +38182,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41401,9 +38431,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41686,9 +38723,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41868,7 +38912,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41883,7 +38929,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41898,7 +38946,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41913,7 +38963,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41928,7 +38980,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41943,7 +38997,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41958,7 +39014,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41973,7 +39031,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41988,7 +39048,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42003,7 +39065,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42018,7 +39082,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42033,7 +39099,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42048,7 +39116,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42063,7 +39133,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42078,7 +39150,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42093,7 +39167,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42108,7 +39184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42123,7 +39201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42138,7 +39218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42153,7 +39235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42168,7 +39252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42183,7 +39269,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42198,7 +39286,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42213,7 +39303,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42228,7 +39320,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42243,7 +39337,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42258,7 +39354,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42273,7 +39371,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42288,7 +39388,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42303,7 +39405,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42318,7 +39422,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42333,7 +39439,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42348,7 +39456,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42363,7 +39473,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42378,7 +39490,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42393,7 +39507,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42408,7 +39524,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42423,7 +39541,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42438,7 +39558,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42453,7 +39575,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42468,7 +39592,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42483,7 +39609,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42498,7 +39626,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42513,7 +39643,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42528,7 +39660,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42543,7 +39677,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42558,7 +39694,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42573,7 +39711,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42588,7 +39728,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42603,7 +39745,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42618,7 +39762,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42633,7 +39779,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42648,7 +39796,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42663,7 +39813,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42678,7 +39830,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42693,7 +39847,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42708,7 +39864,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42723,7 +39881,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42738,7 +39898,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42753,7 +39915,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42768,7 +39932,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42783,7 +39949,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42798,7 +39966,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42813,7 +39983,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42828,7 +40000,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42843,7 +40017,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42858,7 +40034,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42873,7 +40051,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42888,7 +40068,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42903,7 +40085,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42918,7 +40102,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42933,7 +40119,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42948,7 +40136,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42963,7 +40153,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42978,7 +40170,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42993,7 +40187,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43008,7 +40204,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43023,7 +40221,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43038,7 +40238,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43052,7 +40254,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43068,7 +40272,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43082,7 +40288,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43098,7 +40306,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43112,7 +40322,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43128,7 +40340,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43142,7 +40356,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43158,7 +40374,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43172,7 +40390,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43188,7 +40408,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43202,7 +40424,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43218,7 +40442,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43234,7 +40460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43248,7 +40476,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43264,7 +40494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43278,7 +40510,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43294,7 +40528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43308,7 +40544,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43324,7 +40562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43338,7 +40578,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43355,7 +40597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43369,7 +40613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43385,7 +40631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43399,7 +40647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43415,7 +40665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43429,7 +40681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43445,7 +40699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43459,7 +40715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43475,7 +40733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43491,7 +40751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43505,7 +40767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43521,7 +40785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43535,7 +40801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43551,7 +40819,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43565,7 +40835,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43581,7 +40853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43597,7 +40871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43611,7 +40887,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43627,7 +40905,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43641,7 +40921,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43657,7 +40939,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43671,7 +40955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43687,7 +40973,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43701,7 +40989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43717,7 +41007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43731,7 +41023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43747,7 +41041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43761,7 +41057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43777,7 +41075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43791,7 +41091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43807,7 +41109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43823,7 +41127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43837,7 +41143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43853,7 +41161,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43867,7 +41177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43883,7 +41195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43897,7 +41211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43913,7 +41229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43927,7 +41245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43944,7 +41264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43958,7 +41280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43974,7 +41298,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43988,7 +41314,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44004,7 +41332,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44018,7 +41348,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44034,7 +41366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44048,7 +41382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44064,7 +41400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44080,7 +41418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44094,7 +41434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44110,7 +41452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44124,7 +41468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44140,7 +41486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44154,7 +41502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44170,7 +41520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44186,7 +41538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44200,7 +41554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44216,193 +41572,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44410,15 +41846,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44426,15 +41868,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44442,15 +41890,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44458,15 +41912,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44474,15 +41934,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44490,15 +41956,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44506,15 +41978,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44522,15 +42000,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44538,15 +42022,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44554,11 +42044,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44571,17 +42065,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44594,17 +42094,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44617,21 +42123,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44640,11 +42154,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44660,17 +42178,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44683,65 +42207,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44750,11 +42300,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44776,21 +42330,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44799,11 +42361,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44843,7 +42409,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44880,11 +42448,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44919,35 +42491,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44956,11 +42542,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44992,7 +42582,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45001,15 +42593,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45021,11 +42619,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45044,48 +42646,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45125,18 +42745,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45176,7 +42802,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45228,56 +42856,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45305,7 +42955,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45313,11 +42965,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45345,7 +43001,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45353,11 +43011,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45392,59 +43054,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45489,30 +43175,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45547,11 +43247,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45566,9 +43271,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45603,11 +43314,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45622,9 +43338,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45659,11 +43381,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45678,9 +43405,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45715,11 +43448,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45734,9 +43472,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45771,11 +43515,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45790,9 +43539,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45827,11 +43582,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45853,9 +43613,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45870,11 +43636,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45903,17 +43674,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45935,17 +43717,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45974,9 +43767,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46011,11 +43810,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46037,9 +43841,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46079,11 +43889,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46105,9 +43920,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46142,11 +43963,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46175,9 +44001,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46222,11 +44054,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46255,9 +44092,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46292,11 +44135,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46332,9 +44180,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46369,11 +44223,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46409,17 +44268,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46455,9 +44325,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46492,11 +44368,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46532,17 +44413,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46571,9 +44463,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46613,11 +44511,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46653,9 +44556,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46690,11 +44599,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46716,9 +44630,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46758,19 +44678,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46805,11 +44736,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46894,9 +44830,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46941,11 +44883,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47296,9 +45243,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47333,11 +45286,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47351,18 +45309,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47397,11 +45366,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47415,18 +45389,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47461,11 +45446,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47479,18 +45469,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47525,11 +45526,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47543,18 +45549,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47589,11 +45606,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47607,18 +45629,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47653,11 +45686,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47678,26 +45716,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47718,9 +45772,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47755,11 +45815,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47780,18 +45845,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47831,11 +45907,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47856,18 +45937,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47902,11 +45994,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47934,18 +46031,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47990,11 +46098,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48022,19 +46135,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48069,11 +46193,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48108,18 +46237,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48154,11 +46294,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48193,18 +46338,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48239,11 +46395,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48278,18 +46439,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48329,11 +46501,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48368,27 +46545,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48423,11 +46616,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48448,18 +46646,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48499,11 +46708,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48552,18 +46766,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48598,11 +46823,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48686,27 +46916,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48751,11 +46997,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49105,23 +47356,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49156,26 +47418,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49210,26 +47482,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49264,26 +47546,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49318,26 +47610,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49372,26 +47674,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49426,38 +47738,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49492,26 +47822,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49551,26 +47891,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49605,26 +47955,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49669,27 +48029,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49724,26 +48094,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49778,26 +48158,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49832,26 +48222,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49891,32 +48291,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49951,26 +48363,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50010,26 +48432,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50064,32 +48496,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50134,13 +48578,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1940,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1961,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,7 +1969,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1980,7 +1979,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1989,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2011,7 +2010,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2020,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2042,7 +2041,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2051,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2060,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2075,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2092,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2102,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2135,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2153,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2162,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2217,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2227,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2259,7 +2258,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2268,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2279,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,7 +2287,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2298,7 +2297,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2307,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2318,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,7 +2326,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2337,7 +2336,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2346,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2357,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,7 +2365,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2376,7 +2375,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2385,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2396,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,7 +2404,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2415,7 +2414,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2424,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2435,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,7 +2443,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2454,7 +2453,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2463,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2471,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2486,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2501,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2516,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2530,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2544,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2561,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2578,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2588,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2607,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2621,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2629,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2650,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2668,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2735,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2744,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2753,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2762,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2771,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2798,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2807,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2816,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2825,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2888,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2915,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2924,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2933,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3059,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3068,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3086,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3095,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3112,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3124,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3142,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3150,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3158,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3166,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3181,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3194,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3229,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3239,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3286,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3296,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3352,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,16 +3362,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3383,8 +3382,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3395,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3410,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3424,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3439,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3454,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3468,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3482,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3496,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3510,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3524,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3538,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3552,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3567,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3587,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3607,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3627,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3646,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3666,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3685,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3704,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3723,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3742,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3761,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3780,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3799,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3823,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3847,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3871,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3895,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3919,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3943,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3967,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3991,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4015,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4039,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4063,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4087,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4112,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4136,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4150,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4164,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4179,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4203,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4217,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4231,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4246,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4260,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4289,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4318,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4347,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4376,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4405,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4419,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4438,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4467,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4496,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4510,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4529,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4548,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4562,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4576,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4590,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4604,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4721,14 +4720,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4754,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4763,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4779,14 +4778,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4826,14 +4825,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,14 +4870,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4961,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +5004,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5032,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5061,20 +5060,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5175,26 +5174,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5376,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5420,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5464,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5483,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5502,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5521,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5542,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5568,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5592,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5611,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5630,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5659,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5688,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5717,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5757,20 +5756,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5928,12 +5927,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,18 +5956,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5992,18 +5991,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6021,18 +6020,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6049,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,23 +6107,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6142,18 +6141,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6170,7 +6169,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6185,15 +6184,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,15 +6204,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6224,15 +6223,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6244,20 +6243,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6268,20 +6267,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6293,20 +6292,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6317,15 +6316,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6336,8 +6335,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6349,7 +6348,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6360,8 +6359,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6373,7 +6372,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6384,8 +6383,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6397,7 +6396,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6408,8 +6407,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6421,7 +6420,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6432,13 +6431,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6451,18 +6450,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6479,7 +6478,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6507,20 +6506,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6540,12 +6539,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6564,12 +6563,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6588,12 +6587,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6612,12 +6611,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6635,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,12 +6659,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6686,12 +6685,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6710,18 +6709,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6740,18 +6739,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6769,7 +6768,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6777,7 +6776,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6792,20 +6791,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6824,12 +6823,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6848,12 +6847,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6877,12 +6876,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,18 +6905,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6935,18 +6934,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6969,12 +6968,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6993,12 +6992,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7017,18 +7016,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7065,61 +7064,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7130,18 +7129,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7151,38 +7150,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7190,14 +7189,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7210,7 +7209,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7223,7 +7222,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7236,7 +7235,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7249,7 +7248,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7262,7 +7261,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7275,7 +7274,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7288,7 +7287,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7301,7 +7300,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7314,7 +7313,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7327,7 +7326,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7340,7 +7339,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7353,7 +7352,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7366,7 +7365,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7379,7 +7378,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7392,7 +7391,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7405,7 +7404,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7418,7 +7417,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7431,7 +7430,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7444,7 +7443,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7457,7 +7456,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7470,7 +7469,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7483,7 +7482,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7496,7 +7495,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7509,7 +7508,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7522,7 +7521,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7535,7 +7534,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7548,7 +7547,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7561,7 +7560,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7574,7 +7573,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7587,7 +7586,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7600,7 +7599,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7613,7 +7612,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7626,7 +7625,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7639,7 +7638,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7652,7 +7651,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7665,7 +7664,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7678,7 +7677,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7691,7 +7690,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7704,7 +7703,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7717,7 +7716,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7730,7 +7729,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7743,7 +7742,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7756,7 +7755,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7769,7 +7768,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7782,7 +7781,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7795,7 +7794,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7808,7 +7807,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7821,7 +7820,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7834,7 +7833,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7847,7 +7846,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7860,7 +7859,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7873,7 +7872,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7886,7 +7885,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7899,7 +7898,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7912,7 +7911,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7925,7 +7924,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7938,7 +7937,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7948,10 +7947,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7961,10 +7960,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7974,10 +7973,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7987,10 +7986,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8000,180 +7999,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8185,7 +8184,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8196,22 +8195,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8232,7 +8231,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8245,7 +8244,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8258,7 +8257,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8271,7 +8270,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8281,10 +8280,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8294,10 +8293,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8310,7 +8309,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8323,7 +8322,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8336,7 +8335,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8349,7 +8348,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8362,7 +8361,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8375,7 +8374,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8388,7 +8387,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8401,7 +8400,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8428,7 +8427,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8441,7 +8440,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8454,7 +8453,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8467,7 +8466,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8480,7 +8479,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8493,7 +8492,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8506,7 +8505,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8519,7 +8518,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8532,7 +8531,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8545,7 +8544,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8558,7 +8557,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8571,7 +8570,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8600,7 +8599,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8615,7 +8614,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8632,7 +8631,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8647,7 +8646,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8662,7 +8661,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8679,7 +8678,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8696,7 +8695,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8713,7 +8712,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8728,7 +8727,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8745,7 +8744,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8760,7 +8759,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8775,7 +8774,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8790,7 +8789,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8807,7 +8806,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8824,7 +8823,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8839,7 +8838,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8854,7 +8853,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8871,7 +8870,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8886,7 +8885,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8901,7 +8900,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8918,7 +8917,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11091,7 +11090,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11103,7 +11102,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11336,7 +11335,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11440,7 +11439,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11492,7 +11491,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12953,7 +12952,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14080,7 +14079,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16093,7 +16092,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16246,7 +16245,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16429,7 +16428,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16734,7 +16733,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16746,7 +16745,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16856,7 +16855,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16911,7 +16910,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17021,7 +17020,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17082,7 +17081,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17137,7 +17136,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17192,7 +17191,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33833,7 +33832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33849,7 +33848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35137,7 +35136,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35160,7 +35159,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35183,7 +35182,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35206,7 +35205,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35229,7 +35228,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35252,7 +35251,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35275,7 +35274,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35298,7 +35297,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35321,7 +35320,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35344,7 +35343,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35367,7 +35366,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35390,7 +35389,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35413,7 +35412,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35436,7 +35435,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35459,7 +35458,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35482,7 +35481,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35505,7 +35504,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35528,7 +35527,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35551,7 +35550,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35574,7 +35573,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35597,7 +35596,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35620,7 +35619,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35643,7 +35642,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35666,7 +35665,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35689,7 +35688,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35712,7 +35711,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35735,7 +35734,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35758,7 +35757,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35781,7 +35780,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35804,7 +35803,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35827,7 +35826,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35850,7 +35849,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35873,7 +35872,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35896,7 +35895,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35919,7 +35918,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35942,7 +35941,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35965,7 +35964,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35988,7 +35987,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36011,7 +36010,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36034,7 +36033,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36057,7 +36056,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36080,7 +36079,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36103,7 +36102,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36126,7 +36125,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36149,7 +36148,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36172,7 +36171,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36195,7 +36194,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36340,7 +36339,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36356,7 +36355,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36771,7 +36770,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36787,7 +36786,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36953,7 +36952,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36976,7 +36975,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -36999,7 +36998,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37022,7 +37021,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37045,7 +37044,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37068,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37272,7 +37271,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37295,7 +37294,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37318,7 +37317,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37394,7 +37393,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37410,7 +37409,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37542,7 +37541,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37565,7 +37564,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37588,7 +37587,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38026,7 +38025,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38049,7 +38048,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38072,7 +38071,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38095,7 +38094,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38118,7 +38117,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38141,7 +38140,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38164,7 +38163,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38187,7 +38186,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38210,7 +38209,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38233,7 +38232,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38256,7 +38255,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38368,7 +38367,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38402,7 +38401,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38418,7 +38417,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38482,7 +38481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38516,7 +38515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38532,7 +38531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38596,7 +38595,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38630,7 +38629,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38646,7 +38645,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38710,7 +38709,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38744,7 +38743,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38760,7 +38759,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38824,7 +38823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38858,7 +38857,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38874,7 +38873,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38938,7 +38937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38972,7 +38971,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38988,7 +38987,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39086,7 +39085,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39109,7 +39108,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39225,7 +39224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39248,7 +39247,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39410,7 +39409,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39433,7 +39432,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39456,7 +39455,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39490,7 +39489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39506,7 +39505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39604,7 +39603,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39627,7 +39626,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39661,7 +39660,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39677,7 +39676,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39775,7 +39774,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39798,7 +39797,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39832,7 +39831,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39848,7 +39847,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39980,7 +39979,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40003,7 +40002,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40026,7 +40025,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40060,7 +40059,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40076,7 +40075,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40242,7 +40241,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40265,7 +40264,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40288,7 +40287,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40311,7 +40310,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40345,7 +40344,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40361,7 +40360,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40527,7 +40526,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40550,7 +40549,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40573,7 +40572,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40596,7 +40595,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40795,7 +40794,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40818,7 +40817,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40841,7 +40840,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40864,7 +40863,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40898,7 +40897,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40914,7 +40913,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41080,7 +41079,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41103,7 +41102,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41126,7 +41125,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41149,7 +41148,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41345,7 +41344,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41368,7 +41367,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41391,7 +41390,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41425,7 +41424,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41441,7 +41440,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41607,7 +41606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41630,7 +41629,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41653,7 +41652,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41676,7 +41675,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41710,7 +41709,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41726,7 +41725,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41824,7 +41823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41847,7 +41846,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -55,6 +55,28 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const abcdAttributes = Object.assign(Object.create(null), {
+  letter: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  description: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {
+        enumDescription: true
+      }
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,37 +100,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_abcd = {
+const abcdIdentifier = sql.identifier(...["enum_tables", "abcd"]);
+const abcdCodecSpec = {
   name: "abcd",
-  identifier: sql.identifier(...["enum_tables", "abcd"]),
-  attributes: Object.assign(Object.create(null), {
-    letter: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    description: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {
-          enumDescription: true
-        }
-      }
-    }
-  }),
+  identifier: abcdIdentifier,
+  attributes: abcdAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_abcd_abcd = recordCodec(spec_abcd);
-const attributes2 = Object.assign(Object.create(null), {
+const abcdCodec = recordCodec(abcdCodecSpec);
+const abcdViewAttributes = Object.assign(Object.create(null), {
   letter: {
     description: undefined,
     codec: TYPES.text,
@@ -143,17 +145,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["enum_tables", "abcd_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_abcdView = {
+const abcdViewIdentifier = sql.identifier(...parts2);
+const abcdViewCodecSpec = {
   name: "abcdView",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: abcdViewIdentifier,
+  attributes: abcdViewAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_abcdView_abcdView = recordCodec(spec_abcdView);
-const attributes3 = Object.assign(Object.create(null), {
+const abcdViewCodec = recordCodec(abcdViewCodecSpec);
+const simpleEnumAttributes = Object.assign(Object.create(null), {
   value: {
     description: undefined,
     codec: TYPES.text,
@@ -186,23 +188,23 @@ const extensions3 = {
   })
 };
 const parts3 = ["enum_tables", "simple_enum"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_simpleEnum = {
+const simpleEnumIdentifier = sql.identifier(...parts3);
+const simpleEnumCodecSpec = {
   name: "simpleEnum",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: simpleEnumIdentifier,
+  attributes: simpleEnumAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_simpleEnum_simpleEnum = recordCodec(spec_simpleEnum);
+const simpleEnumCodec = recordCodec(simpleEnumCodecSpec);
 const extensions4 = {
   isEnumTableEnum: true,
   tags: {
     name: "LetterAToD"
   }
 };
-const attributes_letter_codec_LetterAToDEnum = enumCodec({
+const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
   name: "LetterAToDEnum",
   identifier: TYPES.text.sqlType,
   values: [{
@@ -239,13 +241,13 @@ const values2 = [{
   value: "D",
   description: "The letter D"
 }];
-const attributes_letter_via_view_codec_LetterAToDViaViewEnum = enumCodec({
+const letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum = enumCodec({
   name: "LetterAToDViaViewEnum",
   identifier: TYPES.text.sqlType,
   values: values2,
   extensions: extensions5
 });
-const attributes4 = Object.assign(Object.create(null), {
+const letterDescriptionsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -257,7 +259,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   letter: {
     description: undefined,
-    codec: attributes_letter_codec_LetterAToDEnum,
+    codec: letterDescriptionsAttributes_letter_codec_LetterAToDEnum,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -266,7 +268,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   letter_via_view: {
     description: undefined,
-    codec: attributes_letter_via_view_codec_LetterAToDViaViewEnum,
+    codec: letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -295,16 +297,16 @@ const extensions6 = {
   })
 };
 const parts4 = ["enum_tables", "letter_descriptions"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_letterDescriptions = {
+const letterDescriptionsIdentifier = sql.identifier(...parts4);
+const letterDescriptionsCodecSpec = {
   name: "letterDescriptions",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: letterDescriptionsIdentifier,
+  attributes: letterDescriptionsAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_letterDescriptions_letterDescriptions = recordCodec(spec_letterDescriptions);
+const letterDescriptionsCodec = recordCodec(letterDescriptionsCodecSpec);
 const extensions7 = {
   isEnumTableEnum: true,
   tags: {
@@ -324,7 +326,7 @@ const values3 = [{
   value: "a4",
   description: "Desc A4"
 }];
-const attributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
+const referencingTableAttributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
   name: "EnumTheFirstEnum",
   identifier: TYPES.text.sqlType,
   values: values3,
@@ -349,7 +351,7 @@ const values4 = [{
   value: "b4",
   description: "Desc B4"
 }];
-const attributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
+const referencingTableAttributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
   name: "EnumTheSecondEnum",
   identifier: TYPES.varchar.sqlType,
   values: values4,
@@ -374,7 +376,7 @@ const values5 = [{
   value: "c4",
   description: "Desc C4"
 }];
-const attributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
+const referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
   name: "LotsOfEnumsEnum3Enum",
   identifier: TYPES.bpchar.sqlType,
   values: values5,
@@ -399,13 +401,13 @@ const values6 = [{
   value: "Qux",
   description: null
 }];
-const attributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
+const referencingTableAttributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
   name: "SimpleEnumEnum",
   identifier: TYPES.text.sqlType,
   values: values6,
   extensions: extensions10
 });
-const attributes5 = Object.assign(Object.create(null), {
+const referencingTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -417,7 +419,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   enum_1: {
     description: undefined,
-    codec: attributes_enum_1_codec_EnumTheFirstEnum,
+    codec: referencingTableAttributes_enum_1_codec_EnumTheFirstEnum,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -426,7 +428,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   enum_2: {
     description: undefined,
-    codec: attributes_enum_2_codec_EnumTheSecondEnum,
+    codec: referencingTableAttributes_enum_2_codec_EnumTheSecondEnum,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -435,7 +437,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   enum_3: {
     description: undefined,
-    codec: attributes_enum_3_codec_LotsOfEnumsEnum3Enum,
+    codec: referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -444,7 +446,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   simple_enum: {
     description: undefined,
-    codec: attributes_simple_enum_codec_SimpleEnumEnum,
+    codec: referencingTableAttributes_simple_enum_codec_SimpleEnumEnum,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -462,17 +464,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts5 = ["enum_tables", "referencing_table"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_referencingTable = {
+const referencingTableIdentifier = sql.identifier(...parts5);
+const referencingTableCodecSpec = {
   name: "referencingTable",
-  identifier: sqlIdent5,
-  attributes: attributes5,
+  identifier: referencingTableIdentifier,
+  attributes: referencingTableAttributes,
   description: undefined,
   extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_referencingTable_referencingTable = recordCodec(spec_referencingTable);
-const attributes6 = Object.assign(Object.create(null), {
+const referencingTableCodec = recordCodec(referencingTableCodecSpec);
+const lotsOfEnumsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -541,16 +543,16 @@ const extensions12 = {
   })
 };
 const parts6 = ["enum_tables", "lots_of_enums"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_lotsOfEnums = {
+const lotsOfEnumsIdentifier = sql.identifier(...parts6);
+const lotsOfEnumsCodecSpec = {
   name: "lotsOfEnums",
-  identifier: sqlIdent6,
-  attributes: attributes6,
+  identifier: lotsOfEnumsIdentifier,
+  attributes: lotsOfEnumsAttributes,
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums = recordCodec(spec_lotsOfEnums);
+const lotsOfEnumsCodec = recordCodec(lotsOfEnumsCodecSpec);
 const extensions13 = {
   description: undefined,
   pg: {
@@ -568,8 +570,8 @@ const registryConfig_pgResources_abcd_abcd = {
   executor: executor_mainPgExecutor,
   name: "abcd",
   identifier: "main.enum_tables.abcd",
-  from: registryConfig_pgCodecs_abcd_abcd.sqlType,
-  codec: registryConfig_pgCodecs_abcd_abcd,
+  from: abcdCodec.sqlType,
+  codec: abcdCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["letter"],
@@ -608,8 +610,8 @@ const registryConfig_pgResources_abcd_view_abcd_view = {
   executor: executor_mainPgExecutor,
   name: "abcd_view",
   identifier: "main.enum_tables.abcd_view",
-  from: registryConfig_pgCodecs_abcdView_abcdView.sqlType,
-  codec: registryConfig_pgCodecs_abcdView_abcdView,
+  from: abcdViewCodec.sqlType,
+  codec: abcdViewCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -639,8 +641,8 @@ const registryConfig_pgResources_simple_enum_simple_enum = {
   executor: executor_mainPgExecutor,
   name: "simple_enum",
   identifier: "main.enum_tables.simple_enum",
-  from: registryConfig_pgCodecs_simpleEnum_simpleEnum.sqlType,
-  codec: registryConfig_pgCodecs_simpleEnum_simpleEnum,
+  from: simpleEnumCodec.sqlType,
+  codec: simpleEnumCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -657,7 +659,7 @@ const extensions16 = {
   }
 };
 const parts7 = ["enum_tables", "referencing_table_mutation"];
-const sqlIdent7 = sql.identifier(...parts7);
+const sqlIdent = sql.identifier(...parts7);
 const extensions17 = {
   description: undefined,
   pg: {
@@ -695,8 +697,8 @@ const registryConfig_pgResources_letter_descriptions_letter_descriptions = {
   executor: executor_mainPgExecutor,
   name: "letter_descriptions",
   identifier: "main.enum_tables.letter_descriptions",
-  from: registryConfig_pgCodecs_letterDescriptions_letterDescriptions.sqlType,
-  codec: registryConfig_pgCodecs_letterDescriptions_letterDescriptions,
+  from: letterDescriptionsCodec.sqlType,
+  codec: letterDescriptionsCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -723,8 +725,8 @@ const registryConfig_pgResources_referencing_table_referencing_table = {
   executor: executor_mainPgExecutor,
   name: "referencing_table",
   identifier: "main.enum_tables.referencing_table",
-  from: registryConfig_pgCodecs_referencingTable_referencingTable.sqlType,
-  codec: registryConfig_pgCodecs_referencingTable_referencingTable,
+  from: referencingTableCodec.sqlType,
+  codec: referencingTableCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -792,8 +794,8 @@ const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
   executor: executor_mainPgExecutor,
   name: "lots_of_enums",
   identifier: "main.enum_tables.lots_of_enums",
-  from: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums.sqlType,
-  codec: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums,
+  from: lotsOfEnumsCodec.sqlType,
+  codec: lotsOfEnumsCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -801,20 +803,20 @@ const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    abcd: registryConfig_pgCodecs_abcd_abcd,
+    abcd: abcdCodec,
     text: TYPES.text,
-    abcdView: registryConfig_pgCodecs_abcdView_abcdView,
-    simpleEnum: registryConfig_pgCodecs_simpleEnum_simpleEnum,
+    abcdView: abcdViewCodec,
+    simpleEnum: simpleEnumCodec,
     int4: TYPES.int,
-    letterDescriptions: registryConfig_pgCodecs_letterDescriptions_letterDescriptions,
-    LetterAToDEnum: attributes_letter_codec_LetterAToDEnum,
-    LetterAToDViaViewEnum: attributes_letter_via_view_codec_LetterAToDViaViewEnum,
-    referencingTable: registryConfig_pgCodecs_referencingTable_referencingTable,
-    EnumTheFirstEnum: attributes_enum_1_codec_EnumTheFirstEnum,
-    EnumTheSecondEnum: attributes_enum_2_codec_EnumTheSecondEnum,
-    LotsOfEnumsEnum3Enum: attributes_enum_3_codec_LotsOfEnumsEnum3Enum,
-    SimpleEnumEnum: attributes_simple_enum_codec_SimpleEnumEnum,
-    lotsOfEnums: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums,
+    letterDescriptions: letterDescriptionsCodec,
+    LetterAToDEnum: letterDescriptionsAttributes_letter_codec_LetterAToDEnum,
+    LetterAToDViaViewEnum: letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum,
+    referencingTable: referencingTableCodec,
+    EnumTheFirstEnum: referencingTableAttributes_enum_1_codec_EnumTheFirstEnum,
+    EnumTheSecondEnum: referencingTableAttributes_enum_2_codec_EnumTheSecondEnum,
+    LotsOfEnumsEnum3Enum: referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum,
+    SimpleEnumEnum: referencingTableAttributes_simple_enum_codec_SimpleEnumEnum,
+    lotsOfEnums: lotsOfEnumsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar
   }),
@@ -827,13 +829,13 @@ const registry = makeRegistry({
       name: "referencing_table_mutation",
       identifier: "main.enum_tables.referencing_table_mutation(enum_tables.referencing_table)",
       from(...args) {
-        return sql`${sqlIdent7}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "t",
         required: true,
         notNull: false,
-        codec: registryConfig_pgCodecs_referencingTable_referencingTable
+        codec: referencingTableCodec
       }],
       isUnique: !false,
       codec: TYPES.int,
@@ -849,7 +851,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     abcd: Object.assign(Object.create(null), {
       letterDescriptionsByTheirLetter: {
-        localCodec: registryConfig_pgCodecs_abcd_abcd,
+        localCodec: abcdCodec,
         remoteResourceOptions: registryConfig_pgResources_letter_descriptions_letter_descriptions,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["letter"],
@@ -866,7 +868,7 @@ const registry = makeRegistry({
     }),
     abcdView: Object.assign(Object.create(null), {
       letterDescriptionsByTheirLetterViaView: {
-        localCodec: registryConfig_pgCodecs_abcdView_abcdView,
+        localCodec: abcdViewCodec,
         remoteResourceOptions: registryConfig_pgResources_letter_descriptions_letter_descriptions,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["letter"],
@@ -883,7 +885,7 @@ const registry = makeRegistry({
     }),
     letterDescriptions: Object.assign(Object.create(null), {
       abcdViewByMyLetterViaView: {
-        localCodec: registryConfig_pgCodecs_letterDescriptions_letterDescriptions,
+        localCodec: letterDescriptionsCodec,
         remoteResourceOptions: registryConfig_pgResources_abcd_view_abcd_view,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["letter_via_view"],
@@ -898,7 +900,7 @@ const registry = makeRegistry({
         }
       },
       abcdByMyLetter: {
-        localCodec: registryConfig_pgCodecs_letterDescriptions_letterDescriptions,
+        localCodec: letterDescriptionsCodec,
         remoteResourceOptions: registryConfig_pgResources_abcd_abcd,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["letter"],
@@ -915,7 +917,7 @@ const registry = makeRegistry({
     }),
     lotsOfEnums: Object.assign(Object.create(null), {
       referencingTablesByTheirEnum1: {
-        localCodec: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums,
+        localCodec: lotsOfEnumsCodec,
         remoteResourceOptions: registryConfig_pgResources_referencing_table_referencing_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_1"],
@@ -930,7 +932,7 @@ const registry = makeRegistry({
         }
       },
       referencingTablesByTheirEnum2: {
-        localCodec: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums,
+        localCodec: lotsOfEnumsCodec,
         remoteResourceOptions: registryConfig_pgResources_referencing_table_referencing_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_2"],
@@ -945,7 +947,7 @@ const registry = makeRegistry({
         }
       },
       referencingTablesByTheirEnum3: {
-        localCodec: registryConfig_pgCodecs_lotsOfEnums_lotsOfEnums,
+        localCodec: lotsOfEnumsCodec,
         remoteResourceOptions: registryConfig_pgResources_referencing_table_referencing_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_3"],
@@ -962,7 +964,7 @@ const registry = makeRegistry({
     }),
     referencingTable: Object.assign(Object.create(null), {
       lotsOfEnumsByMyEnum1: {
-        localCodec: registryConfig_pgCodecs_referencingTable_referencingTable,
+        localCodec: referencingTableCodec,
         remoteResourceOptions: registryConfig_pgResources_lots_of_enums_lots_of_enums,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_1"],
@@ -977,7 +979,7 @@ const registry = makeRegistry({
         }
       },
       lotsOfEnumsByMyEnum2: {
-        localCodec: registryConfig_pgCodecs_referencingTable_referencingTable,
+        localCodec: referencingTableCodec,
         remoteResourceOptions: registryConfig_pgResources_lots_of_enums_lots_of_enums,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_2"],
@@ -992,7 +994,7 @@ const registry = makeRegistry({
         }
       },
       lotsOfEnumsByMyEnum3: {
-        localCodec: registryConfig_pgCodecs_referencingTable_referencingTable,
+        localCodec: referencingTableCodec,
         remoteResourceOptions: registryConfig_pgResources_lots_of_enums_lots_of_enums,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["enum_3"],
@@ -1007,7 +1009,7 @@ const registry = makeRegistry({
         }
       },
       simpleEnumByMySimpleEnum: {
-        localCodec: registryConfig_pgCodecs_referencingTable_referencingTable,
+        localCodec: referencingTableCodec,
         remoteResourceOptions: registryConfig_pgResources_simple_enum_simple_enum,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["simple_enum"],
@@ -1024,7 +1026,7 @@ const registry = makeRegistry({
     }),
     simpleEnum: Object.assign(Object.create(null), {
       referencingTablesByTheirSimpleEnum: {
-        localCodec: registryConfig_pgCodecs_simpleEnum_simpleEnum,
+        localCodec: simpleEnumCodec,
         remoteResourceOptions: registryConfig_pgResources_referencing_table_referencing_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["value"],
@@ -1195,7 +1197,7 @@ function ReferencingTablesConnection_pageInfoPlan($connection) {
 const argDetailsSimple = [{
   graphqlArgName: "t",
   postgresArgName: "t",
-  pgCodec: registryConfig_pgCodecs_referencingTable_referencingTable,
+  pgCodec: referencingTableCodec,
   required: true,
   fetcher: null
 }];
@@ -2620,7 +2622,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_letterDescriptions_letterDescriptions.attributes[attributeName];
+          const attribute = letterDescriptionsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2636,7 +2638,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_letterDescriptions_letterDescriptions.attributes[attributeName];
+          const attribute = letterDescriptionsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2802,7 +2804,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.id.codec)}`;
             }
           });
         }
@@ -2825,7 +2827,7 @@ export const plans = {
             type: "attribute",
             attribute: "letter",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.letter.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.letter.codec)}`;
             }
           });
         }
@@ -2848,7 +2850,7 @@ export const plans = {
             type: "attribute",
             attribute: "letter_via_view",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.letter_via_view.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.letter_via_view.codec)}`;
             }
           });
         }
@@ -2871,7 +2873,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.description.codec)}`;
             }
           });
         }
@@ -2905,7 +2907,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_referencingTable_referencingTable.attributes[attributeName];
+          const attribute = referencingTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -2921,7 +2923,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_referencingTable_referencingTable.attributes[attributeName];
+          const attribute = referencingTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3121,7 +3123,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.id.codec)}`;
             }
           });
         }
@@ -3144,7 +3146,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.enum_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_1.codec)}`;
             }
           });
         }
@@ -3167,7 +3169,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.enum_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_2.codec)}`;
             }
           });
         }
@@ -3190,7 +3192,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.enum_3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_3.codec)}`;
             }
           });
         }
@@ -3213,7 +3215,7 @@ export const plans = {
             type: "attribute",
             attribute: "simple_enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.simple_enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.simple_enum.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -98,7 +98,7 @@ const abcdCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions2 = {
   isTableLike: true,
@@ -139,7 +139,7 @@ const abcdViewCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions2,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -178,7 +178,7 @@ const simpleEnumCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
   name: "LetterAToDEnum",
@@ -280,7 +280,7 @@ const letterDescriptionsCodec = recordCodec({
       foreignKey: "(letter_via_view) references enum_tables.abcd_view"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const referencingTableAttributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
   name: "EnumTheFirstEnum",
@@ -435,7 +435,7 @@ const referencingTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -510,10 +510,10 @@ const lotsOfEnumsCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_abcd_abcd = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "abcd",
   identifier: "main.enum_tables.abcd",
   from: abcdCodec.sqlType,
@@ -543,7 +543,7 @@ const registryConfig_pgResources_abcd_abcd = {
   }
 };
 const registryConfig_pgResources_abcd_view_abcd_view = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "abcd_view",
   identifier: "main.enum_tables.abcd_view",
   from: abcdViewCodec.sqlType,
@@ -574,7 +574,7 @@ const registryConfig_pgResources_abcd_view_abcd_view = {
   }
 };
 const registryConfig_pgResources_simple_enum_simple_enum = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "simple_enum",
   identifier: "main.enum_tables.simple_enum",
   from: simpleEnumCodec.sqlType,
@@ -602,8 +602,8 @@ const registryConfig_pgResources_simple_enum_simple_enum = {
     }
   }
 };
-const sqlIdent = sql.identifier("enum_tables", "referencing_table_mutation");
-const uniques4 = [{
+const referencing_table_mutationFunctionIdentifer = sql.identifier("enum_tables", "referencing_table_mutation");
+const letter_descriptionsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -626,12 +626,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_letter_descriptions_letter_descriptions = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "letter_descriptions",
   identifier: "main.enum_tables.letter_descriptions",
   from: letterDescriptionsCodec.sqlType,
   codec: letterDescriptionsCodec,
-  uniques: uniques4,
+  uniques: letter_descriptionsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -646,7 +646,7 @@ const registryConfig_pgResources_letter_descriptions_letter_descriptions = {
     }
   }
 };
-const uniques5 = [{
+const referencing_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -655,12 +655,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_referencing_table_referencing_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "referencing_table",
   identifier: "main.enum_tables.referencing_table",
   from: referencingTableCodec.sqlType,
   codec: referencingTableCodec,
-  uniques: uniques5,
+  uniques: referencing_tableUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -674,7 +674,7 @@ const registryConfig_pgResources_referencing_table_referencing_table = {
   }
 };
 const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "lots_of_enums",
   identifier: "main.enum_tables.lots_of_enums",
   from: lotsOfEnumsCodec.sqlType,
@@ -764,11 +764,11 @@ const registry = makeRegistry({
     abcd_view: registryConfig_pgResources_abcd_view_abcd_view,
     simple_enum: registryConfig_pgResources_simple_enum_simple_enum,
     referencing_table_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "referencing_table_mutation",
       identifier: "main.enum_tables.referencing_table_mutation(enum_tables.referencing_table)",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${referencing_table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "t",
@@ -2364,7 +2364,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        letter_descriptionsUniques[0].attributes.forEach(attributeName => {
           const attribute = letterDescriptionsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2380,7 +2380,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        letter_descriptionsUniques[0].attributes.forEach(attributeName => {
           const attribute = letterDescriptionsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2656,7 +2656,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        referencing_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = referencingTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2672,7 +2672,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        referencing_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = referencingTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3315,7 +3315,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = letter_descriptionsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3403,7 +3403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = referencing_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3461,7 +3461,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = letter_descriptionsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3590,7 +3590,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = referencing_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3703,7 +3703,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = letter_descriptionsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -3783,7 +3783,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = referencing_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,51 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const abcdAttributes = Object.assign(Object.create(null), {
-  letter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        enumDescription: true
-      }
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -100,35 +71,34 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const abcdIdentifier = sql.identifier(...["enum_tables", "abcd"]);
-const abcdCodecSpec = {
+const abcdCodec = recordCodec({
   name: "abcd",
-  identifier: abcdIdentifier,
-  attributes: abcdAttributes,
+  identifier: sql.identifier("enum_tables", "abcd"),
+  attributes: Object.assign(Object.create(null), {
+    letter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          enumDescription: true
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const abcdCodec = recordCodec(abcdCodecSpec);
-const abcdViewAttributes = Object.assign(Object.create(null), {
-  letter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions2 = {
   isTableLike: true,
@@ -144,36 +114,32 @@ const extensions2 = {
     behavior: ["-*"]
   })
 };
-const parts2 = ["enum_tables", "abcd_view"];
-const abcdViewIdentifier = sql.identifier(...parts2);
-const abcdViewCodecSpec = {
+const abcdViewCodec = recordCodec({
   name: "abcdView",
-  identifier: abcdViewIdentifier,
-  attributes: abcdViewAttributes,
+  identifier: sql.identifier("enum_tables", "abcd_view"),
+  attributes: Object.assign(Object.create(null), {
+    letter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
-};
-const abcdViewCodec = recordCodec(abcdViewCodecSpec);
-const simpleEnumAttributes = Object.assign(Object.create(null), {
-  value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions3 = {
   isTableLike: true,
@@ -187,23 +153,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["enum_tables", "simple_enum"];
-const simpleEnumIdentifier = sql.identifier(...parts3);
-const simpleEnumCodecSpec = {
+const simpleEnumCodec = recordCodec({
   name: "simpleEnum",
-  identifier: simpleEnumIdentifier,
-  attributes: simpleEnumAttributes,
+  identifier: sql.identifier("enum_tables", "simple_enum"),
+  attributes: Object.assign(Object.create(null), {
+    value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const simpleEnumCodec = recordCodec(simpleEnumCodecSpec);
-const extensions4 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "LetterAToD"
-  }
-};
+});
 const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
   name: "LetterAToDEnum",
   identifier: TYPES.text.sqlType,
@@ -220,32 +196,35 @@ const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
     value: "D",
     description: "The letter D"
   }],
-  extensions: extensions4
-});
-const extensions5 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "LetterAToDViaView"
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "LetterAToD"
+    }
   }
-};
-const values2 = [{
-  value: "A",
-  description: "The letter A"
-}, {
-  value: "B",
-  description: "The letter B"
-}, {
-  value: "C",
-  description: "The letter C"
-}, {
-  value: "D",
-  description: "The letter D"
-}];
+});
 const letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum = enumCodec({
   name: "LetterAToDViaViewEnum",
   identifier: TYPES.text.sqlType,
-  values: values2,
-  extensions: extensions5
+  values: [{
+    value: "A",
+    description: "The letter A"
+  }, {
+    value: "B",
+    description: "The letter B"
+  }, {
+    value: "C",
+    description: "The letter C"
+  }, {
+    value: "D",
+    description: "The letter D"
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "LetterAToDViaView"
+    }
+  }
 });
 const letterDescriptionsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -285,127 +264,115 @@ const letterDescriptionsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "letter_descriptions"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(letter_via_view) references enum_tables.abcd_view"
-  })
-};
-const parts4 = ["enum_tables", "letter_descriptions"];
-const letterDescriptionsIdentifier = sql.identifier(...parts4);
-const letterDescriptionsCodecSpec = {
+const letterDescriptionsCodec = recordCodec({
   name: "letterDescriptions",
-  identifier: letterDescriptionsIdentifier,
+  identifier: sql.identifier("enum_tables", "letter_descriptions"),
   attributes: letterDescriptionsAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "letter_descriptions"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(letter_via_view) references enum_tables.abcd_view"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const letterDescriptionsCodec = recordCodec(letterDescriptionsCodecSpec);
-const extensions7 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "EnumTheFirst"
-  }
-};
-const values3 = [{
-  value: "a1",
-  description: "Desc A1"
-}, {
-  value: "a2",
-  description: "Desc A2"
-}, {
-  value: "a3",
-  description: "Desc A3"
-}, {
-  value: "a4",
-  description: "Desc A4"
-}];
+});
 const referencingTableAttributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
   name: "EnumTheFirstEnum",
   identifier: TYPES.text.sqlType,
-  values: values3,
-  extensions: extensions7
-});
-const extensions8 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "EnumTheSecond"
+  values: [{
+    value: "a1",
+    description: "Desc A1"
+  }, {
+    value: "a2",
+    description: "Desc A2"
+  }, {
+    value: "a3",
+    description: "Desc A3"
+  }, {
+    value: "a4",
+    description: "Desc A4"
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "EnumTheFirst"
+    }
   }
-};
-const values4 = [{
-  value: "b1",
-  description: "Desc B1"
-}, {
-  value: "b2",
-  description: "Desc B2"
-}, {
-  value: "b3",
-  description: "Desc B3"
-}, {
-  value: "b4",
-  description: "Desc B4"
-}];
+});
 const referencingTableAttributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
   name: "EnumTheSecondEnum",
   identifier: TYPES.varchar.sqlType,
-  values: values4,
-  extensions: extensions8
-});
-const extensions9 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "LotsOfEnumsEnum3"
+  values: [{
+    value: "b1",
+    description: "Desc B1"
+  }, {
+    value: "b2",
+    description: "Desc B2"
+  }, {
+    value: "b3",
+    description: "Desc B3"
+  }, {
+    value: "b4",
+    description: "Desc B4"
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "EnumTheSecond"
+    }
   }
-};
-const values5 = [{
-  value: "c1",
-  description: "Desc C1"
-}, {
-  value: "c2",
-  description: "Desc C2"
-}, {
-  value: "c3",
-  description: "Desc C3"
-}, {
-  value: "c4",
-  description: "Desc C4"
-}];
+});
 const referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
   name: "LotsOfEnumsEnum3Enum",
   identifier: TYPES.bpchar.sqlType,
-  values: values5,
-  extensions: extensions9
-});
-const extensions10 = {
-  isEnumTableEnum: true,
-  tags: {
-    name: "SimpleEnum"
+  values: [{
+    value: "c1",
+    description: "Desc C1"
+  }, {
+    value: "c2",
+    description: "Desc C2"
+  }, {
+    value: "c3",
+    description: "Desc C3"
+  }, {
+    value: "c4",
+    description: "Desc C4"
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "LotsOfEnumsEnum3"
+    }
   }
-};
-const values6 = [{
-  value: "Foo",
-  description: "The first metasyntactic variable"
-}, {
-  value: "Bar",
-  description: null
-}, {
-  value: "Baz",
-  description: "The third metasyntactic variable, very similar to its predecessor"
-}, {
-  value: "Qux",
-  description: null
-}];
+});
 const referencingTableAttributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
   name: "SimpleEnumEnum",
   identifier: TYPES.text.sqlType,
-  values: values6,
-  extensions: extensions10
+  values: [{
+    value: "Foo",
+    description: "The first metasyntactic variable"
+  }, {
+    value: "Bar",
+    description: null
+  }, {
+    value: "Baz",
+    description: "The third metasyntactic variable, very similar to its predecessor"
+  }, {
+    value: "Qux",
+    description: null
+  }],
+  extensions: {
+    isEnumTableEnum: true,
+    tags: {
+      name: "SimpleEnum"
+    }
+  }
 });
 const referencingTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -454,81 +421,21 @@ const referencingTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "referencing_table"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["enum_tables", "referencing_table"];
-const referencingTableIdentifier = sql.identifier(...parts5);
-const referencingTableCodecSpec = {
+const referencingTableCodec = recordCodec({
   name: "referencingTable",
-  identifier: referencingTableIdentifier,
+  identifier: sql.identifier("enum_tables", "referencing_table"),
   attributes: referencingTableAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "referencing_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const referencingTableCodec = recordCodec(referencingTableCodecSpec);
-const lotsOfEnumsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_2: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_3: {
-    description: undefined,
-    codec: TYPES.bpchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions12 = {
   isTableLike: true,
@@ -542,30 +449,69 @@ const extensions12 = {
     behavior: ["-*"]
   })
 };
-const parts6 = ["enum_tables", "lots_of_enums"];
-const lotsOfEnumsIdentifier = sql.identifier(...parts6);
-const lotsOfEnumsCodecSpec = {
+const lotsOfEnumsCodec = recordCodec({
   name: "lotsOfEnums",
-  identifier: lotsOfEnumsIdentifier,
-  attributes: lotsOfEnumsAttributes,
+  identifier: sql.identifier("enum_tables", "lots_of_enums"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_1: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_2: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_3: {
+      description: undefined,
+      codec: TYPES.bpchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_4: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const lotsOfEnumsCodec = recordCodec(lotsOfEnumsCodecSpec);
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "abcd"
-  },
-  tags: {
-    enum: true,
-    enumName: "LetterAToD",
-    behavior: extensions.tags.behavior
-  }
-};
+});
 const registryConfig_pgResources_abcd_abcd = {
   executor: executor_mainPgExecutor,
   name: "abcd",
@@ -582,95 +528,81 @@ const registryConfig_pgResources_abcd_abcd = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "abcd_view"
-  },
-  tags: {
-    primaryKey: "letter",
-    enum: true,
-    enumName: "LetterAToDViaView",
-    behavior: extensions2.tags.behavior
-  }
-};
-const uniques2 = [{
-  isPrimary: true,
-  attributes: ["letter"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "abcd"
+    },
+    tags: {
+      enum: true,
+      enumName: "LetterAToD",
+      behavior: extensions.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_abcd_view_abcd_view = {
   executor: executor_mainPgExecutor,
   name: "abcd_view",
   identifier: "main.enum_tables.abcd_view",
   from: abcdViewCodec.sqlType,
   codec: abcdViewCodec,
-  uniques: uniques2,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["letter"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "simple_enum"
-  },
-  tags: {
-    enum: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["value"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "abcd_view"
+    },
+    tags: {
+      primaryKey: "letter",
+      enum: true,
+      enumName: "LetterAToDViaView",
+      behavior: extensions2.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_simple_enum_simple_enum = {
   executor: executor_mainPgExecutor,
   name: "simple_enum",
   identifier: "main.enum_tables.simple_enum",
   from: simpleEnumCodec.sqlType,
   codec: simpleEnumCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["value"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "referencing_table_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "simple_enum"
+    },
+    tags: {
+      enum: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
-const parts7 = ["enum_tables", "referencing_table_mutation"];
-const sqlIdent = sql.identifier(...parts7);
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "letter_descriptions"
-  },
-  tags: {
-    foreignKey: "(letter_via_view) references enum_tables.abcd_view"
-  }
-};
+const sqlIdent = sql.identifier("enum_tables", "referencing_table_mutation");
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -702,16 +634,17 @@ const registryConfig_pgResources_letter_descriptions_letter_descriptions = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "referencing_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "letter_descriptions"
+    },
+    tags: {
+      foreignKey: "(letter_via_view) references enum_tables.abcd_view"
+    }
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -730,76 +663,82 @@ const registryConfig_pgResources_referencing_table_referencing_table = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "lots_of_enums"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions12.tags.behavior
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "referencing_table"
+    },
+    tags: {}
   }
 };
-const uniques6 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}, {
-  isPrimary: false,
-  attributes: ["enum_1"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      enum: true,
-      enumName: "EnumTheFirst"
-    })
-  }
-}, {
-  isPrimary: false,
-  attributes: ["enum_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      enum: true,
-      enumName: "EnumTheSecond"
-    })
-  }
-}, {
-  isPrimary: false,
-  attributes: ["enum_3"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      enum: true
-    })
-  }
-}, {
-  isPrimary: false,
-  attributes: ["enum_4"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      enum: true
-    })
-  }
-}];
 const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
   executor: executor_mainPgExecutor,
   name: "lots_of_enums",
   identifier: "main.enum_tables.lots_of_enums",
   from: lotsOfEnumsCodec.sqlType,
   codec: lotsOfEnumsCodec,
-  uniques: uniques6,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }, {
+    isPrimary: false,
+    attributes: ["enum_1"],
+    description: undefined,
+    extensions: {
+      tags: Object.assign(Object.create(null), {
+        enum: true,
+        enumName: "EnumTheFirst"
+      })
+    }
+  }, {
+    isPrimary: false,
+    attributes: ["enum_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.assign(Object.create(null), {
+        enum: true,
+        enumName: "EnumTheSecond"
+      })
+    }
+  }, {
+    isPrimary: false,
+    attributes: ["enum_3"],
+    description: undefined,
+    extensions: {
+      tags: Object.assign(Object.create(null), {
+        enum: true
+      })
+    }
+  }, {
+    isPrimary: false,
+    attributes: ["enum_4"],
+    description: undefined,
+    extensions: {
+      tags: Object.assign(Object.create(null), {
+        enum: true
+      })
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions19
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "lots_of_enums"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -841,7 +780,16 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions16,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "enum_tables",
+          name: "referencing_table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     letter_descriptions: registryConfig_pgResources_letter_descriptions_letter_descriptions,
@@ -1120,21 +1068,6 @@ const fetcher2 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.ReferencingTable);
-function Query_allLetterDescriptions_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLetterDescriptions_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLetterDescriptions_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLetterDescriptions_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLetterDescriptions_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1153,47 +1086,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allReferencingTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReferencingTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReferencingTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReferencingTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReferencingTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function LetterDescriptionsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LetterDescriptionsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LetterDescriptionsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function ReferencingTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReferencingTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReferencingTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple = [{
   graphqlArgName: "t",
   postgresArgName: "t",
@@ -1246,204 +1138,22 @@ const makeArgs = (args, path = []) => {
   return selectArgs;
 };
 const resource_referencing_table_mutationPgResource = registry.pgResources["referencing_table_mutation"];
-function Mutation_referencingTableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLetterDescription_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReferencingTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LetterDescription, $nodeId);
 };
-function Mutation_updateLetterDescription_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLetterDescriptionById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLetterDescriptionByLetter_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLetterDescriptionByLetterViaView_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReferencingTable, $nodeId);
 };
-function Mutation_updateReferencingTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReferencingTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LetterDescription, $nodeId);
 };
-function Mutation_deleteLetterDescription_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLetterDescriptionById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLetterDescriptionByLetter_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLetterDescriptionByLetterViaView_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReferencingTable, $nodeId);
 };
-function Mutation_deleteReferencingTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReferencingTableById_input_applyPlan(_, $object) {
-  return $object;
-}
-function ReferencingTableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReferencingTableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReferencingTableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLetterDescriptionPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLetterDescriptionPayload_letterDescriptionPlan($object) {
-  return $object.get("result");
-}
-function CreateLetterDescriptionPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLetterDescriptionInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLetterDescriptionInput_letterDescription_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReferencingTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReferencingTablePayload_referencingTablePlan($object) {
-  return $object.get("result");
-}
-function CreateReferencingTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateReferencingTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReferencingTableInput_referencingTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLetterDescriptionPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLetterDescriptionPayload_letterDescriptionPlan($object) {
-  return $object.get("result");
-}
-function UpdateLetterDescriptionPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLetterDescriptionInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLetterDescriptionInput_letterDescriptionPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLetterDescriptionByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLetterDescriptionByIdInput_letterDescriptionPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLetterDescriptionByLetterInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLetterDescriptionByLetterInput_letterDescriptionPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLetterDescriptionByLetterViaViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLetterDescriptionByLetterViaViewInput_letterDescriptionPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReferencingTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReferencingTablePayload_referencingTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateReferencingTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReferencingTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReferencingTableInput_referencingTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReferencingTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReferencingTableByIdInput_referencingTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteLetterDescriptionPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLetterDescriptionPayload_letterDescriptionPlan($object) {
-  return $object.get("result");
-}
-function DeleteLetterDescriptionPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLetterDescriptionInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLetterDescriptionByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLetterDescriptionByLetterInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLetterDescriptionByLetterViaViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReferencingTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReferencingTablePayload_referencingTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteReferencingTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReferencingTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReferencingTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -2331,7 +2041,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -2409,23 +2121,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLetterDescriptions_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLetterDescriptions_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLetterDescriptions_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLetterDescriptions_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLetterDescriptions_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2452,23 +2174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReferencingTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReferencingTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReferencingTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReferencingTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReferencingTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2588,9 +2320,16 @@ export const plans = {
   },
   LetterDescriptionsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LetterDescriptionsConnection_nodesPlan,
-    edges: LetterDescriptionsConnection_edgesPlan,
-    pageInfo: LetterDescriptionsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -2606,8 +2345,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -2884,9 +2627,16 @@ export const plans = {
   },
   ReferencingTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReferencingTablesConnection_nodesPlan,
-    edges: ReferencingTablesConnection_edgesPlan,
-    pageInfo: ReferencingTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3237,7 +2987,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_referencingTableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3252,7 +3004,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLetterDescription_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3267,7 +3021,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReferencingTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3281,7 +3037,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLetterDescription_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3297,7 +3055,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLetterDescriptionById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3313,7 +3073,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLetterDescriptionByLetter_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3329,7 +3091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLetterDescriptionByLetterViaView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3343,7 +3107,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReferencingTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3359,7 +3125,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReferencingTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3373,7 +3141,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLetterDescription_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3389,7 +3159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLetterDescriptionById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3405,7 +3177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLetterDescriptionByLetter_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3421,7 +3195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLetterDescriptionByLetterViaView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3435,7 +3211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReferencingTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -3451,22 +3229,30 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReferencingTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   ReferencingTableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReferencingTableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: ReferencingTableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ReferencingTableMutationInput: {
     clientMutationId: {
-      applyPlan: ReferencingTableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     t: undefined
@@ -3510,9 +3296,15 @@ export const plans = {
   },
   CreateLetterDescriptionPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLetterDescriptionPayload_clientMutationIdPlan,
-    letterDescription: CreateLetterDescriptionPayload_letterDescriptionPlan,
-    query: CreateLetterDescriptionPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    letterDescription($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     letterDescriptionEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3547,11 +3339,16 @@ export const plans = {
   },
   CreateLetterDescriptionInput: {
     clientMutationId: {
-      applyPlan: CreateLetterDescriptionInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     letterDescription: {
-      applyPlan: CreateLetterDescriptionInput_letterDescription_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -3587,9 +3384,15 @@ export const plans = {
   },
   CreateReferencingTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReferencingTablePayload_clientMutationIdPlan,
-    referencingTable: CreateReferencingTablePayload_referencingTablePlan,
-    query: CreateReferencingTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    referencingTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     referencingTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3624,19 +3427,30 @@ export const plans = {
   },
   CreateReferencingTableInput: {
     clientMutationId: {
-      applyPlan: CreateReferencingTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     referencingTable: {
-      applyPlan: CreateReferencingTableInput_referencingTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   UpdateLetterDescriptionPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLetterDescriptionPayload_clientMutationIdPlan,
-    letterDescription: UpdateLetterDescriptionPayload_letterDescriptionPlan,
-    query: UpdateLetterDescriptionPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    letterDescription($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     letterDescriptionEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3671,11 +3485,16 @@ export const plans = {
   },
   UpdateLetterDescriptionInput: {
     clientMutationId: {
-      applyPlan: UpdateLetterDescriptionInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     letterDescriptionPatch: {
-      applyPlan: UpdateLetterDescriptionInput_letterDescriptionPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LetterDescriptionPatch: {
@@ -3710,36 +3529,57 @@ export const plans = {
   },
   UpdateLetterDescriptionByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLetterDescriptionByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     letterDescriptionPatch: {
-      applyPlan: UpdateLetterDescriptionByIdInput_letterDescriptionPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLetterDescriptionByLetterInput: {
     clientMutationId: {
-      applyPlan: UpdateLetterDescriptionByLetterInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     letter: undefined,
     letterDescriptionPatch: {
-      applyPlan: UpdateLetterDescriptionByLetterInput_letterDescriptionPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLetterDescriptionByLetterViaViewInput: {
     clientMutationId: {
-      applyPlan: UpdateLetterDescriptionByLetterViaViewInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     letterViaView: undefined,
     letterDescriptionPatch: {
-      applyPlan: UpdateLetterDescriptionByLetterViaViewInput_letterDescriptionPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReferencingTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReferencingTablePayload_clientMutationIdPlan,
-    referencingTable: UpdateReferencingTablePayload_referencingTablePlan,
-    query: UpdateReferencingTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    referencingTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     referencingTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3774,11 +3614,16 @@ export const plans = {
   },
   UpdateReferencingTableInput: {
     clientMutationId: {
-      applyPlan: UpdateReferencingTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     referencingTablePatch: {
-      applyPlan: UpdateReferencingTableInput_referencingTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReferencingTablePatch: {
@@ -3820,23 +3665,34 @@ export const plans = {
   },
   UpdateReferencingTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReferencingTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     referencingTablePatch: {
-      applyPlan: UpdateReferencingTableByIdInput_referencingTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteLetterDescriptionPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLetterDescriptionPayload_clientMutationIdPlan,
-    letterDescription: DeleteLetterDescriptionPayload_letterDescriptionPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    letterDescription($object) {
+      return $object.get("result");
+    },
     deletedLetterDescriptionId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LetterDescription.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLetterDescriptionPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     letterDescriptionEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3871,38 +3727,52 @@ export const plans = {
   },
   DeleteLetterDescriptionInput: {
     clientMutationId: {
-      applyPlan: DeleteLetterDescriptionInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLetterDescriptionByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLetterDescriptionByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLetterDescriptionByLetterInput: {
     clientMutationId: {
-      applyPlan: DeleteLetterDescriptionByLetterInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     letter: undefined
   },
   DeleteLetterDescriptionByLetterViaViewInput: {
     clientMutationId: {
-      applyPlan: DeleteLetterDescriptionByLetterViaViewInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     letterViaView: undefined
   },
   DeleteReferencingTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReferencingTablePayload_clientMutationIdPlan,
-    referencingTable: DeleteReferencingTablePayload_referencingTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    referencingTable($object) {
+      return $object.get("result");
+    },
     deletedReferencingTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReferencingTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReferencingTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     referencingTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -3937,13 +3807,17 @@ export const plans = {
   },
   DeleteReferencingTableInput: {
     clientMutationId: {
-      applyPlan: DeleteReferencingTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReferencingTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReferencingTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,29 +462,25 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(sekrit) references c.person (about)",
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(sekrit) references c.person (about)",
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -533,26 +510,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -591,26 +564,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -640,26 +609,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -698,39 +663,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -753,194 +711,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,29 +887,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -981,198 +918,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,29 +1101,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,29 +1131,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1244,81 +1162,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1424,48 +1330,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,37 +1375,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,37 +1413,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,37 +1451,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,37 +1489,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,37 +1527,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1670,209 +1566,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1890,1111 +1756,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3003,18 +2282,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    foreignKey: "(sekrit) references c.person (about)",
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3032,16 +2299,18 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      foreignKey: "(sekrit) references c.person (about)",
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3060,16 +2329,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3079,68 +2347,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3165,51 +2373,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3227,632 +2401,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3886,400 +2467,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4374,7 +2585,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4396,436 +2614,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4837,7 +3548,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4850,290 +3569,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5586,25 +5276,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5805,21 +5476,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6078,21 +5734,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs12(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6241,21 +5882,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs15(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6324,21 +5950,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs16(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6385,12 +5996,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6685,21 +6290,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs22(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6872,21 +6462,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs25(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6937,21 +6512,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs26(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -7048,21 +6608,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -7113,21 +6658,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs29(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7196,21 +6726,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs30(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7285,127 +6800,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -7979,21 +7374,6 @@ const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -8074,21 +7454,6 @@ const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -8188,51 +7553,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_personSecretsBySecret_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_personSecretsBySecret_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_personSecretsBySecret_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_personSecretsBySecret_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_personSecretsBySecret_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -8280,173 +7600,9 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -8493,26 +7649,6 @@ const makeArgs46 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -8559,9 +7695,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8608,9 +7741,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8657,9 +7787,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8706,9 +7833,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8761,9 +7885,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8816,9 +7937,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8871,9 +7989,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8926,9 +8041,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8981,9 +8093,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -9036,9 +8145,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9097,9 +8203,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -9146,9 +8249,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -9195,9 +8295,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -9244,9 +8341,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -9311,9 +8405,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -9360,9 +8451,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9415,9 +8503,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9470,9 +8555,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -9519,9 +8601,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9568,9 +8647,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9653,9 +8729,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9708,9 +8781,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9763,9 +8833,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9824,9 +8891,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9885,9 +8949,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -9934,9 +8995,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -9983,9 +9041,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -10032,851 +9087,62 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -15389,7 +13655,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -15503,27 +13771,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15553,23 +13834,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15613,23 +13904,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15650,23 +13951,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15681,23 +13992,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15709,11 +14030,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15763,23 +14088,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15812,23 +14147,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15840,23 +14185,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15872,23 +14227,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15900,23 +14265,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15944,23 +14319,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16034,23 +14419,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16077,23 +14472,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16120,23 +14525,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16163,23 +14578,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16206,23 +14631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16249,23 +14684,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16292,23 +14737,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16335,23 +14790,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16783,23 +15248,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16820,23 +15295,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16972,23 +15457,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17018,23 +15513,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17064,23 +15569,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17248,12 +15763,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -17346,9 +15873,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17364,8 +15898,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -17812,9 +16350,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18065,9 +16610,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18319,9 +16871,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18522,9 +17081,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18540,9 +17106,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18567,9 +17140,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18615,9 +17195,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18642,9 +17229,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18716,9 +17310,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18758,9 +17359,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19079,9 +17687,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19250,9 +17865,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19535,9 +18157,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19777,9 +18406,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20062,9 +18698,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20244,7 +18887,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20259,7 +18904,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20274,7 +18921,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20289,7 +18938,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20304,7 +18955,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20319,7 +18972,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20334,7 +18989,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20349,7 +19006,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20364,7 +19023,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20379,7 +19040,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20394,7 +19057,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20409,7 +19074,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20424,7 +19091,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20439,7 +19108,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20454,7 +19125,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20469,7 +19142,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20484,7 +19159,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20499,7 +19176,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20514,7 +19193,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20529,7 +19210,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20544,7 +19227,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20559,7 +19244,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20574,7 +19261,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20589,7 +19278,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20604,7 +19295,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20619,7 +19312,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20634,7 +19329,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20649,7 +19346,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20664,7 +19363,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20679,7 +19380,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20694,7 +19397,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20709,7 +19414,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20724,7 +19431,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20739,7 +19448,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20754,7 +19465,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20769,7 +19482,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20783,7 +19498,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20799,7 +19516,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20813,7 +19532,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20829,7 +19550,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20843,7 +19566,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20860,7 +19585,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20874,7 +19601,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20890,7 +19619,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20904,7 +19635,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20920,7 +19653,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20936,7 +19671,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20950,7 +19687,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20966,7 +19705,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20980,7 +19721,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20996,7 +19739,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21012,7 +19757,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21026,7 +19773,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21042,7 +19791,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21056,7 +19807,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21072,7 +19825,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21086,7 +19841,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21103,7 +19860,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21117,7 +19876,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21133,7 +19894,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21147,7 +19910,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21163,7 +19928,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21179,7 +19946,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21193,7 +19962,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21209,7 +19980,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21223,7 +19996,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21239,7 +20014,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21255,168 +20032,236 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -21424,11 +20269,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21441,17 +20290,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21464,17 +20319,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21487,21 +20348,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -21510,11 +20379,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21530,17 +20403,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21553,18 +20432,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21604,7 +20489,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -21641,11 +20528,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21680,35 +20571,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21720,11 +20625,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21743,33 +20652,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21797,7 +20718,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21805,11 +20728,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21837,7 +20764,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21845,11 +20774,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21884,43 +20817,63 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21955,11 +20908,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -21981,9 +20939,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22028,11 +20992,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22054,9 +21023,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22101,11 +21076,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22134,9 +21114,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22171,11 +21157,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22211,17 +21202,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22250,9 +21252,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22292,11 +21300,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22332,9 +21345,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22369,11 +21388,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22395,9 +21419,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22432,11 +21462,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22521,9 +21556,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22558,11 +21599,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -22583,18 +21629,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22639,11 +21696,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -22664,18 +21726,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22720,11 +21793,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -22752,19 +21830,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22799,11 +21888,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -22838,18 +21932,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22889,11 +21994,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -22928,27 +22038,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22983,11 +22109,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -23008,18 +22139,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23054,11 +22196,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -23142,32 +22289,48 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23202,26 +22365,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23266,26 +22439,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23330,27 +22513,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23385,26 +22578,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23444,32 +22647,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23504,26 +22719,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23558,19 +22783,25 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -493,17 +494,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -542,17 +543,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -600,17 +601,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -649,17 +650,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -707,16 +708,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -726,13 +727,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -744,7 +745,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -762,16 +763,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -781,10 +782,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -799,10 +799,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -817,15 +817,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -864,7 +864,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -873,7 +873,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -909,17 +909,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -930,7 +930,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -940,7 +940,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -950,7 +950,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -961,7 +961,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -971,7 +971,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -981,7 +981,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -990,7 +990,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -999,21 +999,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1021,7 +1021,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1041,7 +1041,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1051,23 +1051,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1106,7 +1106,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1115,7 +1115,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1123,7 +1123,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1133,17 +1133,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1154,7 +1154,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1162,7 +1162,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1172,7 +1172,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1182,7 +1182,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1203,7 +1203,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1213,7 +1213,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1234,7 +1234,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1244,7 +1244,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1252,13 +1252,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1267,13 +1267,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1282,16 +1282,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1299,7 +1299,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1309,17 +1309,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1342,7 +1342,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1360,7 +1360,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1369,7 +1369,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1424,7 +1424,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1434,20 +1434,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1465,7 +1465,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1475,7 +1475,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1486,7 +1486,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1494,7 +1494,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1504,7 +1504,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1514,7 +1514,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1525,7 +1525,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1533,7 +1533,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1543,7 +1543,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1553,7 +1553,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1564,7 +1564,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1572,7 +1572,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1582,7 +1582,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1592,7 +1592,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1603,7 +1603,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1611,7 +1611,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1621,7 +1621,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1631,7 +1631,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1642,7 +1642,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1650,7 +1650,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1660,7 +1660,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1670,7 +1670,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1678,13 +1678,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1693,13 +1693,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1708,13 +1708,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1723,12 +1723,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1737,12 +1737,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1751,12 +1751,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1764,16 +1764,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1782,7 +1782,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1799,7 +1799,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1809,17 +1809,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1828,13 +1828,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1842,7 +1842,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1850,20 +1850,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1871,13 +1871,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1889,8 +1889,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1956,7 +1956,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1965,7 +1965,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1974,7 +1974,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1983,7 +1983,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1992,7 +1992,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2019,7 +2019,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2028,7 +2028,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2037,7 +2037,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2046,7 +2046,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2109,7 +2109,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2127,7 +2127,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2136,7 +2136,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2145,7 +2145,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2154,7 +2154,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2280,7 +2280,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2289,7 +2289,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2307,7 +2307,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2316,7 +2316,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2325,7 +2325,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2333,7 +2333,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2345,17 +2345,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2363,7 +2363,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2371,13 +2371,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2386,12 +2386,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2402,8 +2402,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2415,10 +2415,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2430,10 +2430,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2444,10 +2444,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2459,10 +2459,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2474,10 +2474,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2488,10 +2488,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2502,10 +2502,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2516,10 +2516,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2531,15 +2531,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2551,15 +2551,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2571,15 +2571,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2591,15 +2591,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2610,15 +2610,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2629,15 +2629,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2648,15 +2648,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2667,15 +2667,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2686,15 +2686,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2705,15 +2705,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2725,8 +2725,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2738,7 +2738,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2749,10 +2749,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2763,10 +2763,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2777,10 +2777,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2792,8 +2792,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2805,7 +2805,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2816,10 +2816,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2830,10 +2830,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2844,10 +2844,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2858,10 +2858,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2872,15 +2872,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2891,8 +2891,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2909,7 +2909,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2920,8 +2920,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2938,7 +2938,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2949,10 +2949,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2963,15 +2963,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2983,10 +2983,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3003,7 +3003,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3027,14 +3027,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3055,14 +3055,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3079,7 +3079,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3090,21 +3090,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3122,7 +3122,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3132,7 +3132,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3160,26 +3160,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3201,7 +3201,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3222,20 +3222,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3254,12 +3254,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3277,7 +3277,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3288,8 +3288,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3309,7 +3309,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3319,9 +3319,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3332,8 +3332,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3353,7 +3353,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3363,9 +3363,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3376,15 +3376,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3395,15 +3395,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3414,15 +3414,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3433,8 +3433,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3452,12 +3452,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3475,7 +3475,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3491,20 +3491,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3528,16 +3528,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3561,10 +3561,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3579,15 +3579,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3599,15 +3599,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3618,15 +3618,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3638,20 +3638,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3662,20 +3662,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3687,20 +3687,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3711,15 +3711,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3730,8 +3730,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3743,7 +3743,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3754,8 +3754,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3767,7 +3767,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3778,8 +3778,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3791,7 +3791,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3802,8 +3802,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3815,7 +3815,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3826,13 +3826,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3844,7 +3844,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3881,26 +3881,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3918,16 +3918,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3947,12 +3947,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3971,12 +3971,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3995,12 +3995,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4019,12 +4019,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4043,12 +4043,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4067,12 +4067,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4093,12 +4093,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4117,18 +4117,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4147,18 +4147,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4177,18 +4177,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4206,22 +4206,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4244,22 +4244,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4277,7 +4277,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4298,40 +4298,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4342,21 +4342,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4366,22 +4366,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4389,14 +4389,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4409,7 +4409,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4422,7 +4422,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4435,7 +4435,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4448,7 +4448,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4461,7 +4461,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4474,7 +4474,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4487,7 +4487,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4500,7 +4500,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4513,7 +4513,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4526,7 +4526,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4539,7 +4539,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4552,7 +4552,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4565,7 +4565,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4578,7 +4578,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4591,7 +4591,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4604,7 +4604,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4617,7 +4617,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4630,7 +4630,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4643,7 +4643,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4656,7 +4656,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4669,7 +4669,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4682,7 +4682,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4695,7 +4695,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4708,7 +4708,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4721,7 +4721,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4734,7 +4734,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4747,7 +4747,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4760,7 +4760,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4773,7 +4773,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4786,7 +4786,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4799,7 +4799,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4812,7 +4812,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4825,19 +4825,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4845,12 +4845,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4862,7 +4862,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4870,12 +4870,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4892,7 +4892,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4905,7 +4905,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4918,7 +4918,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4931,7 +4931,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4944,7 +4944,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4957,7 +4957,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4973,7 +4973,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4986,7 +4986,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4999,7 +4999,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5012,7 +5012,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5025,7 +5025,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5038,7 +5038,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5051,7 +5051,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5064,7 +5064,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5077,7 +5077,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5090,7 +5090,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5103,7 +5103,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5116,7 +5116,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5138,7 +5138,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5153,7 +5153,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5170,7 +5170,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5187,7 +5187,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5204,7 +5204,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5219,7 +5219,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5234,7 +5234,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5249,7 +5249,7 @@ const registry = makeRegistry({
         }
       },
       personSecretsByTheirSekrit: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["about"],
@@ -5266,7 +5266,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMySekrit: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["sekrit"],
@@ -5281,7 +5281,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6458,7 +6458,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6470,7 +6470,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7654,7 +7654,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -9421,7 +9421,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9592,7 +9592,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9604,7 +9604,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -17440,7 +17440,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17456,7 +17456,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18114,7 +18114,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18130,7 +18130,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18262,7 +18262,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -18285,7 +18285,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -18308,7 +18308,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -18342,7 +18342,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18358,7 +18358,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18456,7 +18456,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -18479,7 +18479,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -18814,7 +18814,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -18837,7 +18837,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -18860,7 +18860,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -18883,7 +18883,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -18906,7 +18906,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -18929,7 +18929,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -18952,7 +18952,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -18975,7 +18975,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -18998,7 +18998,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -19021,7 +19021,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -19044,7 +19044,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -19102,7 +19102,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19118,7 +19118,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19216,7 +19216,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -19239,7 +19239,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -19273,7 +19273,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19289,7 +19289,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19455,7 +19455,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -19478,7 +19478,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -19501,7 +19501,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -19524,7 +19524,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -19720,7 +19720,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -19743,7 +19743,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -19766,7 +19766,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -19800,7 +19800,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19816,7 +19816,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19982,7 +19982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -20005,7 +20005,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -20028,7 +20028,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -20051,7 +20051,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -20085,7 +20085,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20101,7 +20101,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20199,7 +20199,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -20222,7 +20222,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -479,7 +479,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -524,7 +524,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -578,7 +578,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -623,7 +623,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -677,7 +677,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -725,7 +725,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -856,7 +856,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -885,7 +885,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -915,7 +915,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -978,7 +978,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1062,7 +1062,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1099,7 +1099,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1129,7 +1129,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1159,7 +1159,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1223,7 +1223,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1344,7 +1344,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1373,7 +1373,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1411,7 +1411,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1449,7 +1449,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1487,7 +1487,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1525,7 +1525,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1563,7 +1563,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1691,7 +1691,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2214,7 +2214,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2240,41 +2240,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2282,7 +2282,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2291,12 +2291,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2312,7 +2312,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2321,12 +2321,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2339,7 +2339,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2347,9 +2347,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2365,12 +2365,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2383,8 +2383,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2393,12 +2393,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2411,30 +2411,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2459,12 +2459,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2477,20 +2477,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2603,11 +2603,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2627,11 +2627,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2652,11 +2652,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2677,11 +2677,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2701,11 +2701,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2726,11 +2726,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2751,11 +2751,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2775,11 +2775,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2799,11 +2799,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2823,11 +2823,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2853,11 +2853,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2883,11 +2883,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2913,11 +2913,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2943,11 +2943,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2972,11 +2972,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3001,11 +3001,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3030,11 +3030,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3059,11 +3059,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3088,11 +3088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3117,11 +3117,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3152,11 +3152,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3176,11 +3176,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3200,11 +3200,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3224,11 +3224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3259,11 +3259,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3283,11 +3283,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3307,11 +3307,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3331,11 +3331,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3355,11 +3355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3384,11 +3384,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3423,11 +3423,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3462,11 +3462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3486,11 +3486,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3515,11 +3515,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3540,12 +3540,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3561,12 +3561,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3580,11 +3580,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3612,7 +3612,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3631,7 +3631,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3654,7 +3654,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3687,7 +3687,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3709,7 +3709,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3728,11 +3728,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3782,11 +3782,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3836,11 +3836,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3865,11 +3865,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3923,11 +3923,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3962,7 +3962,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3985,7 +3985,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4005,12 +4005,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4035,12 +4035,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4097,11 +4097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4127,11 +4127,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4156,11 +4156,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4191,11 +4191,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4225,11 +4225,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4260,11 +4260,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4289,11 +4289,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4323,11 +4323,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4357,11 +4357,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4391,11 +4391,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4425,11 +4425,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4466,12 +4466,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4498,7 +4498,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4521,7 +4521,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4543,7 +4543,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4565,7 +4565,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4587,7 +4587,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4609,7 +4609,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4631,7 +4631,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4655,7 +4655,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4677,7 +4677,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4705,7 +4705,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4731,12 +4731,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4761,12 +4761,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4796,12 +4796,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -15977,7 +15977,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15993,7 +15993,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16665,7 +16665,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16681,7 +16681,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16900,7 +16900,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16916,7 +16916,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17716,7 +17716,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17732,7 +17732,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17894,7 +17894,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17910,7 +17910,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18435,7 +18435,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18451,7 +18451,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18727,7 +18727,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18743,7 +18743,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20460,7 +20460,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20547,7 +20547,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20793,7 +20793,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20884,7 +20884,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20958,7 +20958,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21042,7 +21042,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21133,7 +21133,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21271,7 +21271,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21364,7 +21364,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21438,7 +21438,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21575,7 +21575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21662,7 +21662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21759,7 +21759,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21864,7 +21864,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21965,7 +21965,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22085,7 +22085,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22172,7 +22172,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22341,7 +22341,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22405,7 +22405,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22479,7 +22479,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22554,7 +22554,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22618,7 +22618,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22695,7 +22695,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22759,7 +22759,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -493,17 +494,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -542,17 +543,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -600,17 +601,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -649,17 +650,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -707,16 +708,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -726,13 +727,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -744,7 +745,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -762,16 +763,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -781,10 +782,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -799,10 +799,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -817,15 +817,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -864,7 +864,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -873,7 +873,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -909,17 +909,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -930,7 +930,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -940,7 +940,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -950,7 +950,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -961,7 +961,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -971,7 +971,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -981,7 +981,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -990,7 +990,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -999,21 +999,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1021,7 +1021,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1041,7 +1041,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1051,23 +1051,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1106,7 +1106,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1115,7 +1115,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1123,7 +1123,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1133,17 +1133,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1154,7 +1154,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1162,7 +1162,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1172,7 +1172,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1182,7 +1182,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1203,7 +1203,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1213,7 +1213,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1234,7 +1234,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1244,7 +1244,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1252,13 +1252,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1267,13 +1267,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1282,16 +1282,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1299,7 +1299,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1309,17 +1309,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1342,7 +1342,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1360,7 +1360,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1369,7 +1369,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1424,7 +1424,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1434,20 +1434,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1465,7 +1465,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1475,7 +1475,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1486,7 +1486,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1494,7 +1494,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1504,7 +1504,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1514,7 +1514,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1525,7 +1525,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1533,7 +1533,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1543,7 +1543,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1553,7 +1553,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1564,7 +1564,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1572,7 +1572,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1582,7 +1582,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1592,7 +1592,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1603,7 +1603,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1611,7 +1611,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1621,7 +1621,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1631,7 +1631,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1642,7 +1642,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1650,7 +1650,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1660,7 +1660,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1670,7 +1670,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1678,13 +1678,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1693,13 +1693,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1708,13 +1708,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1723,12 +1723,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1737,12 +1737,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1751,12 +1751,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1764,16 +1764,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1782,7 +1782,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1799,7 +1799,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1809,17 +1809,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1828,13 +1828,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1842,7 +1842,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1850,20 +1850,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1871,13 +1871,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1889,8 +1889,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1956,7 +1956,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1965,7 +1965,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1974,7 +1974,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1983,7 +1983,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1992,7 +1992,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2019,7 +2019,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2028,7 +2028,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2037,7 +2037,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2046,7 +2046,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2109,7 +2109,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2127,7 +2127,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2136,7 +2136,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2145,7 +2145,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2154,7 +2154,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2280,7 +2280,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2289,7 +2289,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2307,7 +2307,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2316,7 +2316,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2325,7 +2325,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2333,7 +2333,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2345,17 +2345,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2363,7 +2363,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2371,13 +2371,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2386,12 +2386,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2402,8 +2402,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2415,10 +2415,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2430,10 +2430,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2444,10 +2444,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2459,10 +2459,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2474,10 +2474,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2488,10 +2488,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2502,10 +2502,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2516,10 +2516,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2531,15 +2531,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2551,15 +2551,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2571,15 +2571,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2591,15 +2591,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2610,15 +2610,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2629,15 +2629,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2648,15 +2648,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2667,15 +2667,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2686,15 +2686,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2705,15 +2705,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2725,8 +2725,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2738,7 +2738,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2749,10 +2749,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2763,10 +2763,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2777,10 +2777,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2792,8 +2792,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2805,7 +2805,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2816,10 +2816,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2830,10 +2830,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2844,10 +2844,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2858,10 +2858,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2872,15 +2872,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2891,8 +2891,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2909,7 +2909,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2920,8 +2920,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2938,7 +2938,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2949,10 +2949,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2963,15 +2963,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2983,10 +2983,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3003,7 +3003,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3027,14 +3027,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3055,14 +3055,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3079,7 +3079,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3090,21 +3090,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3122,7 +3122,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3132,7 +3132,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3160,26 +3160,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3201,7 +3201,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3222,20 +3222,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3254,12 +3254,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3277,7 +3277,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3288,8 +3288,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3309,7 +3309,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3319,9 +3319,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3332,8 +3332,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3353,7 +3353,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3363,9 +3363,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3376,15 +3376,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3395,15 +3395,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3414,15 +3414,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3433,8 +3433,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3452,12 +3452,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3475,7 +3475,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3491,20 +3491,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3528,16 +3528,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3561,10 +3561,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3579,15 +3579,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3599,15 +3599,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3618,15 +3618,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3638,20 +3638,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3662,20 +3662,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3687,20 +3687,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3711,15 +3711,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3730,8 +3730,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3743,7 +3743,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3754,8 +3754,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3767,7 +3767,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3778,8 +3778,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3791,7 +3791,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3802,8 +3802,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3815,7 +3815,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3826,13 +3826,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3844,7 +3844,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3879,26 +3879,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3916,16 +3916,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3945,12 +3945,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3969,12 +3969,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3993,12 +3993,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4017,12 +4017,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4041,12 +4041,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4065,12 +4065,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4091,12 +4091,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4115,18 +4115,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4145,18 +4145,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4175,18 +4175,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4204,22 +4204,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4242,22 +4242,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4275,7 +4275,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4296,40 +4296,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4340,21 +4340,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4364,22 +4364,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4387,14 +4387,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4407,7 +4407,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4420,7 +4420,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4433,7 +4433,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4446,7 +4446,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4459,7 +4459,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4472,7 +4472,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4485,7 +4485,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4498,7 +4498,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4511,7 +4511,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4524,7 +4524,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4537,7 +4537,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4550,7 +4550,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4563,7 +4563,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4576,7 +4576,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4589,7 +4589,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4602,7 +4602,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4615,7 +4615,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4628,7 +4628,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4641,7 +4641,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4654,7 +4654,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4667,7 +4667,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4680,7 +4680,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4693,7 +4693,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4706,7 +4706,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4719,7 +4719,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4732,7 +4732,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4745,7 +4745,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4758,7 +4758,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4771,7 +4771,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4784,7 +4784,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4797,7 +4797,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4810,7 +4810,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4823,19 +4823,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4843,12 +4843,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4860,7 +4860,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4868,12 +4868,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4890,7 +4890,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4903,7 +4903,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4916,7 +4916,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4929,7 +4929,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4942,7 +4942,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4955,7 +4955,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4971,7 +4971,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4984,7 +4984,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4997,7 +4997,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5010,7 +5010,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5023,7 +5023,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5036,7 +5036,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5049,7 +5049,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5062,7 +5062,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5075,7 +5075,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5088,7 +5088,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5101,7 +5101,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5114,7 +5114,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5136,7 +5136,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5151,7 +5151,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5168,7 +5168,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5185,7 +5185,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5202,7 +5202,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5217,7 +5217,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5232,7 +5232,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5247,7 +5247,7 @@ const registry = makeRegistry({
         }
       },
       personSecretsByTheirSekrit: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["about"],
@@ -5264,7 +5264,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMySekrit: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["sekrit"],
@@ -5279,7 +5279,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6456,7 +6456,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6468,7 +6468,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7652,7 +7652,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -9419,7 +9419,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9590,7 +9590,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9602,7 +9602,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -17508,7 +17508,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17524,7 +17524,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18182,7 +18182,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18198,7 +18198,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18330,7 +18330,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -18353,7 +18353,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -18376,7 +18376,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -18410,7 +18410,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18426,7 +18426,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18524,7 +18524,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -18547,7 +18547,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -18882,7 +18882,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -18905,7 +18905,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -18928,7 +18928,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -18951,7 +18951,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -18974,7 +18974,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -18997,7 +18997,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -19020,7 +19020,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -19043,7 +19043,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -19066,7 +19066,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -19089,7 +19089,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -19112,7 +19112,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -19170,7 +19170,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19186,7 +19186,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19284,7 +19284,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -19307,7 +19307,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -19341,7 +19341,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19357,7 +19357,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19523,7 +19523,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -19546,7 +19546,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -19569,7 +19569,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -19592,7 +19592,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -19788,7 +19788,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -19811,7 +19811,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -19834,7 +19834,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -19868,7 +19868,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19884,7 +19884,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20050,7 +20050,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -20073,7 +20073,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -20096,7 +20096,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -20119,7 +20119,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -20153,7 +20153,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20169,7 +20169,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20267,7 +20267,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -20290,7 +20290,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -479,7 +479,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -524,7 +524,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -578,7 +578,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -623,7 +623,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -677,7 +677,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -725,7 +725,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -856,7 +856,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -885,7 +885,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -915,7 +915,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -978,7 +978,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1062,7 +1062,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1099,7 +1099,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1129,7 +1129,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1159,7 +1159,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1223,7 +1223,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1344,7 +1344,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1373,7 +1373,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1411,7 +1411,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1449,7 +1449,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1487,7 +1487,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1525,7 +1525,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1563,7 +1563,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1691,7 +1691,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2214,7 +2214,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2240,41 +2240,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2282,7 +2282,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2291,12 +2291,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2312,7 +2312,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2321,12 +2321,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2339,7 +2339,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2347,9 +2347,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2365,12 +2365,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2383,8 +2383,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2393,12 +2393,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2411,30 +2411,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2457,12 +2457,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2475,20 +2475,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2601,11 +2601,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2625,11 +2625,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2650,11 +2650,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2675,11 +2675,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2699,11 +2699,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2724,11 +2724,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2749,11 +2749,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2773,11 +2773,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2797,11 +2797,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2821,11 +2821,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2851,11 +2851,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2881,11 +2881,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2911,11 +2911,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2941,11 +2941,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2970,11 +2970,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2999,11 +2999,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3028,11 +3028,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3057,11 +3057,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3086,11 +3086,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3115,11 +3115,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3150,11 +3150,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3174,11 +3174,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3198,11 +3198,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3222,11 +3222,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3257,11 +3257,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3281,11 +3281,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3305,11 +3305,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3329,11 +3329,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3353,11 +3353,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3382,11 +3382,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3421,11 +3421,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3460,11 +3460,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3484,11 +3484,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3513,11 +3513,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3538,12 +3538,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3559,12 +3559,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3578,11 +3578,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3610,7 +3610,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3629,7 +3629,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3652,7 +3652,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3685,7 +3685,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3707,7 +3707,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3726,11 +3726,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3780,11 +3780,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3834,11 +3834,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3863,11 +3863,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3892,11 +3892,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3921,11 +3921,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3960,7 +3960,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3983,7 +3983,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4003,12 +4003,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4033,12 +4033,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4062,11 +4062,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4095,11 +4095,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4125,11 +4125,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4154,11 +4154,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4189,11 +4189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4223,11 +4223,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4258,11 +4258,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4287,11 +4287,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4321,11 +4321,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4355,11 +4355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4389,11 +4389,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4423,11 +4423,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4464,12 +4464,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4496,7 +4496,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4519,7 +4519,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4541,7 +4541,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4563,7 +4563,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4585,7 +4585,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4607,7 +4607,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4629,7 +4629,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4653,7 +4653,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4675,7 +4675,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4703,7 +4703,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4729,12 +4729,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4759,12 +4759,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4794,12 +4794,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -16029,7 +16029,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16045,7 +16045,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16717,7 +16717,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16733,7 +16733,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16952,7 +16952,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16968,7 +16968,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17768,7 +17768,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17784,7 +17784,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17946,7 +17946,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17962,7 +17962,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18487,7 +18487,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18503,7 +18503,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18779,7 +18779,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18795,7 +18795,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20548,7 +20548,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20635,7 +20635,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20881,7 +20881,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20972,7 +20972,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21046,7 +21046,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21130,7 +21130,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21221,7 +21221,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21359,7 +21359,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21452,7 +21452,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21526,7 +21526,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21663,7 +21663,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21750,7 +21750,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21847,7 +21847,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21952,7 +21952,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22053,7 +22053,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22173,7 +22173,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22260,7 +22260,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22443,7 +22443,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22507,7 +22507,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22581,7 +22581,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22656,7 +22656,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22720,7 +22720,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22797,7 +22797,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22861,7 +22861,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,29 +462,25 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(sekrit) references c.person (about)",
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(sekrit) references c.person (about)",
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -533,26 +510,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -591,26 +564,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -640,26 +609,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -698,39 +663,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -753,194 +711,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,29 +887,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -981,198 +918,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,29 +1101,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,29 +1131,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1244,81 +1162,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1424,48 +1330,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,37 +1375,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,37 +1413,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,37 +1451,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,37 +1489,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,37 +1527,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1670,209 +1566,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1890,1111 +1756,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3003,18 +2282,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    foreignKey: "(sekrit) references c.person (about)",
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3032,16 +2299,18 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      foreignKey: "(sekrit) references c.person (about)",
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3060,16 +2329,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3079,68 +2347,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3165,51 +2373,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3227,632 +2401,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3884,400 +2465,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4372,7 +2583,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4394,436 +2612,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4835,7 +3546,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4848,290 +3567,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5584,25 +5274,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5803,21 +5474,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6076,21 +5732,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs12(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6239,21 +5880,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs15(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6322,21 +5948,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs16(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6383,12 +5994,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6683,21 +6288,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs22(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6870,21 +6460,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs25(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6935,21 +6510,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs26(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -7046,21 +6606,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -7111,21 +6656,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs29(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7194,21 +6724,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs30(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7283,127 +6798,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -7977,21 +7372,6 @@ const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -8072,21 +7452,6 @@ const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -8186,51 +7551,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_personSecretsBySecret_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_personSecretsBySecret_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_personSecretsBySecret_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_personSecretsBySecret_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_personSecretsBySecret_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -8278,173 +7598,9 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -8491,26 +7647,6 @@ const makeArgs46 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -8557,9 +7693,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8606,9 +7739,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8655,9 +7785,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8704,9 +7831,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8759,9 +7883,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8814,9 +7935,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8869,9 +7987,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8924,9 +8039,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8979,9 +8091,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -9034,9 +8143,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9095,9 +8201,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -9144,9 +8247,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -9193,9 +8293,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -9242,9 +8339,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -9309,9 +8403,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -9358,9 +8449,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9413,9 +8501,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9468,9 +8553,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -9517,9 +8599,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9566,9 +8645,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9651,9 +8727,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9706,9 +8779,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9761,9 +8831,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9822,9 +8889,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9883,9 +8947,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -9932,9 +8993,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -9981,9 +9039,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -10030,867 +9085,62 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByAbout_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByAbout_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByAboutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByAboutInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByAboutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -15447,7 +13697,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -15571,27 +13823,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15621,23 +13886,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15681,23 +13956,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15718,23 +14003,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15749,23 +14044,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15777,11 +14082,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15831,23 +14140,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15880,23 +14199,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15908,23 +14237,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15940,23 +14279,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15968,23 +14317,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16012,23 +14371,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16102,23 +14471,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16145,23 +14524,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16188,23 +14577,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16231,23 +14630,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16274,23 +14683,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16317,23 +14736,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16360,23 +14789,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16403,23 +14842,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16851,23 +15300,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16888,23 +15347,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -17040,23 +15509,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17086,23 +15565,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17132,23 +15621,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_personSecretsBySecret_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17316,12 +15815,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -17414,9 +15925,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17432,8 +15950,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -17880,9 +16402,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18133,9 +16662,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18387,9 +16923,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18590,9 +17133,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18608,9 +17158,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18635,9 +17192,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18683,9 +17247,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18710,9 +17281,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18784,9 +17362,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18826,9 +17411,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19147,9 +17739,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19318,9 +17917,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19603,9 +18209,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19845,9 +18458,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20130,9 +18750,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20312,7 +18939,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20327,7 +18956,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20342,7 +18973,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20357,7 +18990,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20372,7 +19007,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20387,7 +19024,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20402,7 +19041,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20417,7 +19058,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20432,7 +19075,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20447,7 +19092,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20462,7 +19109,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20477,7 +19126,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20492,7 +19143,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20507,7 +19160,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20522,7 +19177,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20537,7 +19194,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20552,7 +19211,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20567,7 +19228,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20582,7 +19245,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20597,7 +19262,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20612,7 +19279,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20627,7 +19296,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20642,7 +19313,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20657,7 +19330,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20672,7 +19347,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20687,7 +19364,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20702,7 +19381,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20717,7 +19398,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20732,7 +19415,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20747,7 +19432,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20762,7 +19449,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20777,7 +19466,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20792,7 +19483,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20807,7 +19500,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20822,7 +19517,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20837,7 +19534,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20851,7 +19550,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20867,7 +19568,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20881,7 +19584,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20897,7 +19602,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20911,7 +19618,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20928,7 +19637,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20942,7 +19653,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20958,7 +19671,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20972,7 +19687,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20988,7 +19705,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21004,7 +19723,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21018,7 +19739,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21034,7 +19757,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21048,7 +19773,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21064,7 +19791,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21080,7 +19809,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByAbout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21096,7 +19827,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21110,7 +19843,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21126,7 +19861,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21140,7 +19877,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21156,7 +19895,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21170,7 +19911,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21187,7 +19930,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21201,7 +19946,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21217,7 +19964,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21231,7 +19980,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21247,7 +19998,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21263,7 +20016,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21277,7 +20032,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21293,7 +20050,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21307,7 +20066,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21323,7 +20084,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21339,7 +20102,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByAbout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21355,168 +20120,236 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -21524,11 +20357,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21541,17 +20378,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21564,17 +20407,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21587,21 +20436,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -21610,11 +20467,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21630,17 +20491,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21653,18 +20520,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21704,7 +20577,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -21741,11 +20616,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21780,35 +20659,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21820,11 +20713,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21843,33 +20740,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21897,7 +20806,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21905,11 +20816,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21937,7 +20852,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21945,11 +20862,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21984,43 +20905,63 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22055,11 +20996,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22081,9 +21027,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22128,11 +21080,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22154,9 +21111,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22201,11 +21164,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22234,9 +21202,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22271,11 +21245,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22311,17 +21290,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22350,9 +21340,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22392,11 +21388,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22432,9 +21433,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22469,11 +21476,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22495,9 +21507,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22532,11 +21550,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22621,9 +21644,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22658,11 +21687,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -22683,18 +21717,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22739,11 +21784,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -22764,18 +21814,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22820,11 +21881,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -22852,19 +21918,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22899,11 +21976,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -22938,18 +22020,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22989,11 +22082,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -23028,27 +22126,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23083,11 +22197,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -23108,18 +22227,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23154,11 +22284,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -23242,41 +22377,62 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByAboutInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByAboutInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     about: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByAboutInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23311,26 +22467,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23375,26 +22541,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23439,27 +22615,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23494,26 +22680,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23553,32 +22749,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23613,26 +22821,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23667,25 +22885,33 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByAboutInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByAboutInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     about: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1942,47 +1792,43 @@ const extensions33 = {
     behavior: ["-insert"]
   })
 };
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
   extensions: extensions33,
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1991,29 +1837,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2022,29 +1867,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2054,67 +1898,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2220,48 +2053,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2270,37 +2098,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2309,37 +2136,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2348,37 +2174,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2387,37 +2212,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2426,37 +2250,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2466,195 +2289,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3126,1496 +2920,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4624,15 +3036,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4641,15 +3044,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4658,15 +3052,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4675,15 +3060,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4692,15 +3068,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4709,93 +3076,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4805,17 +3132,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4833,16 +3149,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4852,15 +3169,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4878,16 +3186,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4897,15 +3204,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4914,37 +3212,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4953,97 +3220,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5068,103 +3247,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5182,574 +3297,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {
-    omit: "create",
-    behavior: extensions33.tags.behavior
-  }
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5767,761 +3343,67 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      omit: "create",
+      behavior: extensions33.tags.behavior
     }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["a", "create_post"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_create_post = {
-  name: "create_post",
-  identifier: "main.a.create_post(text)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "t",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "create_post"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_mutation"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts144 = ["c", "table_query"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "post_with_suffix"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "mutation_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["a", "query_compound_type_array"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_mutation"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["b", "compound_type_array_query"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_computed_compound_type_array"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts151 = ["a", "post_many"];
-const sqlIdent109 = sql.identifier(...parts151);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts152 = ["c", "person_computed_out"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback80 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts153 = ["c", "person_first_name"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback81 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts154 = ["c", "person_computed_out_out"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback82 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts155 = ["c", "person_computed_inout"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback83 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_computed_inout_out"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback84 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_exists"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback85 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback86 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback87 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "func_out_complex_setof"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback88 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback89 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "mutation_out_complex_setof"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback90 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts163 = ["c", "person_computed_complex"];
-const sqlIdent121 = sql.identifier(...parts163);
-const fromCallback91 = (...args) => sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts164 = ["c", "person_first_post"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("a", "create_post");
+const sqlIdent101 = sql.identifier("c", "table_mutation");
+const sqlIdent102 = sql.identifier("c", "table_query");
+const sqlIdent103 = sql.identifier("a", "post_with_suffix");
+const sqlIdent104 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent105 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent107 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent108 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent109 = sql.identifier("a", "post_many");
+const sqlIdent110 = sql.identifier("c", "person_computed_out");
+const sqlIdent111 = sql.identifier("c", "person_first_name");
+const sqlIdent112 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout");
+const sqlIdent114 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent115 = sql.identifier("c", "person_exists");
+const sqlIdent116 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent117 = sql.identifier("c", "func_out_complex");
+const sqlIdent118 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent120 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent121 = sql.identifier("c", "person_computed_complex");
+const sqlIdent122 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6546,274 +3428,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts165 = ["c", "badly_behaved_function"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "func_out_table_setof"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "mutation_out_table_setof"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_mutation"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "table_set_query_plpgsql"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts174 = ["c", "person_friends"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent123 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent124 = sql.identifier("c", "func_out_table");
+const sqlIdent125 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table");
+const sqlIdent127 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent128 = sql.identifier("c", "table_set_mutation");
+const sqlIdent129 = sql.identifier("c", "table_set_query");
+const sqlIdent130 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent131 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent132 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6831,254 +3465,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts175 = ["b", "type_function_connection"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts176 = ["b", "type_function_connection_mutation"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["b", "type_function_mutation"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function_connection"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["c", "person_type_function"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["b", "type_function_list_mutation"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts183 = ["c", "person_type_function_list"];
-const sqlIdent141 = sql.identifier(...parts183);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent133 = sql.identifier("b", "type_function_connection");
+const sqlIdent134 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent135 = sql.identifier("b", "type_function");
+const sqlIdent136 = sql.identifier("b", "type_function_mutation");
+const sqlIdent137 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent138 = sql.identifier("c", "person_type_function");
+const sqlIdent139 = sql.identifier("b", "type_function_list");
+const sqlIdent140 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent141 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7193,19 +3600,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7214,9 +3642,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7231,813 +3815,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8049,7 +5666,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8060,7 +5687,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8071,7 +5706,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8082,7 +5725,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8093,7 +5744,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8104,7 +5763,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8115,7 +5782,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8124,10 +5799,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8135,10 +5825,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8150,7 +5848,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8162,7 +5868,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8174,7 +5888,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8185,7 +5907,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8193,10 +5923,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8207,33 +5957,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8242,395 +6063,2038 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    create_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_create_post),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    create_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "create_post",
+      identifier: "main.a.create_post(text)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "t",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "create_post"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9480,25 +8944,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9641,21 +9086,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9706,21 +9136,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9829,21 +9244,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10334,21 +9734,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10441,12 +9826,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10869,21 +10248,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10952,21 +10316,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11353,21 +10702,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11696,21 +11030,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11761,21 +11080,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11872,21 +11176,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11937,21 +11226,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -12020,21 +11294,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12085,21 +11344,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12361,385 +11605,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13313,21 +12182,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13408,21 +12262,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13522,66 +12361,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13629,24 +12408,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13727,21 +12488,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14165,348 +12911,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14553,26 +12958,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14619,9 +13004,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14668,9 +13050,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14717,9 +13096,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14766,9 +13142,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14815,9 +13188,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14864,9 +13234,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14919,9 +13286,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14974,9 +13338,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15029,9 +13390,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15084,9 +13442,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15139,9 +13494,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15194,9 +13546,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15255,9 +13604,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15316,9 +13662,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15377,9 +13720,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15438,9 +13778,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15499,9 +13836,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15560,9 +13894,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15621,9 +13952,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15682,9 +14010,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15743,9 +14068,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15804,9 +14126,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15853,9 +14172,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15902,9 +14218,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15951,9 +14264,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -16018,9 +14328,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16067,9 +14374,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16122,9 +14426,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16177,9 +14478,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16226,9 +14524,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16275,9 +14570,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16342,9 +14634,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16391,9 +14680,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16458,9 +14744,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16513,9 +14796,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16562,9 +14842,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16611,9 +14888,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16678,9 +14952,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16745,9 +15016,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16830,9 +15098,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16885,9 +15150,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16940,9 +15202,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16995,9 +15254,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "t",
   postgresArgName: "t",
@@ -17050,9 +15306,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_create_postPgResource = registry.pgResources["create_post"];
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17105,9 +15358,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17160,9 +15410,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17215,9 +15462,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17276,9 +15520,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17337,9 +15578,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [];
 const makeArgs124 = (args, path = []) => {
   const selectArgs = [];
@@ -17386,9 +15624,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17435,9 +15670,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17484,9 +15716,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17533,9 +15762,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17588,9 +15814,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
@@ -17637,2033 +15860,151 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29682,7 +26023,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -29928,27 +26271,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29968,23 +26324,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29996,23 +26362,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30034,23 +26410,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30134,23 +26520,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30166,11 +26562,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30242,23 +26642,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30273,23 +26683,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30347,23 +26767,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30423,23 +26853,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30451,23 +26891,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30483,23 +26933,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30511,23 +26971,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30555,23 +27025,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30583,23 +27063,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30785,23 +27275,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30828,23 +27328,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30871,23 +27381,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30914,23 +27434,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30957,23 +27487,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31000,23 +27540,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31043,23 +27593,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31086,23 +27646,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31129,23 +27699,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31172,23 +27752,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31215,23 +27805,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31258,23 +27858,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31301,23 +27911,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31344,23 +27964,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31387,23 +28017,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31430,23 +28070,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31473,23 +28123,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31516,23 +28176,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31559,23 +28229,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31602,23 +28282,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31645,23 +28335,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31688,23 +28388,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31731,23 +28441,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31774,23 +28494,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31934,23 +28664,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32352,23 +29092,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32389,23 +29139,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32531,23 +29291,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32577,23 +29347,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32633,23 +29413,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32679,23 +29469,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32863,12 +29663,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -32884,23 +29696,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33245,23 +30067,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33289,9 +30121,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33307,8 +30146,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33449,9 +30292,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36115,9 +32965,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36576,9 +33433,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36968,9 +33832,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37229,9 +34100,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37556,9 +34434,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37574,9 +34459,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37592,9 +34484,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37610,9 +34509,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37637,9 +34543,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37694,9 +34607,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37721,9 +34641,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37786,9 +34713,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37828,9 +34762,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38149,9 +35090,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38237,9 +35185,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38351,9 +35306,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38465,9 +35427,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38579,9 +35548,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38693,9 +35669,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38807,9 +35790,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38978,9 +35968,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39117,9 +36114,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39325,9 +36329,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39496,9 +36507,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39667,9 +36685,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39895,9 +36920,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40180,9 +37212,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40465,9 +37504,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40733,9 +37779,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41018,9 +38071,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41260,9 +38320,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41545,9 +38612,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41727,7 +38801,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41742,7 +38818,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41757,7 +38835,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41772,7 +38852,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41787,7 +38869,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41802,7 +38886,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41817,7 +38903,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41832,7 +38920,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41847,7 +38937,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41862,7 +38954,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41877,7 +38971,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41892,7 +38988,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41907,7 +39005,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41922,7 +39022,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41937,7 +39039,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41952,7 +39056,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41967,7 +39073,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41982,7 +39090,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41997,7 +39107,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42012,7 +39124,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42027,7 +39141,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42042,7 +39158,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42057,7 +39175,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42072,7 +39192,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42087,7 +39209,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42102,7 +39226,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42117,7 +39243,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42132,7 +39260,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42147,7 +39277,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42162,7 +39294,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42177,7 +39311,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42192,7 +39328,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42207,7 +39345,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42222,7 +39362,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42237,7 +39379,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42252,7 +39396,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42267,7 +39413,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42282,7 +39430,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42297,7 +39447,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42312,7 +39464,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42327,7 +39481,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42342,7 +39498,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42357,7 +39515,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42372,7 +39532,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42387,7 +39549,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42402,7 +39566,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42417,7 +39583,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42432,7 +39600,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42447,7 +39617,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42462,7 +39634,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42477,7 +39651,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42492,7 +39668,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42507,7 +39685,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42522,7 +39702,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42537,7 +39719,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42552,7 +39736,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42567,7 +39753,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42582,7 +39770,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42597,7 +39787,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42612,7 +39804,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42627,7 +39821,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42642,7 +39838,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42657,7 +39855,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42672,7 +39872,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42687,7 +39889,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42702,7 +39906,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42717,7 +39923,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42732,7 +39940,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42747,7 +39957,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42762,7 +39974,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42777,7 +39991,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42792,7 +40008,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42807,7 +40025,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42822,7 +40042,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42837,7 +40059,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42852,7 +40076,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42867,7 +40093,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42881,7 +40109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42897,7 +40127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42911,7 +40143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42927,7 +40161,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42941,7 +40177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42957,7 +40195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42971,7 +40211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42987,7 +40229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43001,7 +40245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43017,7 +40263,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43031,7 +40279,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43047,7 +40297,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43063,7 +40315,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43077,7 +40331,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43093,7 +40349,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43107,7 +40365,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43123,7 +40383,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43137,7 +40399,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43153,7 +40417,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43167,7 +40433,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43184,7 +40452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43198,7 +40468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43214,7 +40486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43228,7 +40502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43244,7 +40520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43258,7 +40536,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43274,7 +40554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43288,7 +40570,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43304,7 +40588,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43320,7 +40606,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43334,7 +40622,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43350,7 +40640,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43364,7 +40656,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43380,7 +40674,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43394,7 +40690,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43410,7 +40708,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43426,7 +40726,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43440,7 +40742,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43456,7 +40760,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43470,7 +40776,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43486,7 +40794,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43500,7 +40810,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43516,7 +40828,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43530,7 +40844,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43546,7 +40862,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43560,7 +40878,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43576,7 +40896,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43590,7 +40912,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43606,7 +40930,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43620,7 +40946,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43636,7 +40964,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43652,7 +40982,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43666,7 +40998,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43682,7 +41016,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43696,7 +41032,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43712,7 +41050,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43726,7 +41066,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43742,7 +41084,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43756,7 +41100,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43773,7 +41119,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43787,7 +41135,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43803,7 +41153,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43817,7 +41169,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43833,7 +41187,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43847,7 +41203,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43863,7 +41221,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43877,7 +41237,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43893,7 +41255,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43909,7 +41273,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43923,7 +41289,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43939,7 +41307,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43953,7 +41323,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43969,7 +41341,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43983,7 +41357,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43999,7 +41375,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44015,7 +41393,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44029,7 +41409,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44045,193 +41427,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44239,15 +41701,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44255,15 +41723,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44271,15 +41745,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44287,15 +41767,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44303,15 +41789,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44319,15 +41811,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44335,15 +41833,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44351,15 +41855,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44367,15 +41877,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44383,11 +41899,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44400,17 +41920,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44423,17 +41949,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44446,21 +41978,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44469,11 +42009,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44489,17 +42033,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44512,65 +42062,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44579,11 +42155,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44605,21 +42185,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44628,11 +42216,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44672,7 +42264,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44709,11 +42303,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44748,35 +42346,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44785,11 +42397,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44821,7 +42437,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44830,15 +42448,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44850,11 +42474,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44873,48 +42501,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CreatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: CreatePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44954,18 +42600,24 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     t: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45005,48 +42657,66 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45074,7 +42744,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45082,11 +42754,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45114,7 +42790,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45122,11 +42800,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45161,59 +42843,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45258,30 +42964,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45316,11 +43036,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45335,9 +43060,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45372,11 +43103,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45391,9 +43127,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45428,11 +43170,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45447,9 +43194,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45484,11 +43237,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45503,9 +43261,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45540,11 +43304,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45559,9 +43328,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45596,11 +43371,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45622,9 +43402,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45639,11 +43425,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45672,17 +43463,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45704,17 +43506,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45743,9 +43556,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45780,11 +43599,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45806,9 +43630,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45848,11 +43678,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45874,9 +43709,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45911,11 +43752,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45944,9 +43790,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45991,11 +43843,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46024,9 +43881,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46061,11 +43924,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46101,9 +43969,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46138,11 +44012,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46178,17 +44057,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46224,9 +44114,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46261,11 +44157,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46301,17 +44202,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46340,9 +44252,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46382,11 +44300,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46422,9 +44345,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46459,11 +44388,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46485,9 +44419,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46522,11 +44462,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46611,9 +44556,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46658,11 +44609,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47013,9 +44969,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47050,11 +45012,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47068,18 +45035,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47114,11 +45092,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47132,18 +45115,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47178,11 +45172,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47196,18 +45195,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47242,11 +45252,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47260,18 +45275,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47306,11 +45332,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47324,18 +45355,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47370,11 +45412,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47395,26 +45442,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47435,9 +45498,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47472,11 +45541,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47497,18 +45571,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47548,11 +45633,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47573,18 +45663,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47619,11 +45720,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47651,18 +45757,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47707,11 +45824,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -47739,19 +45861,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47786,11 +45919,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -47825,18 +45963,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47871,11 +46020,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -47910,18 +46064,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47956,11 +46121,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -47995,18 +46165,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48046,11 +46227,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48085,27 +46271,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48140,11 +46342,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48165,18 +46372,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48216,11 +46434,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48269,18 +46492,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48315,11 +46549,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48403,27 +46642,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48468,11 +46723,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -48822,23 +47082,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48873,26 +47144,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48927,26 +47208,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48981,26 +47272,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49035,26 +47336,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49089,26 +47400,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49143,38 +47464,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49209,26 +47548,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49268,26 +47617,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49322,26 +47681,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49386,27 +47755,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49441,26 +47820,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49495,26 +47884,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49549,26 +47948,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49608,32 +48017,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49668,26 +48089,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49727,26 +48158,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49781,32 +48222,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49851,13 +48304,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1798,7 +1798,7 @@ const postCodec = recordCodec({
   attributes: postAttributes,
   description: undefined,
   extensions: extensions33,
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1835,7 +1835,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1865,7 +1865,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1895,7 +1895,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1946,7 +1946,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2067,7 +2067,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2096,7 +2096,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2134,7 +2134,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2172,7 +2172,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2210,7 +2210,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2248,7 +2248,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2286,7 +2286,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2401,7 +2401,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2926,7 +2926,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2965,70 +2965,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3036,7 +3036,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3044,7 +3044,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3052,7 +3052,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3060,7 +3060,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3068,7 +3068,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3077,7 +3077,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3096,7 +3096,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3124,7 +3124,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3132,7 +3132,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3141,12 +3141,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3161,7 +3161,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3169,7 +3169,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3178,12 +3178,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3196,7 +3196,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3204,7 +3204,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3212,7 +3212,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3220,10 +3220,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3239,12 +3239,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3257,9 +3257,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3279,8 +3279,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3289,12 +3289,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3307,26 +3307,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3335,12 +3335,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3356,9 +3356,9 @@ const registryConfig_pgResources_post_post = {
     }
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3378,33 +3378,33 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("a", "create_post");
-const sqlIdent101 = sql.identifier("c", "table_mutation");
-const sqlIdent102 = sql.identifier("c", "table_query");
-const sqlIdent103 = sql.identifier("a", "post_with_suffix");
-const sqlIdent104 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent105 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent107 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent108 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent109 = sql.identifier("a", "post_many");
-const sqlIdent110 = sql.identifier("c", "person_computed_out");
-const sqlIdent111 = sql.identifier("c", "person_first_name");
-const sqlIdent112 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout");
-const sqlIdent114 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent115 = sql.identifier("c", "person_exists");
-const sqlIdent116 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent117 = sql.identifier("c", "func_out_complex");
-const sqlIdent118 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent120 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent121 = sql.identifier("c", "person_computed_complex");
-const sqlIdent122 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const create_postFunctionIdentifer = sql.identifier("a", "create_post");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3420,12 +3420,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3438,17 +3438,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent123 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent124 = sql.identifier("c", "func_out_table");
-const sqlIdent125 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table");
-const sqlIdent127 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent128 = sql.identifier("c", "table_set_mutation");
-const sqlIdent129 = sql.identifier("c", "table_set_query");
-const sqlIdent130 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent131 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent132 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3457,12 +3457,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3477,15 +3477,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent133 = sql.identifier("b", "type_function_connection");
-const sqlIdent134 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent135 = sql.identifier("b", "type_function");
-const sqlIdent136 = sql.identifier("b", "type_function_mutation");
-const sqlIdent137 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent138 = sql.identifier("c", "person_type_function");
-const sqlIdent139 = sql.identifier("b", "type_function_list");
-const sqlIdent140 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent141 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3684,7 +3684,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3737,7 +3737,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3799,16 +3799,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3828,11 +3828,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3853,11 +3853,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3878,11 +3878,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3902,11 +3902,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3927,11 +3927,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3952,11 +3952,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3976,11 +3976,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4000,11 +4000,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4024,11 +4024,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4048,11 +4048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4072,11 +4072,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4096,11 +4096,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4120,11 +4120,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4150,11 +4150,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4180,11 +4180,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4210,11 +4210,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4240,11 +4240,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4269,11 +4269,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4299,11 +4299,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4328,11 +4328,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4357,11 +4357,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4386,11 +4386,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4415,11 +4415,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4444,11 +4444,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4473,11 +4473,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4507,11 +4507,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4541,11 +4541,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4575,11 +4575,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4609,11 +4609,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4643,11 +4643,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4677,11 +4677,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4711,11 +4711,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4745,11 +4745,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4779,11 +4779,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4813,11 +4813,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4847,11 +4847,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4881,11 +4881,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4915,11 +4915,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4950,11 +4950,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4974,11 +4974,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4998,11 +4998,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5022,11 +5022,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5057,11 +5057,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5081,11 +5081,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5105,11 +5105,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5129,11 +5129,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5154,11 +5154,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5193,11 +5193,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5232,11 +5232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5271,11 +5271,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5310,11 +5310,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5349,11 +5349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5373,11 +5373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5402,11 +5402,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5441,11 +5441,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5480,11 +5480,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5504,11 +5504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5533,11 +5533,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5562,11 +5562,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5586,11 +5586,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5610,11 +5610,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5634,11 +5634,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5658,7 +5658,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5679,12 +5679,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5698,12 +5698,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5717,12 +5717,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5736,12 +5736,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5755,12 +5755,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5774,12 +5774,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5794,7 +5794,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5820,7 +5820,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5840,12 +5840,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5860,12 +5860,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5880,12 +5880,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5899,12 +5899,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5918,7 +5918,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5949,12 +5949,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5968,11 +5968,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -6000,7 +6000,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6019,11 +6019,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6058,7 +6058,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6081,7 +6081,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6103,7 +6103,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6141,7 +6141,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6173,7 +6173,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6195,7 +6195,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6217,7 +6217,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6251,7 +6251,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6275,7 +6275,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6309,11 +6309,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6363,11 +6363,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6417,11 +6417,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6446,11 +6446,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6475,11 +6475,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6504,11 +6504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6533,11 +6533,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6569,11 +6569,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6605,11 +6605,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6634,11 +6634,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6663,11 +6663,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6702,11 +6702,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6741,11 +6741,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6780,11 +6780,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6823,7 +6823,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6845,7 +6845,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6872,7 +6872,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6899,7 +6899,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6926,7 +6926,7 @@ const registry = makeRegistry({
       name: "create_post",
       identifier: "main.a.create_post(text)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${create_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "t",
@@ -6953,7 +6953,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6980,7 +6980,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7007,7 +7007,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7040,7 +7040,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7067,7 +7067,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7094,7 +7094,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7121,7 +7121,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7148,7 +7148,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7180,7 +7180,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7204,11 +7204,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7237,11 +7237,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7267,11 +7267,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7331,11 +7331,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7400,11 +7400,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7429,11 +7429,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7463,11 +7463,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7497,11 +7497,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7531,11 +7531,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7565,11 +7565,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7607,7 +7607,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7635,7 +7635,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7658,7 +7658,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7680,7 +7680,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7702,7 +7702,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7724,7 +7724,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7746,7 +7746,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7768,7 +7768,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7792,7 +7792,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7814,7 +7814,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7842,7 +7842,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7871,7 +7871,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7893,7 +7893,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7915,7 +7915,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7942,7 +7942,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7969,7 +7969,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7996,7 +7996,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8028,7 +8028,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8050,7 +8050,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8072,7 +8072,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30540,7 +30540,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30556,7 +30556,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33054,7 +33054,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33070,7 +33070,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33492,7 +33492,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33508,7 +33508,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34129,7 +34129,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34145,7 +34145,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35214,7 +35214,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35230,7 +35230,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35335,7 +35335,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35351,7 +35351,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35456,7 +35456,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35472,7 +35472,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35577,7 +35577,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35593,7 +35593,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35698,7 +35698,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35714,7 +35714,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35819,7 +35819,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35835,7 +35835,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36358,7 +36358,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36374,7 +36374,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36536,7 +36536,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36552,7 +36552,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36714,7 +36714,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36730,7 +36730,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36949,7 +36949,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36965,7 +36965,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37241,7 +37241,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37257,7 +37257,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37808,7 +37808,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37824,7 +37824,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38349,7 +38349,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38365,7 +38365,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38641,7 +38641,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38657,7 +38657,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42235,7 +42235,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42322,7 +42322,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42571,7 +42571,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42628,7 +42628,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42819,7 +42819,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42930,7 +42930,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43012,7 +43012,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43079,7 +43079,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43146,7 +43146,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43213,7 +43213,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43280,7 +43280,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43347,7 +43347,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43575,7 +43575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43649,7 +43649,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43728,7 +43728,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43809,7 +43809,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43900,7 +43900,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43988,7 +43988,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44133,7 +44133,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44271,7 +44271,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44364,7 +44364,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44438,7 +44438,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44575,7 +44575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44988,7 +44988,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45068,7 +45068,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45148,7 +45148,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45228,7 +45228,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45308,7 +45308,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45388,7 +45388,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45517,7 +45517,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45604,7 +45604,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45696,7 +45696,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45790,7 +45790,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45895,7 +45895,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45996,7 +45996,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46097,7 +46097,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46198,7 +46198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46318,7 +46318,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46405,7 +46405,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46525,7 +46525,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46689,7 +46689,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47120,7 +47120,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47184,7 +47184,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47248,7 +47248,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47312,7 +47312,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47376,7 +47376,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47440,7 +47440,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47524,7 +47524,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47588,7 +47588,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47657,7 +47657,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47721,7 +47721,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47796,7 +47796,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47860,7 +47860,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47924,7 +47924,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47988,7 +47988,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48065,7 +48065,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48129,7 +48129,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48198,7 +48198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48270,7 +48270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1944,17 +1943,17 @@ const extensions38 = {
   })
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1965,7 +1964,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1973,7 +1972,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1983,7 +1982,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1993,7 +1992,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2014,7 +2013,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2024,7 +2023,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2045,7 +2044,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2055,7 +2054,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2064,13 +2063,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2079,16 +2078,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2096,7 +2095,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2106,17 +2105,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2139,7 +2138,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2157,7 +2156,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2166,7 +2165,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2221,7 +2220,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2231,20 +2230,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2262,7 +2261,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2272,7 +2271,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2283,7 +2282,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2291,7 +2290,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2301,7 +2300,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2311,7 +2310,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2322,7 +2321,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2330,7 +2329,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2340,7 +2339,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2350,7 +2349,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2361,7 +2360,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2369,7 +2368,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2379,7 +2378,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2389,7 +2388,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2400,7 +2399,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2408,7 +2407,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2418,7 +2417,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2428,7 +2427,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2439,7 +2438,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2447,7 +2446,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2457,7 +2456,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2467,7 +2466,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2475,13 +2474,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2490,13 +2489,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2505,13 +2504,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2520,12 +2519,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2534,12 +2533,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2548,15 +2547,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2565,7 +2564,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2582,7 +2581,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2592,17 +2591,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2611,13 +2610,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2625,7 +2624,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2633,20 +2632,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2654,13 +2653,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2672,8 +2671,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2739,7 +2738,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2748,7 +2747,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2757,7 +2756,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2766,7 +2765,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2775,7 +2774,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2802,7 +2801,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2811,7 +2810,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2820,7 +2819,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2829,7 +2828,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2892,7 +2891,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2910,7 +2909,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2919,7 +2918,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2928,7 +2927,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2937,7 +2936,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3063,7 +3062,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3072,7 +3071,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3090,7 +3089,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3099,7 +3098,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3108,7 +3107,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3116,7 +3115,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3128,17 +3127,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3146,7 +3145,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3154,7 +3153,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3162,7 +3161,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3170,13 +3169,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3185,12 +3184,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3198,13 +3197,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3233,7 +3232,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3243,16 +3242,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3290,7 +3289,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3300,16 +3299,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3356,7 +3355,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3366,16 +3365,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3386,8 +3385,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3399,10 +3398,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3414,10 +3413,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3428,10 +3427,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3443,10 +3442,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3458,10 +3457,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3472,10 +3471,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3486,10 +3485,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3500,10 +3499,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3514,10 +3513,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3528,10 +3527,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3542,10 +3541,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3556,10 +3555,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3571,15 +3570,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3591,15 +3590,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3611,15 +3610,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3631,15 +3630,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3650,15 +3649,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3670,15 +3669,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3689,15 +3688,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3708,15 +3707,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3727,15 +3726,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3746,15 +3745,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3765,15 +3764,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3784,15 +3783,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3803,8 +3802,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3816,7 +3815,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3827,8 +3826,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3840,7 +3839,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3851,8 +3850,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3864,7 +3863,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3875,8 +3874,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3888,7 +3887,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3899,8 +3898,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3912,7 +3911,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3923,8 +3922,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3936,7 +3935,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3947,8 +3946,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3960,7 +3959,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3971,8 +3970,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3984,7 +3983,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3995,8 +3994,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4008,7 +4007,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4019,8 +4018,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4032,7 +4031,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4043,8 +4042,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4056,7 +4055,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4067,8 +4066,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4080,7 +4079,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4091,8 +4090,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4104,7 +4103,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4116,8 +4115,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4129,7 +4128,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4140,10 +4139,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4154,10 +4153,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4168,10 +4167,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4183,8 +4182,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4196,7 +4195,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4207,10 +4206,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4221,10 +4220,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4235,10 +4234,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4250,10 +4249,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4264,8 +4263,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4282,7 +4281,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4293,8 +4292,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4311,7 +4310,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4322,8 +4321,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4340,7 +4339,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4351,8 +4350,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4369,7 +4368,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4380,8 +4379,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4398,7 +4397,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4409,10 +4408,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4423,15 +4422,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4442,8 +4441,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4460,7 +4459,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4471,8 +4470,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4489,7 +4488,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4500,10 +4499,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4514,15 +4513,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4533,15 +4532,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4552,10 +4551,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4566,10 +4565,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4580,10 +4579,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4594,10 +4593,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4608,7 +4607,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4625,7 +4624,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4642,7 +4641,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4659,7 +4658,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4676,7 +4675,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4693,7 +4692,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4710,7 +4709,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4724,14 +4723,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4748,7 +4747,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4758,7 +4757,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4767,7 +4766,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4782,14 +4781,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4806,7 +4805,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4829,14 +4828,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4853,7 +4852,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4874,14 +4873,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4898,7 +4897,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4915,7 +4914,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4937,7 +4936,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4954,7 +4953,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4965,21 +4964,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4997,7 +4996,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5008,13 +5007,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5026,7 +5025,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5036,7 +5035,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5064,20 +5063,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5095,7 +5094,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5111,20 +5110,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5157,7 +5156,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5178,26 +5177,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5220,12 +5219,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5244,12 +5243,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5268,12 +5267,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5307,12 +5306,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5345,7 +5344,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5362,14 +5361,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5380,8 +5379,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5401,7 +5400,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5411,9 +5410,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5424,8 +5423,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5445,7 +5444,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5455,9 +5454,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5468,15 +5467,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5487,15 +5486,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5506,15 +5505,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5525,15 +5524,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5546,20 +5545,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5572,20 +5571,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5596,15 +5595,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5615,15 +5614,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5634,13 +5633,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5652,7 +5651,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5663,13 +5662,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5681,7 +5680,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5692,13 +5691,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5710,7 +5709,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5721,8 +5720,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5739,7 +5738,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5748,7 +5747,7 @@ const extensions167 = {
   },
   tags: {
     omit: "create",
-    behavior: extensions38.tags.behavior
+    behavior: extensions33.tags.behavior
   }
 };
 const uniques25 = [{
@@ -5763,20 +5762,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5794,7 +5793,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5810,26 +5809,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5847,18 +5846,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5876,18 +5875,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5905,12 +5904,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["a", "create_post"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_create_post = {
   name: "create_post",
   identifier: "main.a.create_post(text)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "t",
@@ -5934,12 +5933,12 @@ const options_create_post = {
   description: undefined
 };
 const parts143 = ["c", "table_mutation"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5963,12 +5962,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts144 = ["c", "table_query"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5992,18 +5991,18 @@ const options_table_query = {
   description: undefined
 };
 const parts145 = ["a", "post_with_suffix"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -6027,18 +6026,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts146 = ["a", "mutation_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6056,18 +6055,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts147 = ["a", "query_compound_type_array"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6085,18 +6084,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_mutation"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6114,18 +6113,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts149 = ["b", "compound_type_array_query"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6143,23 +6142,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts150 = ["a", "post_computed_compound_type_array"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6177,18 +6176,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts151 = ["a", "post_many"];
-const sqlIdent151 = sql.identifier(...parts151);
+const sqlIdent109 = sql.identifier(...parts151);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6205,7 +6204,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6220,15 +6219,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts152 = ["c", "person_computed_out"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback80 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback80 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6240,15 +6239,15 @@ const extensions170 = {
   }
 };
 const parts153 = ["c", "person_first_name"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback81 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback81 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6259,15 +6258,15 @@ const extensions171 = {
   }
 };
 const parts154 = ["c", "person_computed_out_out"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback82 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback82 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6279,20 +6278,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts155 = ["c", "person_computed_inout"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback83 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback83 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6303,20 +6302,20 @@ const extensions173 = {
   }
 };
 const parts156 = ["c", "person_computed_inout_out"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback84 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback84 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6328,20 +6327,20 @@ const extensions174 = {
   }
 };
 const parts157 = ["c", "person_exists"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback85 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback85 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6352,15 +6351,15 @@ const extensions175 = {
   }
 };
 const parts158 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback86 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback86 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6371,8 +6370,8 @@ const extensions176 = {
   }
 };
 const parts159 = ["c", "func_out_complex"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback87 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback87 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6384,7 +6383,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6395,8 +6394,8 @@ const extensions177 = {
   }
 };
 const parts160 = ["c", "func_out_complex_setof"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback88 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback88 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6408,7 +6407,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6419,8 +6418,8 @@ const extensions178 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback89 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback89 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6432,7 +6431,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6443,8 +6442,8 @@ const extensions179 = {
   }
 };
 const parts162 = ["c", "mutation_out_complex_setof"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback90 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback90 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6456,7 +6455,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6467,13 +6466,13 @@ const extensions180 = {
   }
 };
 const parts163 = ["c", "person_computed_complex"];
-const sqlIdent163 = sql.identifier(...parts163);
-const fromCallback91 = (...args) => sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+const sqlIdent121 = sql.identifier(...parts163);
+const fromCallback91 = (...args) => sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6486,18 +6485,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts164 = ["c", "person_first_post"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6514,7 +6513,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6542,20 +6541,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts165 = ["c", "badly_behaved_function"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6575,12 +6574,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6599,12 +6598,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts167 = ["c", "func_out_table_setof"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6623,12 +6622,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6647,12 +6646,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts169 = ["c", "mutation_out_table_setof"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6671,12 +6670,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts170 = ["c", "table_set_mutation"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6695,12 +6694,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6721,12 +6720,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts172 = ["c", "table_set_query_plpgsql"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6745,18 +6744,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts173 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6775,18 +6774,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts174 = ["c", "person_friends"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6804,7 +6803,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6812,7 +6811,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6827,20 +6826,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts175 = ["b", "type_function_connection"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6859,12 +6858,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts176 = ["b", "type_function_connection_mutation"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6883,12 +6882,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts177 = ["b", "type_function"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6912,12 +6911,12 @@ const options_type_function = {
   description: undefined
 };
 const parts178 = ["b", "type_function_mutation"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6941,18 +6940,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function_connection"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6970,18 +6969,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts180 = ["c", "person_type_function"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -7004,12 +7003,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7028,12 +7027,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts182 = ["b", "type_function_list_mutation"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7052,18 +7051,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts183 = ["c", "person_type_function_list"];
-const sqlIdent183 = sql.identifier(...parts183);
+const sqlIdent141 = sql.identifier(...parts183);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent183}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7100,61 +7099,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7165,18 +7164,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7186,38 +7185,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7225,14 +7224,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7245,7 +7244,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7258,7 +7257,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7271,7 +7270,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7284,7 +7283,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7297,7 +7296,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7310,7 +7309,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7323,7 +7322,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7336,7 +7335,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7349,7 +7348,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7362,7 +7361,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7375,7 +7374,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7388,7 +7387,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7401,7 +7400,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7414,7 +7413,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7427,7 +7426,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7440,7 +7439,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7453,7 +7452,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7466,7 +7465,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7479,7 +7478,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7492,7 +7491,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7505,7 +7504,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7518,7 +7517,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7531,7 +7530,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7544,7 +7543,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7557,7 +7556,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7570,7 +7569,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7583,7 +7582,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7596,7 +7595,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7609,7 +7608,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7622,7 +7621,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7635,7 +7634,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7648,7 +7647,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7661,7 +7660,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7674,7 +7673,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7687,7 +7686,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7700,7 +7699,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7713,7 +7712,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7726,7 +7725,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7739,7 +7738,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7752,7 +7751,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7765,7 +7764,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7778,7 +7777,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7791,7 +7790,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7804,7 +7803,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7817,7 +7816,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7830,7 +7829,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7843,7 +7842,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7856,7 +7855,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7869,7 +7868,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7882,7 +7881,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7895,7 +7894,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7908,7 +7907,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7921,7 +7920,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7934,7 +7933,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7947,7 +7946,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7960,7 +7959,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7973,7 +7972,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7983,10 +7982,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7996,10 +7995,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -8009,10 +8008,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -8022,10 +8021,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8035,180 +8034,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8220,7 +8219,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8231,22 +8230,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8267,7 +8266,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8280,7 +8279,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8293,7 +8292,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8306,7 +8305,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8316,10 +8315,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8329,10 +8328,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8345,7 +8344,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8358,7 +8357,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8371,7 +8370,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8384,7 +8383,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8397,7 +8396,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8410,7 +8409,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8423,7 +8422,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8436,7 +8435,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8464,7 +8463,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8477,7 +8476,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8490,7 +8489,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8503,7 +8502,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8516,7 +8515,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8529,7 +8528,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8542,7 +8541,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8555,7 +8554,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8568,7 +8567,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8581,7 +8580,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8594,7 +8593,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8607,7 +8606,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8636,7 +8635,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8651,7 +8650,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8668,7 +8667,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8683,7 +8682,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8698,7 +8697,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8715,7 +8714,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8732,7 +8731,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8749,7 +8748,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8764,7 +8763,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8781,7 +8780,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8796,7 +8795,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8811,7 +8810,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8826,7 +8825,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8843,7 +8842,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8860,7 +8859,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8875,7 +8874,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8890,7 +8889,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8907,7 +8906,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8922,7 +8921,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8937,7 +8936,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8954,7 +8953,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11127,7 +11126,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11139,7 +11138,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11372,7 +11371,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11476,7 +11475,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11528,7 +11527,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12989,7 +12988,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14116,7 +14115,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16129,7 +16128,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16282,7 +16281,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16465,7 +16464,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16770,7 +16769,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16782,7 +16781,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16892,7 +16891,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16947,7 +16946,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17112,7 +17111,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17167,7 +17166,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -33692,7 +33691,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33708,7 +33707,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34996,7 +34995,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35019,7 +35018,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35042,7 +35041,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35065,7 +35064,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35088,7 +35087,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35111,7 +35110,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35134,7 +35133,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35157,7 +35156,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35180,7 +35179,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35203,7 +35202,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35226,7 +35225,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35249,7 +35248,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35272,7 +35271,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35295,7 +35294,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35318,7 +35317,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35341,7 +35340,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35364,7 +35363,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35387,7 +35386,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35410,7 +35409,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35433,7 +35432,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35456,7 +35455,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35479,7 +35478,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35502,7 +35501,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35525,7 +35524,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35548,7 +35547,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35571,7 +35570,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35594,7 +35593,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35617,7 +35616,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35640,7 +35639,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35663,7 +35662,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35686,7 +35685,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35709,7 +35708,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35732,7 +35731,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35755,7 +35754,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35778,7 +35777,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35801,7 +35800,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35824,7 +35823,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35847,7 +35846,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -35870,7 +35869,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -35893,7 +35892,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -35916,7 +35915,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -35939,7 +35938,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -35962,7 +35961,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -35985,7 +35984,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36008,7 +36007,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36031,7 +36030,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36054,7 +36053,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36199,7 +36198,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36215,7 +36214,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36630,7 +36629,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36646,7 +36645,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36812,7 +36811,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36835,7 +36834,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -36858,7 +36857,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -36881,7 +36880,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -36904,7 +36903,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -36927,7 +36926,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37131,7 +37130,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37154,7 +37153,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37177,7 +37176,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37253,7 +37252,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37269,7 +37268,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37401,7 +37400,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37424,7 +37423,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37447,7 +37446,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -37885,7 +37884,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -37908,7 +37907,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -37931,7 +37930,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -37954,7 +37953,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -37977,7 +37976,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38000,7 +37999,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38023,7 +38022,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38046,7 +38045,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38069,7 +38068,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38092,7 +38091,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38115,7 +38114,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38227,7 +38226,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38261,7 +38260,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38277,7 +38276,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38341,7 +38340,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38375,7 +38374,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38391,7 +38390,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38455,7 +38454,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38489,7 +38488,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38505,7 +38504,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38569,7 +38568,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38603,7 +38602,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38619,7 +38618,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38683,7 +38682,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38717,7 +38716,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38733,7 +38732,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38797,7 +38796,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38831,7 +38830,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38847,7 +38846,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38945,7 +38944,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -38968,7 +38967,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39084,7 +39083,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39107,7 +39106,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39269,7 +39268,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39292,7 +39291,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39315,7 +39314,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39349,7 +39348,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39365,7 +39364,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39463,7 +39462,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39486,7 +39485,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39520,7 +39519,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39536,7 +39535,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39634,7 +39633,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39657,7 +39656,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39691,7 +39690,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39707,7 +39706,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39839,7 +39838,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39862,7 +39861,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -39885,7 +39884,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -39919,7 +39918,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39935,7 +39934,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40101,7 +40100,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40124,7 +40123,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40147,7 +40146,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40170,7 +40169,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40204,7 +40203,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40220,7 +40219,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40386,7 +40385,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40409,7 +40408,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40432,7 +40431,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40455,7 +40454,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40654,7 +40653,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40677,7 +40676,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40700,7 +40699,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40723,7 +40722,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40757,7 +40756,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40773,7 +40772,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40939,7 +40938,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -40962,7 +40961,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -40985,7 +40984,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41008,7 +41007,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41204,7 +41203,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41227,7 +41226,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41250,7 +41249,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41284,7 +41283,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41300,7 +41299,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41466,7 +41465,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41489,7 +41488,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41512,7 +41511,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41535,7 +41534,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41569,7 +41568,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41585,7 +41584,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41683,7 +41682,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41706,7 +41705,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,761 +3339,64 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["a", "create_post"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_create_post = {
-  name: "create_post",
-  identifier: "main.a.create_post(text)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "t",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "create_post"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_mutation"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts144 = ["c", "table_query"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "post_with_suffix"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "mutation_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["a", "query_compound_type_array"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_mutation"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["b", "compound_type_array_query"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_computed_compound_type_array"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts151 = ["a", "post_many"];
-const sqlIdent109 = sql.identifier(...parts151);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts152 = ["c", "person_computed_out"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback80 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts153 = ["c", "person_first_name"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback81 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts154 = ["c", "person_computed_out_out"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback82 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts155 = ["c", "person_computed_inout"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback83 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_computed_inout_out"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback84 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_exists"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback85 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback86 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback87 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "func_out_complex_setof"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback88 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback89 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "mutation_out_complex_setof"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback90 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts163 = ["c", "person_computed_complex"];
-const sqlIdent121 = sql.identifier(...parts163);
-const fromCallback91 = (...args) => sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts164 = ["c", "person_first_post"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("a", "create_post");
+const sqlIdent101 = sql.identifier("c", "table_mutation");
+const sqlIdent102 = sql.identifier("c", "table_query");
+const sqlIdent103 = sql.identifier("a", "post_with_suffix");
+const sqlIdent104 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent105 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent107 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent108 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent109 = sql.identifier("a", "post_many");
+const sqlIdent110 = sql.identifier("c", "person_computed_out");
+const sqlIdent111 = sql.identifier("c", "person_first_name");
+const sqlIdent112 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout");
+const sqlIdent114 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent115 = sql.identifier("c", "person_exists");
+const sqlIdent116 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent117 = sql.identifier("c", "func_out_complex");
+const sqlIdent118 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent120 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent121 = sql.identifier("c", "person_computed_complex");
+const sqlIdent122 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6540,274 +3421,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts165 = ["c", "badly_behaved_function"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "func_out_table_setof"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "mutation_out_table_setof"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_mutation"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "table_set_query_plpgsql"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts174 = ["c", "person_friends"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent123 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent124 = sql.identifier("c", "func_out_table");
+const sqlIdent125 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table");
+const sqlIdent127 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent128 = sql.identifier("c", "table_set_mutation");
+const sqlIdent129 = sql.identifier("c", "table_set_query");
+const sqlIdent130 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent131 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent132 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6825,254 +3458,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts175 = ["b", "type_function_connection"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts176 = ["b", "type_function_connection_mutation"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["b", "type_function_mutation"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function_connection"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["c", "person_type_function"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["b", "type_function_list_mutation"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts183 = ["c", "person_type_function_list"];
-const sqlIdent141 = sql.identifier(...parts183);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent133 = sql.identifier("b", "type_function_connection");
+const sqlIdent134 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent135 = sql.identifier("b", "type_function");
+const sqlIdent136 = sql.identifier("b", "type_function_mutation");
+const sqlIdent137 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent138 = sql.identifier("c", "person_type_function");
+const sqlIdent139 = sql.identifier("b", "type_function_list");
+const sqlIdent140 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent141 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7187,19 +3593,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7208,9 +3635,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7225,813 +3808,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8043,7 +5659,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8054,7 +5680,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8065,7 +5699,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8076,7 +5718,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8087,7 +5737,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8098,7 +5756,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8109,7 +5775,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8118,10 +5792,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8129,10 +5818,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8144,7 +5841,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8156,7 +5861,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8168,7 +5881,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8179,7 +5900,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8187,10 +5916,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8201,33 +5950,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8236,395 +6056,2038 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    create_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_create_post),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    create_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "create_post",
+      identifier: "main.a.create_post(text)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "t",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "create_post"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9474,25 +8937,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9635,21 +9079,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9700,21 +9129,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9823,21 +9237,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10328,21 +9727,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10435,12 +9819,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10863,21 +10241,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10946,21 +10309,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11347,21 +10695,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11690,21 +11023,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11755,21 +11073,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11866,21 +11169,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11931,21 +11219,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -12014,21 +11287,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12079,21 +11337,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12355,385 +11598,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13307,21 +12175,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13402,21 +12255,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13516,66 +12354,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13623,24 +12401,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13721,21 +12481,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14159,348 +12904,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14547,26 +12951,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14613,9 +12997,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14662,9 +13043,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14711,9 +13089,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14760,9 +13135,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14809,9 +13181,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14858,9 +13227,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14913,9 +13279,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14968,9 +13331,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15023,9 +13383,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15078,9 +13435,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15133,9 +13487,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15188,9 +13539,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15249,9 +13597,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15310,9 +13655,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15371,9 +13713,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15432,9 +13771,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15493,9 +13829,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15554,9 +13887,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15615,9 +13945,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15676,9 +14003,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15737,9 +14061,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15798,9 +14119,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15847,9 +14165,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15896,9 +14211,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15945,9 +14257,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -16012,9 +14321,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16061,9 +14367,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16116,9 +14419,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16171,9 +14471,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16220,9 +14517,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16269,9 +14563,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16336,9 +14627,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16385,9 +14673,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16452,9 +14737,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16507,9 +14789,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16556,9 +14835,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16605,9 +14881,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16672,9 +14945,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16739,9 +15009,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16824,9 +15091,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16879,9 +15143,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16934,9 +15195,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16989,9 +15247,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17044,9 +15299,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17105,9 +15357,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17160,9 +15409,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17215,9 +15461,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17270,9 +15513,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17331,9 +15571,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17392,9 +15629,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17441,9 +15675,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17490,9 +15721,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17539,9 +15767,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17588,9 +15813,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17643,9 +15865,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17692,2061 +15911,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29853,7 +26162,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30099,27 +26410,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30139,23 +26463,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30167,23 +26501,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30205,23 +26549,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30305,23 +26659,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30337,11 +26701,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30413,23 +26781,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30444,23 +26822,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30518,23 +26906,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30594,23 +26992,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30622,23 +27030,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30654,23 +27072,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30682,23 +27110,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30726,23 +27164,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30754,23 +27202,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30956,23 +27414,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30999,23 +27467,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31042,23 +27520,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31085,23 +27573,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31128,23 +27626,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31171,23 +27679,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31214,23 +27732,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31257,23 +27785,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31300,23 +27838,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31343,23 +27891,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31386,23 +27944,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31429,23 +27997,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31472,23 +28050,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31515,23 +28103,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31558,23 +28156,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31601,23 +28209,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31644,23 +28262,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31687,23 +28315,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31730,23 +28368,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31773,23 +28421,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31816,23 +28474,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31859,23 +28527,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31902,23 +28580,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31945,23 +28633,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32105,23 +28803,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32523,23 +29231,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32560,23 +29278,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32702,23 +29430,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32748,23 +29486,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32804,23 +29552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32850,23 +29608,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33034,12 +29802,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33055,23 +29835,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33416,23 +30206,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33460,9 +30260,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33478,8 +30285,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33620,9 +30431,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36286,9 +33104,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36747,9 +33572,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37139,9 +33971,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37400,9 +34239,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37727,9 +34573,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37745,9 +34598,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37763,9 +34623,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37781,9 +34648,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37808,9 +34682,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37865,9 +34746,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37892,9 +34780,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37957,9 +34852,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37999,9 +34901,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38320,9 +35229,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38408,9 +35324,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38522,9 +35445,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38636,9 +35566,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38750,9 +35687,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38864,9 +35808,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38978,9 +35929,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39149,9 +36107,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39288,9 +36253,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39496,9 +36468,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39667,9 +36646,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39838,9 +36824,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40066,9 +37059,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40351,9 +37351,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40636,9 +37643,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40904,9 +37918,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41189,9 +38210,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41431,9 +38459,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41716,9 +38751,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41898,7 +38940,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41913,7 +38957,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41928,7 +38974,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41943,7 +38991,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41958,7 +39008,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41973,7 +39025,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41988,7 +39042,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42003,7 +39059,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42018,7 +39076,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42033,7 +39093,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42048,7 +39110,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42063,7 +39127,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42078,7 +39144,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42093,7 +39161,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42108,7 +39178,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42123,7 +39195,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42138,7 +39212,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42153,7 +39229,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42168,7 +39246,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42183,7 +39263,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42198,7 +39280,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42213,7 +39297,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42228,7 +39314,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42243,7 +39331,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42258,7 +39348,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42273,7 +39365,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42288,7 +39382,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42303,7 +39399,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42318,7 +39416,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42333,7 +39433,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42348,7 +39450,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42363,7 +39467,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42378,7 +39484,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42393,7 +39501,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42408,7 +39518,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42423,7 +39535,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42438,7 +39552,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42453,7 +39569,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42468,7 +39586,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42483,7 +39603,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42498,7 +39620,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42513,7 +39637,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42528,7 +39654,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42543,7 +39671,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42558,7 +39688,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42573,7 +39705,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42588,7 +39722,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42603,7 +39739,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42618,7 +39756,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42633,7 +39773,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42648,7 +39790,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42663,7 +39807,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42678,7 +39824,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42693,7 +39841,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42708,7 +39858,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42723,7 +39875,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42738,7 +39892,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42753,7 +39909,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42768,7 +39926,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42783,7 +39943,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42798,7 +39960,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42813,7 +39977,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42828,7 +39994,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42843,7 +40011,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42858,7 +40028,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42873,7 +40045,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42888,7 +40062,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42903,7 +40079,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42918,7 +40096,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42933,7 +40113,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42948,7 +40130,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42963,7 +40147,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42978,7 +40164,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42993,7 +40181,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43008,7 +40198,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43023,7 +40215,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43038,7 +40232,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43053,7 +40249,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43068,7 +40266,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43082,7 +40282,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43098,7 +40300,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43112,7 +40316,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43128,7 +40334,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43142,7 +40350,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43158,7 +40368,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43172,7 +40384,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43188,7 +40402,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43202,7 +40418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43218,7 +40436,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43232,7 +40452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43248,7 +40470,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43264,7 +40488,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43278,7 +40504,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43294,7 +40522,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43308,7 +40538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43324,7 +40556,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43338,7 +40572,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43354,7 +40590,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43368,7 +40606,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43385,7 +40625,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43399,7 +40641,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43415,7 +40659,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43429,7 +40675,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43445,7 +40693,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43459,7 +40709,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43475,7 +40727,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43489,7 +40743,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43505,7 +40761,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43521,7 +40779,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43535,7 +40795,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43551,7 +40813,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43565,7 +40829,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43581,7 +40847,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43595,7 +40863,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43611,7 +40881,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43627,7 +40899,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43641,7 +40915,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43657,7 +40933,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43671,7 +40949,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43687,7 +40967,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43701,7 +40983,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43717,7 +41001,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43731,7 +41017,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43747,7 +41035,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43761,7 +41051,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43777,7 +41069,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43791,7 +41085,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43807,7 +41103,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43821,7 +41119,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43837,7 +41137,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43853,7 +41155,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43867,7 +41171,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43883,7 +41189,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43897,7 +41205,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43913,7 +41223,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43927,7 +41239,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43943,7 +41257,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43957,7 +41273,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43974,7 +41292,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43988,7 +41308,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44004,7 +41326,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44018,7 +41342,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44034,7 +41360,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44048,7 +41376,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44064,7 +41394,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44078,7 +41410,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44094,7 +41428,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44110,7 +41446,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44124,7 +41462,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44140,7 +41480,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44154,7 +41496,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44170,7 +41514,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44184,7 +41530,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44200,7 +41548,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44216,7 +41566,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44230,7 +41582,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44246,193 +41600,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44440,15 +41874,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44456,15 +41896,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44472,15 +41918,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44488,15 +41940,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44504,15 +41962,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44520,15 +41984,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44536,15 +42006,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44552,15 +42028,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44568,15 +42050,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44584,11 +42072,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44601,17 +42093,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44624,17 +42122,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44647,21 +42151,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44670,11 +42182,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44690,17 +42206,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44713,65 +42235,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44780,11 +42328,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44806,21 +42358,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44829,11 +42389,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44873,7 +42437,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44910,11 +42476,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44949,35 +42519,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44986,11 +42570,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -45022,7 +42610,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45031,15 +42621,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45051,11 +42647,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45074,48 +42674,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45155,18 +42773,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45206,7 +42830,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45258,56 +42884,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45335,7 +42983,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45343,11 +42993,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45375,7 +43029,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45383,11 +43039,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45422,59 +43082,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45519,30 +43203,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45577,11 +43275,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45596,9 +43299,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45633,11 +43342,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45652,9 +43366,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45689,11 +43409,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45708,9 +43433,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45745,11 +43476,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45764,9 +43500,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45801,11 +43543,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45820,9 +43567,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45857,11 +43610,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45883,9 +43641,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45900,11 +43664,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45933,17 +43702,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45965,17 +43745,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46004,9 +43795,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46041,11 +43838,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46067,9 +43869,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46109,11 +43917,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46135,9 +43948,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46172,11 +43991,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46205,9 +44029,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46252,11 +44082,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46285,9 +44120,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46322,11 +44163,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46362,9 +44208,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46399,11 +44251,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46439,17 +44296,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46485,9 +44353,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46522,11 +44396,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46562,17 +44441,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46601,9 +44491,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46643,11 +44539,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46683,9 +44584,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46720,11 +44627,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46746,9 +44658,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46788,19 +44706,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46835,11 +44764,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46924,9 +44858,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46971,11 +44911,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47326,9 +45271,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47363,11 +45314,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47381,18 +45337,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47427,11 +45394,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47445,18 +45417,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47491,11 +45474,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47509,18 +45497,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47555,11 +45554,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47573,18 +45577,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47619,11 +45634,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47637,18 +45657,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47683,11 +45714,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47708,26 +45744,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47748,9 +45800,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47785,11 +45843,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47810,18 +45873,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47861,11 +45935,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47886,18 +45965,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47932,11 +46022,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47964,18 +46059,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48020,11 +46126,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48052,19 +46163,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48099,11 +46221,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48138,18 +46265,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48184,11 +46322,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48223,18 +46366,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48269,11 +46423,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48308,18 +46467,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48359,11 +46529,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48398,27 +46573,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48453,11 +46644,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48478,18 +46674,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48529,11 +46736,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48582,18 +46794,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48628,11 +46851,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48716,27 +46944,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48781,11 +47025,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49135,23 +47384,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49186,26 +47446,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49240,26 +47510,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49294,26 +47574,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49348,26 +47638,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49402,26 +47702,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49456,38 +47766,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49522,26 +47850,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49581,26 +47919,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49635,26 +47983,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49699,27 +48057,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49754,26 +48122,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49808,26 +48186,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49862,26 +48250,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49921,32 +48319,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49981,26 +48391,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50040,26 +48460,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50094,32 +48524,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50164,13 +48606,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1940,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1961,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,7 +1969,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1980,7 +1979,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1989,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2011,7 +2010,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2020,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2042,7 +2041,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2051,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2060,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2075,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2092,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2102,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2135,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2153,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2162,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2217,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2227,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2259,7 +2258,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2268,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2279,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,7 +2287,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2298,7 +2297,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2307,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2318,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,7 +2326,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2337,7 +2336,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2346,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2357,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,7 +2365,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2376,7 +2375,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2385,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2396,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,7 +2404,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2415,7 +2414,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2424,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2435,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,7 +2443,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2454,7 +2453,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2463,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2471,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2486,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2501,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2516,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2530,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2544,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2561,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2578,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2588,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2607,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2621,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2629,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2650,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2668,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2735,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2744,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2753,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2762,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2771,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2798,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2807,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2816,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2825,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2888,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2915,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2924,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2933,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3059,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3068,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3086,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3095,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3112,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3124,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3142,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3150,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3158,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3166,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3181,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3194,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3229,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3239,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3286,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3296,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3352,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,16 +3362,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3383,8 +3382,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3395,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3410,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3424,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3439,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3454,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3468,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3482,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3496,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3510,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3524,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3538,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3552,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3567,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3587,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3607,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3627,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3646,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3666,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3685,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3704,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3723,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3742,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3761,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3780,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3799,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3823,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3847,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3871,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3895,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3919,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3943,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3967,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3991,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4015,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4039,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4063,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4087,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4112,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4136,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4150,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4164,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4179,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4203,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4217,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4231,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4246,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4260,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4289,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4318,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4347,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4376,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4405,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4419,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4438,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4467,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4496,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4510,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4529,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4548,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4562,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4576,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4590,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4604,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4721,14 +4720,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4754,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4763,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4779,14 +4778,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4826,14 +4825,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,14 +4870,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4961,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +5004,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5032,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5061,20 +5060,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5175,26 +5174,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5376,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5420,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5464,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5483,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5502,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5521,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5542,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5568,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5592,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5611,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5630,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5659,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5688,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5717,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5757,20 +5756,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["a", "create_post"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_create_post = {
   name: "create_post",
   identifier: "main.a.create_post(text)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "t",
@@ -5928,12 +5927,12 @@ const options_create_post = {
   description: undefined
 };
 const parts143 = ["c", "table_mutation"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,12 +5956,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts144 = ["c", "table_query"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5986,18 +5985,18 @@ const options_table_query = {
   description: undefined
 };
 const parts145 = ["a", "post_with_suffix"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -6021,18 +6020,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts146 = ["a", "mutation_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6049,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts147 = ["a", "query_compound_type_array"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_mutation"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,18 +6107,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts149 = ["b", "compound_type_array_query"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6137,23 +6136,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts150 = ["a", "post_computed_compound_type_array"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6171,18 +6170,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts151 = ["a", "post_many"];
-const sqlIdent151 = sql.identifier(...parts151);
+const sqlIdent109 = sql.identifier(...parts151);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6199,7 +6198,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6214,15 +6213,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts152 = ["c", "person_computed_out"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback80 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback80 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6234,15 +6233,15 @@ const extensions170 = {
   }
 };
 const parts153 = ["c", "person_first_name"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback81 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback81 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6253,15 +6252,15 @@ const extensions171 = {
   }
 };
 const parts154 = ["c", "person_computed_out_out"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback82 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback82 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6273,20 +6272,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts155 = ["c", "person_computed_inout"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback83 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback83 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6297,20 +6296,20 @@ const extensions173 = {
   }
 };
 const parts156 = ["c", "person_computed_inout_out"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback84 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback84 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6322,20 +6321,20 @@ const extensions174 = {
   }
 };
 const parts157 = ["c", "person_exists"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback85 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback85 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6346,15 +6345,15 @@ const extensions175 = {
   }
 };
 const parts158 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback86 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback86 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6365,8 +6364,8 @@ const extensions176 = {
   }
 };
 const parts159 = ["c", "func_out_complex"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback87 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback87 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6378,7 +6377,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6389,8 +6388,8 @@ const extensions177 = {
   }
 };
 const parts160 = ["c", "func_out_complex_setof"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback88 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback88 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6402,7 +6401,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6413,8 +6412,8 @@ const extensions178 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback89 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback89 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6426,7 +6425,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6437,8 +6436,8 @@ const extensions179 = {
   }
 };
 const parts162 = ["c", "mutation_out_complex_setof"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback90 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback90 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6450,7 +6449,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6461,13 +6460,13 @@ const extensions180 = {
   }
 };
 const parts163 = ["c", "person_computed_complex"];
-const sqlIdent163 = sql.identifier(...parts163);
-const fromCallback91 = (...args) => sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+const sqlIdent121 = sql.identifier(...parts163);
+const fromCallback91 = (...args) => sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6480,18 +6479,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts164 = ["c", "person_first_post"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6508,7 +6507,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6536,20 +6535,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts165 = ["c", "badly_behaved_function"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6569,12 +6568,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6593,12 +6592,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts167 = ["c", "func_out_table_setof"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6617,12 +6616,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6641,12 +6640,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts169 = ["c", "mutation_out_table_setof"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6665,12 +6664,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts170 = ["c", "table_set_mutation"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6689,12 +6688,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6715,12 +6714,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts172 = ["c", "table_set_query_plpgsql"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6739,18 +6738,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts173 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6769,18 +6768,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts174 = ["c", "person_friends"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6798,7 +6797,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6806,7 +6805,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6821,20 +6820,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts175 = ["b", "type_function_connection"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6853,12 +6852,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts176 = ["b", "type_function_connection_mutation"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6877,12 +6876,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts177 = ["b", "type_function"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,12 +6905,12 @@ const options_type_function = {
   description: undefined
 };
 const parts178 = ["b", "type_function_mutation"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6935,18 +6934,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function_connection"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6964,18 +6963,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts180 = ["c", "person_type_function"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6998,12 +6997,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7022,12 +7021,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts182 = ["b", "type_function_list_mutation"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7046,18 +7045,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts183 = ["c", "person_type_function_list"];
-const sqlIdent183 = sql.identifier(...parts183);
+const sqlIdent141 = sql.identifier(...parts183);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent183}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7094,61 +7093,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7159,18 +7158,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7180,38 +7179,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7219,14 +7218,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7239,7 +7238,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7252,7 +7251,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7265,7 +7264,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7278,7 +7277,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7291,7 +7290,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7304,7 +7303,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7317,7 +7316,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7330,7 +7329,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7343,7 +7342,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7356,7 +7355,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7369,7 +7368,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7382,7 +7381,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7395,7 +7394,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7408,7 +7407,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7421,7 +7420,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7434,7 +7433,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7447,7 +7446,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7460,7 +7459,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7473,7 +7472,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7486,7 +7485,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7499,7 +7498,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7512,7 +7511,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7525,7 +7524,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7538,7 +7537,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7551,7 +7550,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7564,7 +7563,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7577,7 +7576,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7590,7 +7589,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7603,7 +7602,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7616,7 +7615,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7629,7 +7628,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7642,7 +7641,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7655,7 +7654,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7668,7 +7667,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7681,7 +7680,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7694,7 +7693,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7707,7 +7706,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7720,7 +7719,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7733,7 +7732,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7746,7 +7745,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7759,7 +7758,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7772,7 +7771,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7785,7 +7784,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7798,7 +7797,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7811,7 +7810,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7824,7 +7823,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7837,7 +7836,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7850,7 +7849,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7863,7 +7862,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7876,7 +7875,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7889,7 +7888,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7902,7 +7901,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7915,7 +7914,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7928,7 +7927,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7941,7 +7940,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7954,7 +7953,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7967,7 +7966,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7977,10 +7976,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7990,10 +7989,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -8003,10 +8002,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -8016,10 +8015,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8029,180 +8028,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8214,7 +8213,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8225,22 +8224,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8261,7 +8260,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8274,7 +8273,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8287,7 +8286,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8300,7 +8299,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8310,10 +8309,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8323,10 +8322,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8339,7 +8338,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8352,7 +8351,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8365,7 +8364,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8378,7 +8377,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8391,7 +8390,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8404,7 +8403,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8417,7 +8416,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8430,7 +8429,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8458,7 +8457,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8471,7 +8470,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8484,7 +8483,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8497,7 +8496,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8510,7 +8509,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8523,7 +8522,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8536,7 +8535,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8549,7 +8548,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8562,7 +8561,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8575,7 +8574,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8588,7 +8587,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8601,7 +8600,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8630,7 +8629,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8645,7 +8644,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8662,7 +8661,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8677,7 +8676,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8692,7 +8691,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8709,7 +8708,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8726,7 +8725,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8743,7 +8742,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8758,7 +8757,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8775,7 +8774,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8790,7 +8789,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8805,7 +8804,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8820,7 +8819,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8837,7 +8836,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8854,7 +8853,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8869,7 +8868,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8884,7 +8883,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8901,7 +8900,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8916,7 +8915,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8931,7 +8930,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8948,7 +8947,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11121,7 +11120,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11133,7 +11132,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11366,7 +11365,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11470,7 +11469,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11522,7 +11521,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12983,7 +12982,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14110,7 +14109,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16123,7 +16122,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16276,7 +16275,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16459,7 +16458,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16764,7 +16763,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16776,7 +16775,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16886,7 +16885,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16941,7 +16940,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17051,7 +17050,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17112,7 +17111,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17167,7 +17166,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17222,7 +17221,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33863,7 +33862,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33879,7 +33878,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35167,7 +35166,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35190,7 +35189,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35213,7 +35212,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35236,7 +35235,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35259,7 +35258,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35282,7 +35281,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35305,7 +35304,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35328,7 +35327,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35351,7 +35350,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35374,7 +35373,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35397,7 +35396,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35420,7 +35419,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35443,7 +35442,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35466,7 +35465,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35489,7 +35488,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35512,7 +35511,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35535,7 +35534,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35558,7 +35557,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35581,7 +35580,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35604,7 +35603,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35627,7 +35626,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35650,7 +35649,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35673,7 +35672,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35696,7 +35695,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35719,7 +35718,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35742,7 +35741,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35765,7 +35764,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35788,7 +35787,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35811,7 +35810,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35834,7 +35833,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35857,7 +35856,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35880,7 +35879,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35903,7 +35902,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35926,7 +35925,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35949,7 +35948,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35972,7 +35971,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35995,7 +35994,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -36018,7 +36017,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36041,7 +36040,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36064,7 +36063,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36087,7 +36086,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36110,7 +36109,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36133,7 +36132,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36156,7 +36155,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36179,7 +36178,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36202,7 +36201,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36225,7 +36224,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36370,7 +36369,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36386,7 +36385,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36801,7 +36800,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36817,7 +36816,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36983,7 +36982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -37006,7 +37005,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -37029,7 +37028,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37052,7 +37051,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37075,7 +37074,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37098,7 +37097,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37302,7 +37301,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37325,7 +37324,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37348,7 +37347,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37424,7 +37423,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37440,7 +37439,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37572,7 +37571,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37595,7 +37594,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37618,7 +37617,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38056,7 +38055,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38079,7 +38078,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38102,7 +38101,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38125,7 +38124,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38148,7 +38147,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38171,7 +38170,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38194,7 +38193,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38217,7 +38216,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38240,7 +38239,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38263,7 +38262,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38286,7 +38285,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38398,7 +38397,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38432,7 +38431,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38448,7 +38447,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38512,7 +38511,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38546,7 +38545,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38562,7 +38561,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38626,7 +38625,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38660,7 +38659,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38676,7 +38675,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38740,7 +38739,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38774,7 +38773,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38790,7 +38789,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38854,7 +38853,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38888,7 +38887,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38904,7 +38903,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38968,7 +38967,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -39002,7 +39001,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39018,7 +39017,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39116,7 +39115,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39139,7 +39138,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39255,7 +39254,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39278,7 +39277,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39440,7 +39439,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39463,7 +39462,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39486,7 +39485,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39520,7 +39519,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39536,7 +39535,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39634,7 +39633,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39657,7 +39656,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39691,7 +39690,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39707,7 +39706,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39805,7 +39804,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39828,7 +39827,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39862,7 +39861,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39878,7 +39877,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40010,7 +40009,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40033,7 +40032,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40056,7 +40055,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40090,7 +40089,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40106,7 +40105,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40272,7 +40271,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40295,7 +40294,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40318,7 +40317,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40341,7 +40340,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40375,7 +40374,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40391,7 +40390,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40557,7 +40556,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40580,7 +40579,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40603,7 +40602,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40626,7 +40625,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40825,7 +40824,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40848,7 +40847,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40871,7 +40870,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40894,7 +40893,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40928,7 +40927,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40944,7 +40943,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41110,7 +41109,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41133,7 +41132,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41156,7 +41155,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41179,7 +41178,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41375,7 +41374,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41398,7 +41397,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41421,7 +41420,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41455,7 +41454,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41471,7 +41470,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41637,7 +41636,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41660,7 +41659,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41683,7 +41682,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41706,7 +41705,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41740,7 +41739,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41756,7 +41755,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41854,7 +41853,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41877,7 +41876,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,33 +3371,33 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("a", "create_post");
-const sqlIdent101 = sql.identifier("c", "table_mutation");
-const sqlIdent102 = sql.identifier("c", "table_query");
-const sqlIdent103 = sql.identifier("a", "post_with_suffix");
-const sqlIdent104 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent105 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent107 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent108 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent109 = sql.identifier("a", "post_many");
-const sqlIdent110 = sql.identifier("c", "person_computed_out");
-const sqlIdent111 = sql.identifier("c", "person_first_name");
-const sqlIdent112 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout");
-const sqlIdent114 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent115 = sql.identifier("c", "person_exists");
-const sqlIdent116 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent117 = sql.identifier("c", "func_out_complex");
-const sqlIdent118 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent120 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent121 = sql.identifier("c", "person_computed_complex");
-const sqlIdent122 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const create_postFunctionIdentifer = sql.identifier("a", "create_post");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3413,12 +3413,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3431,17 +3431,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent123 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent124 = sql.identifier("c", "func_out_table");
-const sqlIdent125 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table");
-const sqlIdent127 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent128 = sql.identifier("c", "table_set_mutation");
-const sqlIdent129 = sql.identifier("c", "table_set_query");
-const sqlIdent130 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent131 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent132 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3450,12 +3450,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3470,15 +3470,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent133 = sql.identifier("b", "type_function_connection");
-const sqlIdent134 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent135 = sql.identifier("b", "type_function");
-const sqlIdent136 = sql.identifier("b", "type_function_mutation");
-const sqlIdent137 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent138 = sql.identifier("c", "person_type_function");
-const sqlIdent139 = sql.identifier("b", "type_function_list");
-const sqlIdent140 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent141 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3677,7 +3677,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3730,7 +3730,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3792,16 +3792,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3821,11 +3821,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3846,11 +3846,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3871,11 +3871,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3895,11 +3895,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3920,11 +3920,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3945,11 +3945,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3969,11 +3969,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3993,11 +3993,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4017,11 +4017,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4041,11 +4041,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4065,11 +4065,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4089,11 +4089,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4113,11 +4113,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4143,11 +4143,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4173,11 +4173,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4203,11 +4203,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4233,11 +4233,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4262,11 +4262,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4292,11 +4292,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4321,11 +4321,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4350,11 +4350,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4379,11 +4379,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4408,11 +4408,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4437,11 +4437,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4466,11 +4466,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4500,11 +4500,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4534,11 +4534,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4568,11 +4568,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4602,11 +4602,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4636,11 +4636,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4670,11 +4670,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4704,11 +4704,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4738,11 +4738,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4772,11 +4772,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4806,11 +4806,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4840,11 +4840,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4874,11 +4874,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4908,11 +4908,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4943,11 +4943,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4967,11 +4967,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4991,11 +4991,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5015,11 +5015,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5050,11 +5050,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5074,11 +5074,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5098,11 +5098,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5122,11 +5122,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5147,11 +5147,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5186,11 +5186,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5225,11 +5225,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5264,11 +5264,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5303,11 +5303,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5342,11 +5342,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5366,11 +5366,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5395,11 +5395,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5434,11 +5434,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5473,11 +5473,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5497,11 +5497,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5526,11 +5526,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5555,11 +5555,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5579,11 +5579,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5603,11 +5603,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5627,11 +5627,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5651,7 +5651,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5672,12 +5672,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5691,12 +5691,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5710,12 +5710,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5729,12 +5729,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5748,12 +5748,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5767,12 +5767,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5787,7 +5787,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5813,7 +5813,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5833,12 +5833,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5853,12 +5853,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5873,12 +5873,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5892,12 +5892,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5911,7 +5911,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5942,12 +5942,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5961,11 +5961,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5993,7 +5993,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6012,11 +6012,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6051,7 +6051,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6074,7 +6074,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6096,7 +6096,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6134,7 +6134,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6166,7 +6166,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6188,7 +6188,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6210,7 +6210,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6244,7 +6244,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6268,7 +6268,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6302,11 +6302,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6356,11 +6356,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6410,11 +6410,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6439,11 +6439,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6468,11 +6468,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6497,11 +6497,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6526,11 +6526,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6562,11 +6562,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6598,11 +6598,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6627,11 +6627,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6656,11 +6656,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6695,11 +6695,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6734,11 +6734,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6773,11 +6773,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6816,7 +6816,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6838,7 +6838,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6865,7 +6865,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6892,7 +6892,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6919,7 +6919,7 @@ const registry = makeRegistry({
       name: "create_post",
       identifier: "main.a.create_post(text)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${create_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "t",
@@ -6946,7 +6946,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6973,7 +6973,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7000,7 +7000,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7033,7 +7033,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7060,7 +7060,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7087,7 +7087,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7114,7 +7114,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7141,7 +7141,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7173,7 +7173,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7197,11 +7197,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7230,11 +7230,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7260,11 +7260,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7289,11 +7289,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7324,11 +7324,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7358,11 +7358,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7393,11 +7393,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7422,11 +7422,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7456,11 +7456,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7490,11 +7490,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7524,11 +7524,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7558,11 +7558,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7628,7 +7628,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7651,7 +7651,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7673,7 +7673,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7695,7 +7695,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7717,7 +7717,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7739,7 +7739,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7761,7 +7761,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7785,7 +7785,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7835,7 +7835,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7864,7 +7864,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7886,7 +7886,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7908,7 +7908,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7935,7 +7935,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7962,7 +7962,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7989,7 +7989,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8021,7 +8021,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8043,7 +8043,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8065,7 +8065,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30679,7 +30679,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30695,7 +30695,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33193,7 +33193,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33209,7 +33209,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33631,7 +33631,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33647,7 +33647,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34268,7 +34268,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34284,7 +34284,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35353,7 +35353,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35369,7 +35369,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35474,7 +35474,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35490,7 +35490,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35595,7 +35595,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35611,7 +35611,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35716,7 +35716,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35732,7 +35732,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35837,7 +35837,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35853,7 +35853,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35958,7 +35958,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35974,7 +35974,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36497,7 +36497,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36513,7 +36513,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36675,7 +36675,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36691,7 +36691,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36853,7 +36853,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36869,7 +36869,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37088,7 +37088,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37104,7 +37104,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37380,7 +37380,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37396,7 +37396,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37947,7 +37947,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37963,7 +37963,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38488,7 +38488,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38504,7 +38504,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38780,7 +38780,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38796,7 +38796,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42408,7 +42408,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42495,7 +42495,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42744,7 +42744,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42801,7 +42801,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43058,7 +43058,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43169,7 +43169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43251,7 +43251,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43318,7 +43318,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43385,7 +43385,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43452,7 +43452,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43519,7 +43519,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43586,7 +43586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43814,7 +43814,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43888,7 +43888,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43967,7 +43967,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44048,7 +44048,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44139,7 +44139,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44227,7 +44227,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44372,7 +44372,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44510,7 +44510,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44603,7 +44603,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44677,7 +44677,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44740,7 +44740,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44877,7 +44877,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45290,7 +45290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45370,7 +45370,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45450,7 +45450,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45530,7 +45530,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45610,7 +45610,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45690,7 +45690,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45819,7 +45819,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45906,7 +45906,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45998,7 +45998,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46092,7 +46092,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46197,7 +46197,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46298,7 +46298,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46399,7 +46399,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46500,7 +46500,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46620,7 +46620,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46707,7 +46707,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46827,7 +46827,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46991,7 +46991,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47422,7 +47422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47486,7 +47486,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47550,7 +47550,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47614,7 +47614,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47678,7 +47678,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47742,7 +47742,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47826,7 +47826,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47890,7 +47890,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47959,7 +47959,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48023,7 +48023,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48098,7 +48098,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48162,7 +48162,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48226,7 +48226,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48290,7 +48290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48367,7 +48367,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48431,7 +48431,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48500,7 +48500,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48572,7 +48572,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const geomAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -148,10 +148,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_geom = {
+const geomIdentifier = sql.identifier(...["geometry", "geom"]);
+const geomCodecSpec = {
   name: "geom",
-  identifier: sql.identifier(...["geometry", "geom"]),
-  attributes,
+  identifier: geomIdentifier,
+  attributes: geomAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -164,7 +165,7 @@ const spec_geom = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_geom_geom = recordCodec(spec_geom);
+const geomCodec = recordCodec(geomCodecSpec);
 const extensions2 = {
   description: undefined,
   pg: {
@@ -189,7 +190,7 @@ const pgResource_geomPgResource = makeRegistry({
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
     point: TYPES.point,
-    geom: registryConfig_pgCodecs_geom_geom,
+    geom: geomCodec,
     line: TYPES.line,
     lseg: TYPES.lseg,
     box: TYPES.box,
@@ -202,8 +203,8 @@ const pgResource_geomPgResource = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "geom",
       identifier: "main.geometry.geom",
-      from: registryConfig_pgCodecs_geom_geom.sqlType,
-      codec: registryConfig_pgCodecs_geom_geom,
+      from: geomCodec.sqlType,
+      codec: geomCodec,
       uniques,
       isVirtual: false,
       description: undefined,
@@ -1023,7 +1024,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_geom_geom.attributes[attributeName];
+          const attribute = geomCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1039,7 +1040,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_geom_geom.attributes[attributeName];
+          const attribute = geomCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1375,7 +1376,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.id.codec)}`;
             }
           });
         }
@@ -1398,7 +1399,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.point.codec)}`;
             }
           });
         }
@@ -1421,7 +1422,7 @@ export const plans = {
             type: "attribute",
             attribute: "line",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.line.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.line.codec)}`;
             }
           });
         }
@@ -1444,7 +1445,7 @@ export const plans = {
             type: "attribute",
             attribute: "lseg",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.lseg.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.lseg.codec)}`;
             }
           });
         }
@@ -1467,7 +1468,7 @@ export const plans = {
             type: "attribute",
             attribute: "box",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.box.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.box.codec)}`;
             }
           });
         }
@@ -1490,7 +1491,7 @@ export const plans = {
             type: "attribute",
             attribute: "open_path",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.open_path.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.open_path.codec)}`;
             }
           });
         }
@@ -1513,7 +1514,7 @@ export const plans = {
             type: "attribute",
             attribute: "closed_path",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.closed_path.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.closed_path.codec)}`;
             }
           });
         }
@@ -1536,7 +1537,7 @@ export const plans = {
             type: "attribute",
             attribute: "polygon",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.polygon.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.polygon.codec)}`;
             }
           });
         }
@@ -1559,7 +1560,7 @@ export const plans = {
             type: "attribute",
             attribute: "circle",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.circle.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), geomAttributes.circle.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -131,7 +131,7 @@ const geomAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -155,9 +155,9 @@ const geomCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const geomUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -182,12 +182,12 @@ const pgResource_geomPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     geom: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "geom",
       identifier: "main.geometry.geom",
       from: geomCodec.sqlType,
       codec: geomCodec,
-      uniques,
+      uniques: geomUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -936,7 +936,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        geomUniques[0].attributes.forEach(attributeName => {
           const attribute = geomCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -952,7 +952,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        geomUniques[0].attributes.forEach(attributeName => {
           const attribute = geomCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1618,7 +1618,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = geomUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1741,7 +1741,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = geomUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1882,7 +1882,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = geomUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const geomAttributes = Object.assign(Object.create(null), {
@@ -148,10 +141,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const geomIdentifier = sql.identifier(...["geometry", "geom"]);
-const geomCodecSpec = {
+const geomCodec = recordCodec({
   name: "geom",
-  identifier: geomIdentifier,
+  identifier: sql.identifier("geometry", "geom"),
   attributes: geomAttributes,
   description: undefined,
   extensions: {
@@ -164,17 +156,7 @@ const geomCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const geomCodec = recordCodec(geomCodecSpec);
-const extensions2 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "geometry",
-    name: "geom"
-  },
-  tags: {}
-};
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -208,7 +190,15 @@ const pgResource_geomPgResource = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions2
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "geometry",
+          name: "geom"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -261,21 +251,6 @@ const fetcher = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Geom);
-function Query_allGeoms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGeoms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGeoms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGeoms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGeoms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -294,99 +269,14 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function GeomsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GeomsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GeomsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Mutation_createGeom_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Geom, $nodeId);
 };
-function Mutation_updateGeom_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGeomById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Geom, $nodeId);
 };
-function Mutation_deleteGeom_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGeomById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateGeomPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGeomPayload_geomPlan($object) {
-  return $object.get("result");
-}
-function CreateGeomPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGeomInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGeomInput_geom_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGeomPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGeomPayload_geomPlan($object) {
-  return $object.get("result");
-}
-function UpdateGeomPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGeomInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGeomInput_geomPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGeomByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGeomByIdInput_geomPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteGeomPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGeomPayload_geomPlan($object) {
-  return $object.get("result");
-}
-function DeleteGeomPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGeomInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGeomByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -871,7 +761,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -910,23 +802,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGeoms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGeoms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGeoms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGeoms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGeoms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -990,9 +892,16 @@ export const plans = {
   Circle: {},
   GeomsConnection: {
     __assertStep: ConnectionStep,
-    nodes: GeomsConnection_nodesPlan,
-    edges: GeomsConnection_edgesPlan,
-    pageInfo: GeomsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1008,8 +917,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1609,7 +1522,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGeom_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1623,7 +1538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGeom_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1639,7 +1556,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGeomById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1653,7 +1572,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGeom_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1669,16 +1590,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGeomById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateGeomPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGeomPayload_clientMutationIdPlan,
-    geom: CreateGeomPayload_geomPlan,
-    query: CreateGeomPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    geom($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     geomEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1713,11 +1642,16 @@ export const plans = {
   },
   CreateGeomInput: {
     clientMutationId: {
-      applyPlan: CreateGeomInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     geom: {
-      applyPlan: CreateGeomInput_geom_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -1788,9 +1722,15 @@ export const plans = {
   },
   UpdateGeomPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGeomPayload_clientMutationIdPlan,
-    geom: UpdateGeomPayload_geomPlan,
-    query: UpdateGeomPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    geom($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     geomEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1825,11 +1765,16 @@ export const plans = {
   },
   UpdateGeomInput: {
     clientMutationId: {
-      applyPlan: UpdateGeomInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     geomPatch: {
-      applyPlan: UpdateGeomInput_geomPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GeomPatch: {
@@ -1899,23 +1844,34 @@ export const plans = {
   },
   UpdateGeomByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGeomByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     geomPatch: {
-      applyPlan: UpdateGeomByIdInput_geomPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteGeomPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGeomPayload_clientMutationIdPlan,
-    geom: DeleteGeomPayload_geomPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    geom($object) {
+      return $object.get("result");
+    },
     deletedGeomId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Geom.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteGeomPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     geomEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1950,13 +1906,17 @@ export const plans = {
   },
   DeleteGeomInput: {
     clientMutationId: {
-      applyPlan: DeleteGeomInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteGeomByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGeomByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,67 +416,60 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
+const nonUpdatableViewCodec = recordCodec({
+  name: "nonUpdatableView",
+  identifier: sql.identifier("a", "non_updatable_view"),
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
       }
     }
-  }
-});
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
-  name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
-  attributes: nonUpdatableViewAttributes,
+  }),
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -506,26 +481,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -537,26 +508,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -568,26 +535,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -599,26 +562,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -630,26 +589,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -672,81 +627,72 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
-  attributes: foreignKeyAttributes,
+  identifier: sql.identifier("a", "foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -769,102 +715,71 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
-  attributes: testviewAttributes,
-  description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
+  identifier: sql.identifier("a", "testview"),
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
       }
     }
-  }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
+  },
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -878,17 +793,35 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -911,26 +844,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -954,28 +883,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1009,26 +934,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1062,26 +983,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1126,26 +1043,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1190,95 +1103,86 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
-  attributes: updatableViewAttributes,
+  identifier: sql.identifier("b", "updatable_view"),
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1323,95 +1227,85 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
-  attributes: edgeCaseAttributes,
+  identifier: sql.identifier("c", "edge_case"),
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1454,116 +1348,104 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1588,267 +1470,242 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1857,29 +1714,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1889,92 +1745,81 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -2043,56 +1888,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2101,29 +1941,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2132,29 +1971,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2164,69 +2002,58 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
+const wrappedUrlCodec = recordCodec({
+  name: "wrappedUrl",
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
       }
     }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
-  name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2348,48 +2175,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2398,37 +2220,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2437,37 +2258,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2476,37 +2296,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2515,37 +2334,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2554,37 +2372,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2594,201 +2411,172 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3356,1520 +3144,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4878,15 +3260,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4895,15 +3268,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4912,15 +3276,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4929,15 +3284,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4946,15 +3292,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4963,93 +3300,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -5059,17 +3356,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -5087,16 +3373,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -5106,15 +3393,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -5132,16 +3410,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -5151,15 +3428,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5168,37 +3436,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5207,97 +3444,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5322,103 +3471,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5436,571 +3521,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6018,732 +3567,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6768,274 +3648,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -7053,254 +3685,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7415,19 +3820,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7436,9 +3862,189 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {
+              behavior: ["-filterBy -orderBy"]
+            }
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7453,813 +4059,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8271,7 +5910,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8282,7 +5931,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8293,7 +5950,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8304,7 +5969,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8315,7 +5988,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8326,7 +6007,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8337,7 +6026,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8346,10 +6043,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8357,10 +6069,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8372,7 +6092,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8384,7 +6112,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8396,7 +6132,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8407,7 +6151,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8415,10 +6167,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8429,33 +6201,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8464,394 +6307,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9701,25 +9161,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9862,21 +9303,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9927,21 +9353,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -10050,21 +9461,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10555,21 +9951,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10662,12 +10043,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -11090,21 +10465,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -11173,21 +10533,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11574,21 +10919,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11917,21 +11247,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11982,21 +11297,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -12093,21 +11393,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -12158,21 +11443,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -12241,21 +11511,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12306,21 +11561,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12582,370 +11822,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13519,21 +12399,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13614,21 +12479,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13728,36 +12578,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13805,24 +12625,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13903,21 +12705,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14341,348 +13128,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14729,26 +13175,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14795,9 +13221,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14844,9 +13267,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14893,9 +13313,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14942,9 +13359,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14991,9 +13405,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -15040,9 +13451,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15095,9 +13503,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15150,9 +13555,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15205,9 +13607,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15260,9 +13659,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15315,9 +13711,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15370,9 +13763,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15431,9 +13821,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15492,9 +13879,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15553,9 +13937,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15614,9 +13995,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15675,9 +14053,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15736,9 +14111,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15797,9 +14169,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15858,9 +14227,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15919,9 +14285,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15980,9 +14343,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -16029,9 +14389,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -16078,9 +14435,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -16127,9 +14481,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -16194,9 +14545,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16243,9 +14591,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16298,9 +14643,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16353,9 +14695,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16402,9 +14741,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16451,9 +14787,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16518,9 +14851,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16567,9 +14897,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16634,9 +14961,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16689,9 +15013,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16738,9 +15059,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16787,9 +15105,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16854,9 +15169,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16921,9 +15233,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17006,9 +15315,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -17061,9 +15367,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17116,9 +15419,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17171,9 +15471,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17226,9 +15523,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17287,9 +15581,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17342,9 +15633,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17397,9 +15685,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17452,9 +15737,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17513,9 +15795,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17574,9 +15853,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17623,9 +15899,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17672,9 +15945,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17721,9 +15991,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17770,9 +16037,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17825,9 +16089,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17874,2061 +16135,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29452,7 +25803,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -29698,27 +26051,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29738,23 +26104,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29766,23 +26142,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29804,23 +26190,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29904,23 +26300,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29936,11 +26342,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30012,23 +26422,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30043,23 +26463,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30117,23 +26547,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30193,23 +26633,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30221,23 +26671,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30253,23 +26713,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30281,23 +26751,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30325,23 +26805,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30353,23 +26843,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30555,23 +27055,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30591,23 +27101,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30634,23 +27154,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30677,23 +27207,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30720,23 +27260,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30763,23 +27313,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30806,23 +27366,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30849,23 +27419,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30885,23 +27465,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30928,23 +27518,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30964,23 +27564,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31007,23 +27617,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31050,23 +27670,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31093,23 +27723,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31136,23 +27776,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31179,23 +27829,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31222,23 +27882,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31258,23 +27928,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31301,23 +27981,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31337,23 +28027,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31380,23 +28080,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31423,23 +28133,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31466,23 +28186,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31509,23 +28239,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32040,23 +28780,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32077,23 +28827,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32219,23 +28979,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32275,23 +29045,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32459,12 +29239,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -32480,23 +29272,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32841,23 +29643,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32885,9 +29697,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -32903,8 +29722,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33045,9 +29868,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33378,9 +30208,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33567,9 +30404,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33825,9 +30669,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34038,9 +30889,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34056,9 +30914,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34074,9 +30939,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34092,9 +30964,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34119,9 +30998,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34176,9 +31062,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34203,9 +31096,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34268,9 +31168,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34310,9 +31217,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34415,9 +31329,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34444,9 +31365,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34558,9 +31486,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34672,9 +31607,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34786,9 +31728,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34900,9 +31849,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35014,9 +31970,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35128,9 +32091,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35174,9 +32144,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35256,9 +32233,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35291,9 +32275,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35405,9 +32396,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35519,9 +32517,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35633,9 +32638,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35747,9 +32759,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35861,9 +32880,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35899,9 +32925,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36013,9 +33046,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36082,9 +33122,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36253,9 +33300,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36378,7 +33432,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36393,7 +33449,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36408,7 +33466,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36423,7 +33483,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36438,7 +33500,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36453,7 +33517,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36468,7 +33534,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36483,7 +33551,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36498,7 +33568,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36513,7 +33585,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36528,7 +33602,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36543,7 +33619,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36558,7 +33636,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36573,7 +33653,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36588,7 +33670,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36603,7 +33687,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36618,7 +33704,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36633,7 +33721,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36648,7 +33738,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36663,7 +33755,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36678,7 +33772,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36693,7 +33789,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36708,7 +33806,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36723,7 +33823,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36738,7 +33840,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36753,7 +33857,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36768,7 +33874,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36783,7 +33891,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36798,7 +33908,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36813,7 +33925,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36828,7 +33942,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36843,7 +33959,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36858,7 +33976,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36873,7 +33993,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36888,7 +34010,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36903,7 +34027,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36918,7 +34044,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36933,7 +34061,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36948,7 +34078,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36963,7 +34095,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36978,7 +34112,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -36993,7 +34129,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37008,7 +34146,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37023,7 +34163,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37038,7 +34180,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37053,7 +34197,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37068,7 +34214,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37083,7 +34231,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37098,7 +34248,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37113,7 +34265,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37128,7 +34282,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37143,7 +34299,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37158,7 +34316,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37173,7 +34333,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37188,7 +34350,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37203,7 +34367,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37218,7 +34384,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37233,7 +34401,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37248,7 +34418,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37263,7 +34435,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37278,7 +34452,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37293,7 +34469,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37308,7 +34486,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37323,7 +34503,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37338,7 +34520,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37353,7 +34537,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37368,7 +34554,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37383,7 +34571,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37398,7 +34588,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37413,7 +34605,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37428,7 +34622,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37443,7 +34639,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37458,7 +34656,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37473,7 +34673,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37488,7 +34690,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37503,7 +34707,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37518,7 +34724,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37533,7 +34741,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37548,7 +34758,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37562,7 +34774,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37578,7 +34792,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37592,7 +34808,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37608,7 +34826,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37622,7 +34842,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37638,7 +34860,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37652,7 +34876,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37668,7 +34894,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37682,7 +34910,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37698,7 +34928,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37712,7 +34944,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37728,7 +34962,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37744,7 +34980,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37758,7 +34996,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37774,7 +35014,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37788,7 +35030,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37804,7 +35048,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37818,7 +35064,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37834,7 +35082,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37848,7 +35098,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37865,7 +35117,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37879,7 +35133,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37895,7 +35151,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37909,7 +35167,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37925,7 +35185,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37939,7 +35201,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37955,7 +35219,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37969,7 +35235,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -37985,7 +35253,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38001,7 +35271,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38015,7 +35287,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38031,7 +35305,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38045,7 +35321,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38061,7 +35339,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38075,7 +35355,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38091,7 +35373,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38107,7 +35391,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38121,7 +35407,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38137,7 +35425,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38151,7 +35441,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38167,7 +35459,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38181,7 +35475,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38197,7 +35493,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38211,7 +35509,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38227,7 +35527,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38241,7 +35543,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38257,7 +35561,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38271,7 +35577,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38287,7 +35595,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38301,7 +35611,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38317,7 +35629,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38333,7 +35647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38347,7 +35663,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38363,7 +35681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38377,7 +35697,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38393,7 +35715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38407,7 +35731,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38423,7 +35749,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38437,7 +35765,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38454,7 +35784,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38468,7 +35800,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38484,7 +35818,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38498,7 +35834,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38514,7 +35852,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38528,7 +35868,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38544,7 +35886,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38558,7 +35902,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38574,7 +35920,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38590,7 +35938,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38604,7 +35954,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38620,7 +35972,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38634,7 +35988,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38650,7 +36006,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38664,7 +36022,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38680,7 +36040,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38696,7 +36058,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38710,7 +36074,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -38726,193 +36092,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -38920,15 +36366,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -38936,15 +36388,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -38952,15 +36410,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -38968,15 +36432,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -38984,15 +36454,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -39000,15 +36476,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -39016,15 +36498,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -39032,15 +36520,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -39048,15 +36542,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -39064,11 +36564,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39081,17 +36585,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39104,17 +36614,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39127,21 +36643,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -39150,11 +36674,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39170,17 +36698,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39193,65 +36727,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -39260,11 +36820,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -39286,21 +36850,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39309,11 +36881,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -39353,7 +36929,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -39390,11 +36968,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -39429,35 +37011,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39466,11 +37062,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -39502,7 +37102,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39511,15 +37113,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39531,11 +37139,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39554,48 +37166,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -39635,18 +37265,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -39686,7 +37322,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -39754,56 +37392,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39831,7 +37491,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39839,11 +37501,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -39871,7 +37537,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -39879,11 +37547,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -39918,59 +37590,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40015,30 +37711,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40073,11 +37783,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40092,9 +37807,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40129,11 +37850,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40148,9 +37874,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40185,11 +37917,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40204,9 +37941,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40241,11 +37984,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40260,9 +38008,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40297,11 +38051,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40316,9 +38075,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40353,11 +38118,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40379,9 +38149,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -40396,11 +38172,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40429,17 +38210,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40461,17 +38253,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40500,9 +38303,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40537,11 +38346,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40563,9 +38377,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40605,11 +38425,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40631,9 +38456,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40668,11 +38499,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40701,9 +38537,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40748,11 +38590,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40781,9 +38628,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40818,11 +38671,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40858,9 +38716,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -40895,11 +38759,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40935,17 +38804,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -40981,9 +38861,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41018,11 +38904,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41058,17 +38949,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41097,9 +38999,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41139,11 +39047,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41179,9 +39092,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41216,11 +39135,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41242,9 +39166,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41284,19 +39214,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41331,11 +39272,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41429,9 +39375,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41476,11 +39428,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -41882,9 +39839,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41919,11 +39882,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -41937,18 +39905,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41983,11 +39962,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -42001,18 +39985,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42047,11 +40042,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -42065,18 +40065,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42111,11 +40122,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -42129,18 +40145,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42175,11 +40202,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -42193,18 +40225,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42239,11 +40282,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -42264,26 +40312,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -42304,9 +40368,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42341,11 +40411,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -42366,18 +40441,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42417,11 +40503,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -42442,18 +40533,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42488,11 +40590,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -42520,18 +40627,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42576,11 +40694,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -42608,19 +40731,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42655,11 +40789,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -42694,18 +40833,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42740,11 +40890,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -42779,18 +40934,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42825,11 +40991,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -42864,18 +41035,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42915,11 +41097,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -42954,27 +41141,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43009,11 +41212,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -43034,18 +41242,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43085,11 +41304,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -43138,18 +41362,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43184,11 +41419,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -43272,27 +41512,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43337,11 +41593,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -43691,23 +41952,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43742,26 +42014,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43796,26 +42078,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43850,26 +42142,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43904,26 +42206,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43958,26 +42270,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44012,38 +42334,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44078,26 +42418,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44137,26 +42487,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44191,26 +42551,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44255,27 +42625,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44310,26 +42690,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44364,26 +42754,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44418,26 +42818,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44477,32 +42887,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44537,26 +42959,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44596,26 +43028,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44650,32 +43092,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44720,13 +43174,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -475,7 +475,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -485,17 +485,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -511,22 +573,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -542,22 +604,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -573,84 +635,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -672,7 +672,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -682,17 +682,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -727,7 +727,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -737,17 +737,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -769,7 +769,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -779,17 +779,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -824,7 +824,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -834,17 +834,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -866,7 +866,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -879,17 +879,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -911,7 +911,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -921,17 +921,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -954,7 +954,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -966,17 +966,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1009,7 +1009,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1019,17 +1019,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1062,7 +1062,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1072,17 +1072,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1126,7 +1126,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1136,17 +1136,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1190,7 +1190,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1200,17 +1200,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1256,7 +1256,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1269,17 +1269,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1323,7 +1323,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1333,17 +1333,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1351,13 +1351,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1392,7 +1392,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1402,17 +1402,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1454,7 +1454,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1531,7 +1531,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1541,17 +1541,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1560,13 +1560,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1578,7 +1578,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1588,7 +1588,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1598,20 +1598,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1643,7 +1643,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1655,17 +1655,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1674,16 +1674,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1692,16 +1691,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1710,15 +1709,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1743,7 +1742,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1765,7 +1764,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1776,7 +1775,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1808,7 +1807,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1818,17 +1817,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1839,7 +1838,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1849,7 +1848,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1859,7 +1858,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1870,7 +1869,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1880,7 +1879,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1890,7 +1889,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1899,7 +1898,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1908,21 +1907,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1930,7 +1929,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1954,7 +1953,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1964,23 +1963,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2023,7 +2022,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2034,7 +2033,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2044,7 +2043,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2054,17 +2053,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -2075,7 +2074,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -2083,7 +2082,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -2093,7 +2092,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2103,7 +2102,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2124,7 +2123,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2134,7 +2133,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2155,7 +2154,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2165,7 +2164,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2174,13 +2173,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2189,16 +2188,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2208,7 +2207,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2218,17 +2217,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2252,7 +2251,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2274,7 +2273,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2283,7 +2282,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2349,7 +2348,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2359,20 +2358,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2390,7 +2389,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2400,7 +2399,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2411,7 +2410,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2419,7 +2418,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2429,7 +2428,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2439,7 +2438,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2450,7 +2449,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2458,7 +2457,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2468,7 +2467,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2478,7 +2477,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2489,7 +2488,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2497,7 +2496,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2507,7 +2506,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2517,7 +2516,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2528,7 +2527,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2536,7 +2535,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2546,7 +2545,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2556,7 +2555,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2567,7 +2566,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2575,7 +2574,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2585,7 +2584,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2595,7 +2594,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2603,13 +2602,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2618,13 +2617,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2633,13 +2632,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2648,12 +2647,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2662,12 +2661,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2676,15 +2675,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2695,7 +2694,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2716,7 +2715,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2726,17 +2725,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2745,13 +2744,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2759,7 +2758,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2767,20 +2766,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2788,13 +2787,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2806,8 +2805,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2885,7 +2884,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2896,7 +2895,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2918,7 +2917,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2929,7 +2928,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2962,7 +2961,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2973,7 +2972,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2984,7 +2983,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2995,7 +2994,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3072,7 +3071,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3094,7 +3093,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3116,7 +3115,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3127,7 +3126,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3281,7 +3280,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3292,7 +3291,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3314,7 +3313,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3325,7 +3324,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3336,7 +3335,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3346,7 +3345,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3358,17 +3357,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3376,7 +3375,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3384,7 +3383,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3392,7 +3391,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3400,13 +3399,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3415,12 +3414,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3428,13 +3427,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3469,7 +3468,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3479,16 +3478,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3534,7 +3533,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3544,16 +3543,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3610,7 +3609,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3620,16 +3619,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3640,8 +3639,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3653,10 +3652,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3668,10 +3667,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3682,10 +3681,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3697,10 +3696,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3712,10 +3711,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3726,10 +3725,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3740,10 +3739,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3754,10 +3753,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3768,10 +3767,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3782,10 +3781,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3796,10 +3795,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3810,10 +3809,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3825,15 +3824,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3845,15 +3844,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3865,15 +3864,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3885,15 +3884,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3904,15 +3903,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3924,15 +3923,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3943,15 +3942,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3962,15 +3961,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3981,15 +3980,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4000,15 +3999,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4019,15 +4018,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4038,15 +4037,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4057,8 +4056,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -4070,7 +4069,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4081,8 +4080,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -4094,7 +4093,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4105,8 +4104,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -4118,7 +4117,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4129,8 +4128,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -4142,7 +4141,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4153,8 +4152,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -4166,7 +4165,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4177,8 +4176,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -4190,7 +4189,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4201,8 +4200,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -4214,7 +4213,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4225,8 +4224,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -4238,7 +4237,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4249,8 +4248,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4262,7 +4261,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4273,8 +4272,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4286,7 +4285,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4297,8 +4296,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4310,7 +4309,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4321,8 +4320,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4334,7 +4333,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4345,8 +4344,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4358,7 +4357,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4370,8 +4369,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4383,7 +4382,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4394,10 +4393,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4408,10 +4407,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4422,10 +4421,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4437,8 +4436,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4450,7 +4449,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4461,10 +4460,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4475,10 +4474,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4489,10 +4488,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4504,10 +4503,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4518,8 +4517,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4536,7 +4535,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4547,8 +4546,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4565,7 +4564,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4576,8 +4575,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4594,7 +4593,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4605,8 +4604,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4623,7 +4622,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4634,8 +4633,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4652,7 +4651,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4663,10 +4662,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4677,15 +4676,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4696,8 +4695,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4714,7 +4713,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4725,8 +4724,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4743,7 +4742,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4754,10 +4753,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4768,15 +4767,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4787,15 +4786,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4806,10 +4805,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4820,10 +4819,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4834,10 +4833,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4848,10 +4847,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4862,7 +4861,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4879,7 +4878,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4896,7 +4895,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4913,7 +4912,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4930,7 +4929,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4947,7 +4946,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4964,7 +4963,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4978,14 +4977,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5002,7 +5001,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5012,7 +5011,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5021,7 +5020,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -5036,14 +5035,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5060,7 +5059,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -5083,14 +5082,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5107,7 +5106,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5128,14 +5127,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5152,7 +5151,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5169,7 +5168,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -5191,7 +5190,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5208,7 +5207,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5219,21 +5218,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5251,7 +5250,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5262,13 +5261,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5280,7 +5279,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5290,7 +5289,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5318,20 +5317,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5349,7 +5348,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5365,20 +5364,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5411,7 +5410,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5432,26 +5431,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5474,12 +5473,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5498,12 +5497,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5522,12 +5521,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5561,12 +5560,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5599,7 +5598,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5616,14 +5615,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5634,8 +5633,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5655,7 +5654,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5665,9 +5664,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5678,8 +5677,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5699,7 +5698,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5709,9 +5708,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5722,15 +5721,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5741,15 +5740,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5760,15 +5759,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5779,15 +5778,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5800,20 +5799,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5826,20 +5825,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5850,15 +5849,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5869,15 +5868,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5888,13 +5887,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5906,7 +5905,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5917,13 +5916,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5935,7 +5934,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5946,13 +5945,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5964,7 +5963,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5975,8 +5974,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5993,7 +5992,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6014,20 +6013,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6045,7 +6044,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -6061,26 +6060,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6098,18 +6097,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6127,18 +6126,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6156,12 +6155,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6185,12 +6184,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6214,18 +6213,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -6249,18 +6248,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6278,18 +6277,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6307,18 +6306,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6336,18 +6335,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6365,23 +6364,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6399,18 +6398,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6427,7 +6426,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6442,15 +6441,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6462,15 +6461,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6481,15 +6480,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6501,20 +6500,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6525,20 +6524,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6550,20 +6549,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6574,15 +6573,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6593,8 +6592,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6606,7 +6605,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6617,8 +6616,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6630,7 +6629,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6641,8 +6640,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6654,7 +6653,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6665,8 +6664,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6678,7 +6677,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6689,13 +6688,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6708,18 +6707,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6736,7 +6735,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6764,20 +6763,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6797,12 +6796,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6821,12 +6820,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6845,12 +6844,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6869,12 +6868,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6893,12 +6892,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6917,12 +6916,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6943,12 +6942,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6967,18 +6966,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6997,18 +6996,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -7026,7 +7025,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -7034,7 +7033,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -7049,20 +7048,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -7081,12 +7080,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -7105,12 +7104,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -7134,12 +7133,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -7163,18 +7162,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -7192,18 +7191,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -7226,12 +7225,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7250,12 +7249,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7274,18 +7273,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7322,61 +7321,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7387,18 +7386,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7408,38 +7407,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7447,14 +7446,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7467,7 +7466,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7480,7 +7479,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7493,7 +7492,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7506,7 +7505,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7519,7 +7518,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7532,7 +7531,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7545,7 +7544,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7558,7 +7557,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7571,7 +7570,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7584,7 +7583,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7597,7 +7596,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7610,7 +7609,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7623,7 +7622,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7636,7 +7635,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7649,7 +7648,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7662,7 +7661,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7675,7 +7674,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7688,7 +7687,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7701,7 +7700,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7714,7 +7713,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7727,7 +7726,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7740,7 +7739,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7753,7 +7752,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7766,7 +7765,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7779,7 +7778,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7792,7 +7791,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7805,7 +7804,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7818,7 +7817,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7831,7 +7830,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7844,7 +7843,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7857,7 +7856,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7870,7 +7869,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7883,7 +7882,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7896,7 +7895,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7909,7 +7908,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7922,7 +7921,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7935,7 +7934,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7948,7 +7947,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7961,7 +7960,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7974,7 +7973,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7987,7 +7986,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -8000,7 +7999,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -8013,7 +8012,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -8026,7 +8025,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -8039,7 +8038,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -8052,7 +8051,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -8065,7 +8064,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -8078,7 +8077,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -8091,7 +8090,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -8104,7 +8103,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -8117,7 +8116,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -8130,7 +8129,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -8143,7 +8142,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -8156,7 +8155,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -8169,7 +8168,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -8182,7 +8181,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -8195,7 +8194,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -8205,10 +8204,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -8218,10 +8217,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -8231,10 +8230,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -8244,10 +8243,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8257,180 +8256,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8442,7 +8441,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8453,22 +8452,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8489,7 +8488,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8502,7 +8501,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8515,7 +8514,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8528,7 +8527,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8538,10 +8537,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8551,10 +8550,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8567,7 +8566,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8580,7 +8579,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8593,7 +8592,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8606,7 +8605,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8619,7 +8618,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8632,7 +8631,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8645,7 +8644,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8658,7 +8657,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8685,7 +8684,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8698,7 +8697,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8711,7 +8710,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8724,7 +8723,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8737,7 +8736,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8750,7 +8749,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8763,7 +8762,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8776,7 +8775,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8789,7 +8788,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8802,7 +8801,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8815,7 +8814,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8828,7 +8827,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8857,7 +8856,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8872,7 +8871,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8889,7 +8888,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8904,7 +8903,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8919,7 +8918,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8936,7 +8935,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8953,7 +8952,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8970,7 +8969,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8985,7 +8984,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9002,7 +9001,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -9017,7 +9016,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -9032,7 +9031,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -9047,7 +9046,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -9064,7 +9063,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -9081,7 +9080,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9096,7 +9095,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9111,7 +9110,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9128,7 +9127,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9143,7 +9142,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9158,7 +9157,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9175,7 +9174,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11348,7 +11347,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11360,7 +11359,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11593,7 +11592,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11697,7 +11696,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11749,7 +11748,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -13195,7 +13194,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14292,7 +14291,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16305,7 +16304,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16458,7 +16457,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16641,7 +16640,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16946,7 +16945,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16958,7 +16957,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -17068,7 +17067,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17123,7 +17122,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17233,7 +17232,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17294,7 +17293,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17349,7 +17348,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17404,7 +17403,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33288,7 +33287,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33304,7 +33303,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33368,7 +33367,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -33462,7 +33461,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33478,7 +33477,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33621,7 +33620,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33637,7 +33636,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33735,7 +33734,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -33758,7 +33757,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -33849,7 +33848,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33865,7 +33864,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33929,7 +33928,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34367,7 +34366,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -34390,7 +34389,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -34468,7 +34467,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34484,7 +34483,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34548,7 +34547,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -34582,7 +34581,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34598,7 +34597,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34662,7 +34661,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -34696,7 +34695,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34712,7 +34711,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34776,7 +34775,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -34810,7 +34809,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34826,7 +34825,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34890,7 +34889,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -34924,7 +34923,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34940,7 +34939,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35004,7 +35003,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -35038,7 +35037,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35054,7 +35053,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35118,7 +35117,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -35246,7 +35245,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -35315,7 +35314,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35331,7 +35330,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35395,7 +35394,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -35429,7 +35428,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35445,7 +35444,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35509,7 +35508,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -35543,7 +35542,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35559,7 +35558,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35623,7 +35622,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -35657,7 +35656,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35673,7 +35672,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35737,7 +35736,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -35771,7 +35770,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35787,7 +35786,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35851,7 +35850,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -35923,7 +35922,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35939,7 +35938,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36003,7 +36002,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -36106,7 +36105,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36122,7 +36121,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36220,7 +36219,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -36243,7 +36242,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -36277,7 +36276,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36293,7 +36292,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36357,7 +36356,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -468,7 +468,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -495,7 +495,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -522,7 +522,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -549,7 +549,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -576,7 +576,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -603,7 +603,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -641,7 +641,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyCodec = recordCodec({
   name: "foreignKey",
@@ -691,7 +691,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -729,7 +729,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewCodec = recordCodec({
   name: "testview",
@@ -779,7 +779,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -820,7 +820,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -858,7 +858,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -899,7 +899,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -948,7 +948,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -997,7 +997,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1057,7 +1057,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1117,7 +1117,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewCodec = recordCodec({
   name: "updatableView",
@@ -1181,7 +1181,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1241,7 +1241,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1304,7 +1304,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1362,7 +1362,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1434,7 +1434,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1484,7 +1484,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1536,7 +1536,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1683,7 +1683,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1712,7 +1712,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1742,7 +1742,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1809,7 +1809,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1902,7 +1902,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1939,7 +1939,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1969,7 +1969,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1999,7 +1999,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -2052,7 +2052,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2189,7 +2189,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2218,7 +2218,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2256,7 +2256,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2294,7 +2294,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2332,7 +2332,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2370,7 +2370,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2408,7 +2408,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2529,7 +2529,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -3150,7 +3150,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -3189,70 +3189,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3260,7 +3260,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3268,7 +3268,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3276,7 +3276,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3284,7 +3284,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3292,7 +3292,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3301,7 +3301,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3320,7 +3320,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3348,7 +3348,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3356,7 +3356,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3365,12 +3365,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3385,7 +3385,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3393,7 +3393,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3402,12 +3402,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3420,7 +3420,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3428,7 +3428,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3436,7 +3436,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3444,10 +3444,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3463,12 +3463,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3481,9 +3481,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3503,8 +3503,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3513,12 +3513,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3531,26 +3531,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3559,12 +3559,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3577,9 +3577,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3599,32 +3599,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3640,12 +3640,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3658,17 +3658,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3677,12 +3677,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3697,15 +3697,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3910,7 +3910,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3971,7 +3971,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -4043,16 +4043,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4072,11 +4072,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4097,11 +4097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4122,11 +4122,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4146,11 +4146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4171,11 +4171,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4196,11 +4196,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4220,11 +4220,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4244,11 +4244,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4268,11 +4268,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4292,11 +4292,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4316,11 +4316,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4340,11 +4340,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4364,11 +4364,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4394,11 +4394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4424,11 +4424,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4454,11 +4454,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4484,11 +4484,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4513,11 +4513,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4543,11 +4543,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4572,11 +4572,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4630,11 +4630,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4659,11 +4659,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4688,11 +4688,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4717,11 +4717,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4751,11 +4751,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4785,11 +4785,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4819,11 +4819,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4853,11 +4853,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4887,11 +4887,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4921,11 +4921,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4955,11 +4955,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4989,11 +4989,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5023,11 +5023,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -5057,11 +5057,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -5091,11 +5091,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -5125,11 +5125,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -5159,11 +5159,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5194,11 +5194,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5218,11 +5218,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5242,11 +5242,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5266,11 +5266,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5301,11 +5301,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5325,11 +5325,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5349,11 +5349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5373,11 +5373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5398,11 +5398,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5437,11 +5437,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5476,11 +5476,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5515,11 +5515,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5593,11 +5593,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5617,11 +5617,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5646,11 +5646,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5685,11 +5685,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5724,11 +5724,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5748,11 +5748,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5777,11 +5777,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5806,11 +5806,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5830,11 +5830,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5854,11 +5854,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5878,11 +5878,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5902,7 +5902,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5923,12 +5923,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5942,12 +5942,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5961,12 +5961,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5980,12 +5980,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5999,12 +5999,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -6018,12 +6018,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6038,7 +6038,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -6064,7 +6064,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -6084,12 +6084,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6104,12 +6104,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6124,12 +6124,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6143,12 +6143,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6162,7 +6162,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -6193,12 +6193,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -6212,11 +6212,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -6244,7 +6244,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6263,11 +6263,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6302,7 +6302,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6325,7 +6325,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6347,7 +6347,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6385,7 +6385,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6417,7 +6417,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6439,7 +6439,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6461,7 +6461,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6495,7 +6495,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6519,7 +6519,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6553,11 +6553,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6607,11 +6607,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6661,11 +6661,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6690,11 +6690,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6719,11 +6719,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6748,11 +6748,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6777,11 +6777,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6813,11 +6813,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6849,11 +6849,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6878,11 +6878,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6907,11 +6907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6946,11 +6946,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6985,11 +6985,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7024,11 +7024,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -7067,7 +7067,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7089,7 +7089,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7116,7 +7116,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7143,7 +7143,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7170,7 +7170,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7197,7 +7197,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7224,7 +7224,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7257,7 +7257,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7284,7 +7284,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7311,7 +7311,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7338,7 +7338,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7365,7 +7365,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7397,7 +7397,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7421,11 +7421,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7454,11 +7454,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7484,11 +7484,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7513,11 +7513,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7548,11 +7548,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7582,11 +7582,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7617,11 +7617,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7646,11 +7646,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7680,11 +7680,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7714,11 +7714,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7748,11 +7748,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7782,11 +7782,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7824,7 +7824,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7852,7 +7852,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7875,7 +7875,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7897,7 +7897,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7919,7 +7919,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7941,7 +7941,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7963,7 +7963,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7985,7 +7985,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8009,7 +8009,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8031,7 +8031,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -8059,7 +8059,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -8088,7 +8088,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8110,7 +8110,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8132,7 +8132,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -8159,7 +8159,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -8186,7 +8186,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8213,7 +8213,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8245,7 +8245,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8267,7 +8267,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8289,7 +8289,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30116,7 +30116,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30132,7 +30132,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30297,7 +30297,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30313,7 +30313,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30463,7 +30463,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30479,7 +30479,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30698,7 +30698,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30714,7 +30714,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31394,7 +31394,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31410,7 +31410,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31515,7 +31515,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31531,7 +31531,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31636,7 +31636,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31652,7 +31652,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31757,7 +31757,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31773,7 +31773,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31878,7 +31878,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31894,7 +31894,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31999,7 +31999,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32015,7 +32015,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32304,7 +32304,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32320,7 +32320,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32425,7 +32425,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32441,7 +32441,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32546,7 +32546,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32562,7 +32562,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32667,7 +32667,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32683,7 +32683,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32788,7 +32788,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32804,7 +32804,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32954,7 +32954,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32970,7 +32970,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33151,7 +33151,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33167,7 +33167,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33329,7 +33329,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33345,7 +33345,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36900,7 +36900,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -36987,7 +36987,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37236,7 +37236,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37293,7 +37293,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37566,7 +37566,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37677,7 +37677,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37759,7 +37759,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37826,7 +37826,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37893,7 +37893,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -37960,7 +37960,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38027,7 +38027,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38094,7 +38094,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38322,7 +38322,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38396,7 +38396,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38475,7 +38475,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38556,7 +38556,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38647,7 +38647,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38735,7 +38735,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -38880,7 +38880,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39018,7 +39018,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39111,7 +39111,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39185,7 +39185,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39248,7 +39248,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39394,7 +39394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39858,7 +39858,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39938,7 +39938,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40018,7 +40018,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40098,7 +40098,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40178,7 +40178,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40258,7 +40258,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40387,7 +40387,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40474,7 +40474,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40566,7 +40566,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40660,7 +40660,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40765,7 +40765,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40866,7 +40866,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40967,7 +40967,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41068,7 +41068,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41188,7 +41188,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41275,7 +41275,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41395,7 +41395,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41559,7 +41559,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41990,7 +41990,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42054,7 +42054,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42118,7 +42118,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42182,7 +42182,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42246,7 +42246,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42310,7 +42310,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42394,7 +42394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42458,7 +42458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42527,7 +42527,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42591,7 +42591,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42666,7 +42666,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42730,7 +42730,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42794,7 +42794,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42858,7 +42858,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42935,7 +42935,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42999,7 +42999,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43068,7 +43068,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43140,7 +43140,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const employeeAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -94,10 +94,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_employee = {
+const employeeIdentifier = sql.identifier(...["index_expressions", "employee"]);
+const employeeCodecSpec = {
   name: "employee",
-  identifier: sql.identifier(...["index_expressions", "employee"]),
-  attributes,
+  identifier: employeeIdentifier,
+  attributes: employeeAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -110,7 +111,7 @@ const spec_employee = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_employee_employee = recordCodec(spec_employee);
+const employeeCodec = recordCodec(employeeCodecSpec);
 const extensions2 = {
   description: undefined,
   pg: {
@@ -134,15 +135,15 @@ const pgResource_employeePgResource = makeRegistry({
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
-    employee: registryConfig_pgCodecs_employee_employee
+    employee: employeeCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     employee: {
       executor: executor_mainPgExecutor,
       name: "employee",
       identifier: "main.index_expressions.employee",
-      from: registryConfig_pgCodecs_employee_employee.sqlType,
-      codec: registryConfig_pgCodecs_employee_employee,
+      from: employeeCodec.sqlType,
+      codec: employeeCodec,
       uniques,
       isVirtual: false,
       description: undefined,
@@ -528,7 +529,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_employee_employee.attributes[attributeName];
+          const attribute = employeeCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -544,7 +545,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_employee_employee.attributes[attributeName];
+          const attribute = employeeCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -676,7 +677,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.id.codec)}`;
             }
           });
         }
@@ -699,7 +700,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.first_name.codec)}`;
             }
           });
         }
@@ -722,7 +723,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.last_name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -77,7 +77,7 @@ const employeeAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -101,9 +101,9 @@ const employeeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const employeeUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -121,12 +121,12 @@ const pgResource_employeePgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     employee: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "employee",
       identifier: "main.index_expressions.employee",
       from: employeeCodec.sqlType,
       codec: employeeCodec,
-      uniques,
+      uniques: employeeUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -510,7 +510,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        employeeUniques[0].attributes.forEach(attributeName => {
           const attribute = employeeCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -526,7 +526,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        employeeUniques[0].attributes.forEach(attributeName => {
           const attribute = employeeCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,32 +3371,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3412,12 +3412,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3430,17 +3430,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3449,12 +3449,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3469,15 +3469,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3729,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,16 +3791,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3820,11 +3820,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3944,11 +3944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3968,11 +3968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3992,11 +3992,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4016,11 +4016,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4040,11 +4040,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4088,11 +4088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4112,11 +4112,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4142,11 +4142,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4172,11 +4172,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4202,11 +4202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4232,11 +4232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4261,11 +4261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4291,11 +4291,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4320,11 +4320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4349,11 +4349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4378,11 +4378,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4407,11 +4407,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4436,11 +4436,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4465,11 +4465,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4499,11 +4499,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4533,11 +4533,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4567,11 +4567,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4635,11 +4635,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4669,11 +4669,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4703,11 +4703,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4737,11 +4737,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4771,11 +4771,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4805,11 +4805,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4839,11 +4839,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4873,11 +4873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4907,11 +4907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4942,11 +4942,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4966,11 +4966,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4990,11 +4990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5014,11 +5014,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5049,11 +5049,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5073,11 +5073,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5121,11 +5121,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5146,11 +5146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5185,11 +5185,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5224,11 +5224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5263,11 +5263,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5302,11 +5302,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5341,11 +5341,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5365,11 +5365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5394,11 +5394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5433,11 +5433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5472,11 +5472,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5496,11 +5496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5525,11 +5525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5578,11 +5578,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5602,11 +5602,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5626,11 +5626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5650,7 +5650,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5671,12 +5671,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5690,12 +5690,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5709,12 +5709,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5728,12 +5728,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5747,12 +5747,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5766,12 +5766,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5786,7 +5786,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5812,7 +5812,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5832,12 +5832,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5852,12 +5852,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5872,12 +5872,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5891,12 +5891,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5910,7 +5910,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5941,12 +5941,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5960,11 +5960,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5992,7 +5992,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6011,11 +6011,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6050,7 +6050,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6073,7 +6073,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6095,7 +6095,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6133,7 +6133,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6165,7 +6165,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6187,7 +6187,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6209,7 +6209,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6243,7 +6243,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6267,7 +6267,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6301,11 +6301,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6355,11 +6355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6409,11 +6409,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6438,11 +6438,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6467,11 +6467,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6496,11 +6496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6525,11 +6525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6561,11 +6561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6597,11 +6597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6626,11 +6626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6655,11 +6655,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6694,11 +6694,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6733,11 +6733,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6772,11 +6772,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6815,7 +6815,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6837,7 +6837,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6864,7 +6864,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6891,7 +6891,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6918,7 +6918,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6945,7 +6945,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6972,7 +6972,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7005,7 +7005,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7032,7 +7032,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7059,7 +7059,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7113,7 +7113,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7145,7 +7145,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7169,11 +7169,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7232,11 +7232,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7261,11 +7261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7330,11 +7330,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7394,11 +7394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7428,11 +7428,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7462,11 +7462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7496,11 +7496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7530,11 +7530,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7572,7 +7572,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7623,7 +7623,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7645,7 +7645,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7667,7 +7667,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7689,7 +7689,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7757,7 +7757,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7779,7 +7779,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7836,7 +7836,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7858,7 +7858,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7880,7 +7880,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7907,7 +7907,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7961,7 +7961,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7993,7 +7993,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8015,7 +8015,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8037,7 +8037,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30656,7 +30656,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30672,7 +30672,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33170,7 +33170,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33186,7 +33186,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33608,7 +33608,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33624,7 +33624,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34245,7 +34245,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34261,7 +34261,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35330,7 +35330,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35346,7 +35346,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35451,7 +35451,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35467,7 +35467,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35572,7 +35572,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35588,7 +35588,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35693,7 +35693,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35709,7 +35709,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35814,7 +35814,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35830,7 +35830,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35935,7 +35935,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35951,7 +35951,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36474,7 +36474,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36490,7 +36490,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36652,7 +36652,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36668,7 +36668,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36830,7 +36830,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36846,7 +36846,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37065,7 +37065,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37081,7 +37081,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37357,7 +37357,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37373,7 +37373,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37924,7 +37924,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37940,7 +37940,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38465,7 +38465,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38481,7 +38481,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38757,7 +38757,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38773,7 +38773,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42385,7 +42385,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42472,7 +42472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42721,7 +42721,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42778,7 +42778,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43035,7 +43035,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43146,7 +43146,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43228,7 +43228,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43295,7 +43295,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43362,7 +43362,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43429,7 +43429,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43496,7 +43496,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43563,7 +43563,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43791,7 +43791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43865,7 +43865,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43944,7 +43944,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44025,7 +44025,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44116,7 +44116,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44204,7 +44204,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44349,7 +44349,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44487,7 +44487,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44580,7 +44580,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44654,7 +44654,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44717,7 +44717,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44854,7 +44854,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45267,7 +45267,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45347,7 +45347,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45427,7 +45427,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45507,7 +45507,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45587,7 +45587,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45667,7 +45667,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45796,7 +45796,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45883,7 +45883,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45975,7 +45975,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46069,7 +46069,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46174,7 +46174,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46275,7 +46275,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46376,7 +46376,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46477,7 +46477,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46597,7 +46597,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46684,7 +46684,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46804,7 +46804,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46968,7 +46968,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47399,7 +47399,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47463,7 +47463,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47527,7 +47527,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47591,7 +47591,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47655,7 +47655,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47719,7 +47719,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47803,7 +47803,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47867,7 +47867,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47936,7 +47936,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48000,7 +48000,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48075,7 +48075,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48139,7 +48139,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48203,7 +48203,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48267,7 +48267,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48344,7 +48344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48408,7 +48408,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48477,7 +48477,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48549,7 +48549,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1940,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1961,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,7 +1969,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1980,7 +1979,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1989,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2011,7 +2010,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2020,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2042,7 +2041,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2051,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2060,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2075,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2092,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2102,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2135,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2153,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2162,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2217,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2227,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2259,7 +2258,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2268,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2279,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,7 +2287,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2298,7 +2297,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2307,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2318,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,7 +2326,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2337,7 +2336,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2346,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2357,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,7 +2365,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2376,7 +2375,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2385,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2396,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,7 +2404,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2415,7 +2414,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2424,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2435,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,7 +2443,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2454,7 +2453,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2463,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2471,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2486,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2501,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2516,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2530,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2544,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2561,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2578,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2588,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2607,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2621,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2629,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2650,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2668,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2735,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2744,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2753,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2762,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2771,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2798,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2807,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2816,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2825,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2888,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2915,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2924,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2933,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3059,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3068,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3086,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3095,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3112,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3124,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3142,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3150,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3158,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3166,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3181,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3194,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3229,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3239,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3286,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3296,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3352,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,16 +3362,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3383,8 +3382,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3395,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3410,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3424,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3439,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3454,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3468,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3482,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3496,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3510,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3524,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3538,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3552,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3567,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3587,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3607,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3627,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3646,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3666,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3685,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3704,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3723,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3742,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3761,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3780,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3799,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3823,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3847,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3871,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3895,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3919,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3943,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3967,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3991,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4015,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4039,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4063,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4087,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4112,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4136,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4150,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4164,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4179,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4203,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4217,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4231,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4246,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4260,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4289,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4318,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4347,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4376,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4405,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4419,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4438,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4467,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4496,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4510,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4529,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4548,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4562,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4576,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4590,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4604,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4721,14 +4720,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4754,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4763,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4779,14 +4778,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4826,14 +4825,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,14 +4870,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4961,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +5004,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5032,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5061,20 +5060,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5175,26 +5174,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5376,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5420,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5464,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5483,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5502,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5521,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5542,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5568,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5592,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5611,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5630,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5659,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5688,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5717,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5757,20 +5756,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5928,12 +5927,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,18 +5956,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5992,18 +5991,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6021,18 +6020,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6049,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,23 +6107,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6142,18 +6141,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6170,7 +6169,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6185,15 +6184,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,15 +6204,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6224,15 +6223,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6244,20 +6243,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6268,20 +6267,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6293,20 +6292,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6317,15 +6316,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6336,8 +6335,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6349,7 +6348,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6360,8 +6359,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6373,7 +6372,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6384,8 +6383,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6397,7 +6396,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6408,8 +6407,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6421,7 +6420,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6432,13 +6431,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6451,18 +6450,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6479,7 +6478,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6507,20 +6506,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6540,12 +6539,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6564,12 +6563,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6588,12 +6587,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6612,12 +6611,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6635,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,12 +6659,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6686,12 +6685,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6710,18 +6709,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6740,18 +6739,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6769,7 +6768,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6777,7 +6776,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6792,20 +6791,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6824,12 +6823,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6848,12 +6847,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6877,12 +6876,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,18 +6905,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6935,18 +6934,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6969,12 +6968,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6993,12 +6992,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7017,18 +7016,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7065,61 +7064,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7130,18 +7129,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7151,38 +7150,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7190,14 +7189,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7210,7 +7209,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7223,7 +7222,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7236,7 +7235,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7249,7 +7248,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7262,7 +7261,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7275,7 +7274,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7288,7 +7287,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7301,7 +7300,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7314,7 +7313,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7327,7 +7326,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7340,7 +7339,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7353,7 +7352,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7366,7 +7365,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7379,7 +7378,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7392,7 +7391,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7405,7 +7404,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7418,7 +7417,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7431,7 +7430,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7444,7 +7443,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7457,7 +7456,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7470,7 +7469,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7483,7 +7482,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7496,7 +7495,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7509,7 +7508,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7522,7 +7521,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7535,7 +7534,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7548,7 +7547,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7561,7 +7560,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7574,7 +7573,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7587,7 +7586,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7600,7 +7599,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7613,7 +7612,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7626,7 +7625,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7639,7 +7638,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7652,7 +7651,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7665,7 +7664,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7678,7 +7677,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7691,7 +7690,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7704,7 +7703,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7717,7 +7716,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7730,7 +7729,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7743,7 +7742,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7756,7 +7755,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7769,7 +7768,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7782,7 +7781,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7795,7 +7794,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7808,7 +7807,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7821,7 +7820,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7834,7 +7833,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7847,7 +7846,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7860,7 +7859,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7873,7 +7872,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7886,7 +7885,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7899,7 +7898,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7912,7 +7911,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7925,7 +7924,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7938,7 +7937,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7948,10 +7947,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7961,10 +7960,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7974,10 +7973,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7987,10 +7986,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8000,180 +7999,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8185,7 +8184,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8196,22 +8195,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8232,7 +8231,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8245,7 +8244,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8258,7 +8257,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8271,7 +8270,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8281,10 +8280,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8294,10 +8293,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8310,7 +8309,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8323,7 +8322,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8336,7 +8335,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8349,7 +8348,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8362,7 +8361,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8375,7 +8374,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8388,7 +8387,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8401,7 +8400,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8428,7 +8427,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8441,7 +8440,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8454,7 +8453,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8467,7 +8466,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8480,7 +8479,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8493,7 +8492,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8506,7 +8505,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8519,7 +8518,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8532,7 +8531,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8545,7 +8544,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8558,7 +8557,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8571,7 +8570,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8600,7 +8599,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8615,7 +8614,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8632,7 +8631,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8647,7 +8646,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8662,7 +8661,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8679,7 +8678,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8696,7 +8695,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8713,7 +8712,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8728,7 +8727,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8745,7 +8744,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8760,7 +8759,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8775,7 +8774,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8790,7 +8789,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8807,7 +8806,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8824,7 +8823,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8839,7 +8838,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8854,7 +8853,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8871,7 +8870,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8886,7 +8885,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8901,7 +8900,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8918,7 +8917,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11091,7 +11090,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11103,7 +11102,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11336,7 +11335,7 @@ function Q_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11440,7 +11439,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11492,7 +11491,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12953,7 +12952,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14080,7 +14079,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16093,7 +16092,7 @@ function M_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16246,7 +16245,7 @@ function M_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16429,7 +16428,7 @@ function M_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16734,7 +16733,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16746,7 +16745,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16856,7 +16855,7 @@ function M_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16911,7 +16910,7 @@ function M_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17021,7 +17020,7 @@ function M_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17082,7 +17081,7 @@ function M_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17137,7 +17136,7 @@ function M_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17192,7 +17191,7 @@ function M_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33838,7 +33837,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33854,7 +33853,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35142,7 +35141,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35165,7 +35164,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35188,7 +35187,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35211,7 +35210,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35234,7 +35233,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35257,7 +35256,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35280,7 +35279,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35303,7 +35302,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35326,7 +35325,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35349,7 +35348,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35372,7 +35371,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35395,7 +35394,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35418,7 +35417,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35441,7 +35440,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35464,7 +35463,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35487,7 +35486,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35510,7 +35509,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35533,7 +35532,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35556,7 +35555,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35579,7 +35578,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35602,7 +35601,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35625,7 +35624,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35648,7 +35647,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35671,7 +35670,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35694,7 +35693,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35717,7 +35716,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35740,7 +35739,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35763,7 +35762,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35786,7 +35785,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35809,7 +35808,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35832,7 +35831,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35855,7 +35854,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35878,7 +35877,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35901,7 +35900,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35924,7 +35923,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35947,7 +35946,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35970,7 +35969,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35993,7 +35992,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36016,7 +36015,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36039,7 +36038,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36062,7 +36061,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36085,7 +36084,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36108,7 +36107,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36131,7 +36130,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36154,7 +36153,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36177,7 +36176,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36200,7 +36199,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36345,7 +36344,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36361,7 +36360,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36776,7 +36775,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36792,7 +36791,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36958,7 +36957,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36981,7 +36980,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -37004,7 +37003,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37027,7 +37026,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37050,7 +37049,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37073,7 +37072,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37277,7 +37276,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37300,7 +37299,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37323,7 +37322,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37399,7 +37398,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37415,7 +37414,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37547,7 +37546,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37570,7 +37569,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37593,7 +37592,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38031,7 +38030,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38054,7 +38053,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38077,7 +38076,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38100,7 +38099,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38123,7 +38122,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38146,7 +38145,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38169,7 +38168,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38192,7 +38191,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38215,7 +38214,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38238,7 +38237,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38261,7 +38260,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38373,7 +38372,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38407,7 +38406,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38423,7 +38422,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38487,7 +38486,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38521,7 +38520,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38537,7 +38536,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38601,7 +38600,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38635,7 +38634,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38651,7 +38650,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38715,7 +38714,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38749,7 +38748,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38765,7 +38764,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38829,7 +38828,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38863,7 +38862,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38879,7 +38878,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38943,7 +38942,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38977,7 +38976,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38993,7 +38992,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39091,7 +39090,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39114,7 +39113,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39230,7 +39229,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39253,7 +39252,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39415,7 +39414,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39438,7 +39437,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39461,7 +39460,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39495,7 +39494,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39511,7 +39510,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39609,7 +39608,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39632,7 +39631,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39666,7 +39665,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39682,7 +39681,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39780,7 +39779,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39803,7 +39802,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39837,7 +39836,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39853,7 +39852,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39985,7 +39984,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40008,7 +40007,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40031,7 +40030,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40065,7 +40064,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40081,7 +40080,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40247,7 +40246,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40270,7 +40269,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40293,7 +40292,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40316,7 +40315,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40350,7 +40349,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40366,7 +40365,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40532,7 +40531,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40555,7 +40554,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40578,7 +40577,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40601,7 +40600,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40800,7 +40799,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40823,7 +40822,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40846,7 +40845,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40869,7 +40868,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40903,7 +40902,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40919,7 +40918,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41085,7 +41084,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41108,7 +41107,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41131,7 +41130,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41154,7 +41153,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41350,7 +41349,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41373,7 +41372,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41396,7 +41395,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41430,7 +41429,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41446,7 +41445,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41612,7 +41611,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41635,7 +41634,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41658,7 +41657,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41681,7 +41680,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41715,7 +41714,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41731,7 +41730,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41829,7 +41828,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41852,7 +41851,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Q_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Q",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,732 +3339,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6511,274 +3420,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6796,254 +3457,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7158,19 +3592,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7179,9 +3634,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7196,813 +3807,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8014,7 +5658,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8025,7 +5679,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8036,7 +5698,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8047,7 +5717,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8058,7 +5736,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8069,7 +5755,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8080,7 +5774,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8089,10 +5791,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8100,10 +5817,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8115,7 +5840,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8127,7 +5860,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8139,7 +5880,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8150,7 +5899,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8158,10 +5915,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8172,33 +5949,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8207,394 +6055,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9444,25 +8909,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Q_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Q_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9605,21 +9051,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Q_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9670,21 +9101,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Q_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9793,21 +9209,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Q_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10298,21 +9699,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Q_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,12 +9791,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Q_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10833,21 +10213,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Q_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10916,21 +10281,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Q_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11317,21 +10667,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Q_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11660,21 +10995,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Q_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11725,21 +11045,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Q_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11836,21 +11141,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Q_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11901,21 +11191,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Q_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11984,21 +11259,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Q_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12049,21 +11309,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Q_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12325,385 +11570,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Q_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Q_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Q_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Q_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Q_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Q_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Q_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Q_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Q_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Q_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13277,21 +12147,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13372,21 +12227,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13486,66 +12326,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13593,24 +12373,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function I_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function I_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function I_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function I_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function I_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function I_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13691,21 +12453,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14129,348 +12876,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PI_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PI_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14517,26 +12923,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14583,9 +12969,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function M_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,9 +13015,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function M_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14681,9 +13061,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function M_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14730,9 +13107,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function M_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14779,9 +13153,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function M_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14828,9 +13199,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function M_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14883,9 +13251,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function M_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14938,9 +13303,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function M_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14993,9 +13355,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function M_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15048,9 +13407,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function M_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15103,9 +13459,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function M_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15158,9 +13511,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function M_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15219,9 +13569,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function M_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15280,9 +13627,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function M_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15341,9 +13685,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function M_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15402,9 +13743,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function M_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15463,9 +13801,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function M_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15524,9 +13859,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function M_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15585,9 +13917,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function M_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15646,9 +13975,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function M_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15707,9 +14033,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function M_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15768,9 +14091,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function M_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15817,9 +14137,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function M_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15866,9 +14183,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function M_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15915,9 +14229,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function M_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15982,9 +14293,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function M_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16031,9 +14339,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function M_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16086,9 +14391,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function M_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16141,9 +14443,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function M_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16190,9 +14489,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function M_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16239,9 +14535,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function M_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16306,9 +14599,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function M_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16355,9 +14645,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function M_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16422,9 +14709,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function M_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16477,9 +14761,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function M_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16526,9 +14807,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function M_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16575,9 +14853,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function M_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16642,9 +14917,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function M_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16709,9 +14981,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function M_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16794,9 +15063,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function M_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16849,9 +15115,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function M_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16904,9 +15167,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function M_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16959,9 +15219,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function M_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17014,9 +15271,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function M_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17075,9 +15329,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function M_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17130,9 +15381,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function M_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17185,9 +15433,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function M_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17240,9 +15485,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function M_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17301,9 +15543,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function M_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17362,9 +15601,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function M_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17411,9 +15647,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function M_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17460,9 +15693,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function M_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17509,9 +15739,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function M_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17558,9 +15785,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function M_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17613,9 +15837,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function M_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17662,2061 +15883,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function M_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function M_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function M_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function M_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function M_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function M_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function M_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function M_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function M_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function M_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function M_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function M_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function M_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function M_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function M_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function M_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function M_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function M_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function M_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function M_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function M_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function M_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function M_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function M_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function M_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function M_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function M_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function M_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function M_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function M_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function M_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function M_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function M_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function M_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function M_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function M_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function M_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function M_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`schema {
   query: Q
   mutation: M
@@ -29828,7 +26139,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Q_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30074,27 +26387,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Q_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30114,23 +26440,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30142,23 +26478,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30180,23 +26526,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30280,23 +26636,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30312,11 +26678,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30388,23 +26758,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30419,23 +26799,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30493,23 +26883,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30569,23 +26969,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30597,23 +27007,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30629,23 +27049,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30657,23 +27087,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30701,23 +27141,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30729,23 +27179,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30931,23 +27391,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30974,23 +27444,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31017,23 +27497,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31060,23 +27550,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31103,23 +27603,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31146,23 +27656,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31189,23 +27709,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31232,23 +27762,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31275,23 +27815,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31318,23 +27868,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31361,23 +27921,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31404,23 +27974,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31447,23 +28027,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31490,23 +28080,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31533,23 +28133,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31576,23 +28186,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31619,23 +28239,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31662,23 +28292,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31705,23 +28345,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31748,23 +28398,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31791,23 +28451,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31834,23 +28504,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31877,23 +28557,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31920,23 +28610,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Q_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32080,23 +28780,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32498,23 +29208,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32535,23 +29255,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32677,23 +29407,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32723,23 +29463,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32779,23 +29529,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32825,23 +29585,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33009,12 +29779,24 @@ export const plans = {
   },
   I: {
     __assertStep: assertExecutableStep,
-    seconds: I_secondsPlan,
-    minutes: I_minutesPlan,
-    hours: I_hoursPlan,
-    days: I_daysPlan,
-    months: I_monthsPlan,
-    years: I_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33030,23 +29812,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33391,23 +30183,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33435,9 +30237,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33453,8 +30262,12 @@ export const plans = {
   },
   PI: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PI_hasNextPagePlan,
-    hasPreviousPage: PI_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33595,9 +30408,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36261,9 +33081,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36722,9 +33549,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37114,9 +33948,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37375,9 +34216,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37702,9 +34550,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37720,9 +34575,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37738,9 +34600,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37756,9 +34625,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37783,9 +34659,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37840,9 +34723,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37867,9 +34757,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37932,9 +34829,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37974,9 +34878,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38295,9 +35206,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38383,9 +35301,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38497,9 +35422,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38611,9 +35543,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38725,9 +35664,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38839,9 +35785,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38953,9 +35906,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39124,9 +36084,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39263,9 +36230,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39471,9 +36445,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39642,9 +36623,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39813,9 +36801,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40041,9 +37036,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40326,9 +37328,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40611,9 +37620,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40879,9 +37895,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41164,9 +38187,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41406,9 +38436,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41691,9 +38728,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41873,7 +38917,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41888,7 +38934,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41903,7 +38951,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41918,7 +38968,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41933,7 +38985,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41948,7 +39002,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41963,7 +39019,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41978,7 +39036,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41993,7 +39053,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42008,7 +39070,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42023,7 +39087,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42038,7 +39104,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42053,7 +39121,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42068,7 +39138,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42083,7 +39155,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42098,7 +39172,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42113,7 +39189,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42128,7 +39206,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42143,7 +39223,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42158,7 +39240,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42173,7 +39257,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42188,7 +39274,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42203,7 +39291,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42218,7 +39308,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42233,7 +39325,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42248,7 +39342,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42263,7 +39359,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42278,7 +39376,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42293,7 +39393,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42308,7 +39410,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42323,7 +39427,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42338,7 +39444,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42353,7 +39461,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42368,7 +39478,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42383,7 +39495,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42398,7 +39512,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42413,7 +39529,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42428,7 +39546,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42443,7 +39563,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42458,7 +39580,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42473,7 +39597,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42488,7 +39614,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42503,7 +39631,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42518,7 +39648,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42533,7 +39665,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42548,7 +39682,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42563,7 +39699,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42578,7 +39716,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42593,7 +39733,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42608,7 +39750,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42623,7 +39767,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42638,7 +39784,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42653,7 +39801,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42668,7 +39818,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42683,7 +39835,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42698,7 +39852,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42713,7 +39869,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42728,7 +39886,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42743,7 +39903,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42758,7 +39920,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42773,7 +39937,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42788,7 +39954,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42803,7 +39971,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42818,7 +39988,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42833,7 +40005,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42848,7 +40022,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42863,7 +40039,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42878,7 +40056,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42893,7 +40073,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42908,7 +40090,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42923,7 +40107,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42938,7 +40124,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42953,7 +40141,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42968,7 +40158,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42983,7 +40175,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42998,7 +40192,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43013,7 +40209,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43028,7 +40226,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43043,7 +40243,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: M_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43057,7 +40259,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43073,7 +40277,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43087,7 +40293,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43103,7 +40311,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43117,7 +40327,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43133,7 +40345,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43147,7 +40361,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43163,7 +40379,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43177,7 +40395,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43193,7 +40413,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43207,7 +40429,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43223,7 +40447,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43239,7 +40465,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43253,7 +40481,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43269,7 +40499,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43283,7 +40515,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43299,7 +40533,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43313,7 +40549,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43329,7 +40567,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43343,7 +40583,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43360,7 +40602,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43374,7 +40618,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43390,7 +40636,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43404,7 +40652,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43420,7 +40670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43434,7 +40686,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43450,7 +40704,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43464,7 +40720,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43480,7 +40738,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43496,7 +40756,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43510,7 +40772,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43526,7 +40790,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43540,7 +40806,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43556,7 +40824,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43570,7 +40840,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43586,7 +40858,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43602,7 +40876,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43616,7 +40892,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43632,7 +40910,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43646,7 +40926,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43662,7 +40944,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43676,7 +40960,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43692,7 +40978,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43706,7 +40994,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43722,7 +41012,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43736,7 +41028,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43752,7 +41046,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43766,7 +41062,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43782,7 +41080,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43796,7 +41096,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43812,7 +41114,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43828,7 +41132,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43842,7 +41148,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43858,7 +41166,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43872,7 +41182,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43888,7 +41200,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43902,7 +41216,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43918,7 +41234,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43932,7 +41250,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43949,7 +41269,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43963,7 +41285,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43979,7 +41303,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43993,7 +41319,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44009,7 +41337,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44023,7 +41353,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44039,7 +41371,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44053,7 +41387,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44069,7 +41405,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44085,7 +41423,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44099,7 +41439,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44115,7 +41457,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44129,7 +41473,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44145,7 +41491,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44159,7 +41507,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44175,7 +41525,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44191,7 +41543,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44205,7 +41559,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44221,193 +41577,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: M_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     we($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44415,15 +41851,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44431,15 +41873,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44447,15 +41895,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44463,15 +41917,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44479,15 +41939,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44495,15 +41961,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44511,15 +41983,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44527,15 +42005,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44543,15 +42027,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44559,11 +42049,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44576,17 +42070,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44599,17 +42099,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44622,21 +42128,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44645,11 +42159,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44665,17 +42183,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44688,65 +42212,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     we($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44755,11 +42305,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44781,21 +42335,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44804,11 +42366,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44848,7 +42414,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44885,11 +42453,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44924,35 +42496,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44961,11 +42547,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44997,7 +42587,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45006,15 +42598,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45026,11 +42624,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45049,48 +42651,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45130,18 +42750,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45181,7 +42807,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45233,56 +42861,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45310,7 +42960,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45318,11 +42970,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45350,7 +43006,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45358,11 +43016,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45397,59 +43059,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45494,30 +43180,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45552,11 +43252,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45571,9 +43276,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45608,11 +43319,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45627,9 +43343,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45664,11 +43386,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45683,9 +43410,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45720,11 +43453,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45739,9 +43477,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45776,11 +43520,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45795,9 +43544,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45832,11 +43587,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45858,9 +43618,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45875,11 +43641,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45908,17 +43679,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45940,17 +43722,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45979,9 +43772,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46016,11 +43815,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46042,9 +43846,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46084,11 +43894,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46110,9 +43925,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46147,11 +43968,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46180,9 +44006,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46227,11 +44059,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46260,9 +44097,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46297,11 +44140,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46337,9 +44185,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46374,11 +44228,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46414,17 +44273,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46460,9 +44330,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46497,11 +44373,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46537,17 +44418,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46576,9 +44468,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46618,11 +44516,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46658,9 +44561,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46695,11 +44604,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46721,9 +44635,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46763,19 +44683,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46810,11 +44741,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46899,9 +44835,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46946,11 +44888,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47301,9 +45248,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47338,11 +45291,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47356,18 +45314,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47402,11 +45371,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47420,18 +45394,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47466,11 +45451,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47484,18 +45474,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47530,11 +45531,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47548,18 +45554,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47594,11 +45611,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47612,18 +45634,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47658,11 +45691,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47683,26 +45721,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47723,9 +45777,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47760,11 +45820,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47785,18 +45850,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47836,11 +45912,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47861,18 +45942,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47907,11 +45999,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47939,18 +46036,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47995,11 +46103,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48027,19 +46140,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48074,11 +46198,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48113,18 +46242,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48159,11 +46299,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48198,18 +46343,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48244,11 +46400,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48283,18 +46444,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48334,11 +46506,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48373,27 +46550,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48428,11 +46621,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48453,18 +46651,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48504,11 +46713,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48557,18 +46771,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48603,11 +46828,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48691,27 +46921,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48756,11 +47002,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49110,23 +47361,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49161,26 +47423,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49215,26 +47487,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49269,26 +47551,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49323,26 +47615,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49377,26 +47679,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49431,38 +47743,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49497,26 +47827,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49556,26 +47896,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49610,26 +47960,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49674,27 +48034,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49729,26 +48099,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49783,26 +48163,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49837,26 +48227,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49896,32 +48296,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49956,26 +48368,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50015,26 +48437,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50069,32 +48501,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50139,13 +48583,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -2,20 +2,18 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectSingleStep, PgSelectStep, PgUni
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const handler_codec_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
 const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sql.identifier(...["js_reserved", "item_type"]),
+  identifier: sql.identifier("js_reserved", "item_type"),
   values: ["TOPIC", "STATUS"],
   description: undefined,
   extensions: {
@@ -80,27 +78,23 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_topics"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts2 = ["js_reserved", "relational_topics"];
-const relationalTopicsIdentifier = sql.identifier(...parts2);
-const relationalTopicsCodecSpec = {
+const relationalTopicsCodec = recordCodec({
   name: "relationalTopics",
-  identifier: relationalTopicsIdentifier,
+  identifier: sql.identifier("js_reserved", "relational_topics"),
   attributes: relationalTopicsAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_topics"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+});
 const __proto__Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -130,26 +124,22 @@ const __proto__Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "__proto__"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["js_reserved", "__proto__"];
-const __proto__Identifier = sql.identifier(...parts3);
-const __proto__CodecSpec = {
+const __proto__Codec = recordCodec({
   name: "__proto__",
-  identifier: __proto__Identifier,
+  identifier: sql.identifier("js_reserved", "__proto__"),
   attributes: __proto__Attributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "__proto__"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const __proto__Codec = recordCodec(__proto__CodecSpec);
+});
 const buildingAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -179,26 +169,22 @@ const buildingAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "building"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["js_reserved", "building"];
-const buildingIdentifier = sql.identifier(...parts4);
-const buildingCodecSpec = {
+const buildingCodec = recordCodec({
   name: "building",
-  identifier: buildingIdentifier,
+  identifier: sql.identifier("js_reserved", "building"),
   attributes: buildingAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "building"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const buildingCodec = recordCodec(buildingCodecSpec);
+});
 const constructorAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -228,26 +214,22 @@ const constructorAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "constructor"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["js_reserved", "constructor"];
-const constructorIdentifier = sql.identifier(...parts5);
-const constructorCodecSpec = {
+const constructorCodec = recordCodec({
   name: "constructor",
-  identifier: constructorIdentifier,
+  identifier: sql.identifier("js_reserved", "constructor"),
   attributes: constructorAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "constructor"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const constructorCodec = recordCodec(constructorCodecSpec);
+});
 const cropAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -277,26 +259,22 @@ const cropAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "crop"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["js_reserved", "crop"];
-const cropIdentifier = sql.identifier(...parts6);
-const cropCodecSpec = {
+const cropCodec = recordCodec({
   name: "crop",
-  identifier: cropIdentifier,
+  identifier: sql.identifier("js_reserved", "crop"),
   attributes: cropAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "crop"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cropCodec = recordCodec(cropCodecSpec);
+});
 const machineAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -326,26 +304,22 @@ const machineAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "machine"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["js_reserved", "machine"];
-const machineIdentifier = sql.identifier(...parts7);
-const machineCodecSpec = {
+const machineCodec = recordCodec({
   name: "machine",
-  identifier: machineIdentifier,
+  identifier: sql.identifier("js_reserved", "machine"),
   attributes: machineAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "machine"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const machineCodec = recordCodec(machineCodecSpec);
+});
 const materialAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -375,26 +349,22 @@ const materialAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "material"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["js_reserved", "material"];
-const materialIdentifier = sql.identifier(...parts8);
-const materialCodecSpec = {
+const materialCodec = recordCodec({
   name: "material",
-  identifier: materialIdentifier,
+  identifier: sql.identifier("js_reserved", "material"),
   attributes: materialAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "material"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const materialCodec = recordCodec(materialCodecSpec);
+});
 const nullAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -424,26 +394,22 @@ const nullAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "null"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["js_reserved", "null"];
-const nullIdentifier = sql.identifier(...parts9);
-const nullCodecSpec = {
+const nullCodec = recordCodec({
   name: "null",
-  identifier: nullIdentifier,
+  identifier: sql.identifier("js_reserved", "null"),
   attributes: nullAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "null"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullCodec = recordCodec(nullCodecSpec);
+});
 const projectAttributes = Object.fromEntries([["id", {
   description: undefined,
   codec: TYPES.int,
@@ -469,26 +435,22 @@ const projectAttributes = Object.fromEntries([["id", {
     tags: {}
   }
 }]]);
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "project"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["js_reserved", "project"];
-const projectIdentifier = sql.identifier(...parts10);
-const projectCodecSpec = {
+const projectCodec = recordCodec({
   name: "project",
-  identifier: projectIdentifier,
+  identifier: sql.identifier("js_reserved", "project"),
   attributes: projectAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "project"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const projectCodec = recordCodec(projectCodecSpec);
+});
 const relationalStatusAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -541,27 +503,23 @@ const relationalStatusAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_status"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts11 = ["js_reserved", "relational_status"];
-const relationalStatusIdentifier = sql.identifier(...parts11);
-const relationalStatusCodecSpec = {
+const relationalStatusCodec = recordCodec({
   name: "relationalStatus",
-  identifier: relationalStatusIdentifier,
+  identifier: sql.identifier("js_reserved", "relational_status"),
   attributes: relationalStatusAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_status"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalStatusCodec = recordCodec(relationalStatusCodecSpec);
+});
 const yieldAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -591,26 +549,22 @@ const yieldAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "yield"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["js_reserved", "yield"];
-const yieldIdentifier = sql.identifier(...parts12);
-const yieldCodecSpec = {
+const yieldCodec = recordCodec({
   name: "yield",
-  identifier: yieldIdentifier,
+  identifier: sql.identifier("js_reserved", "yield"),
   attributes: yieldAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "yield"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const yieldCodec = recordCodec(yieldCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -649,26 +603,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["js_reserved", "reserved"];
-const reservedIdentifier = sql.identifier(...parts13);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("js_reserved", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -710,145 +660,18 @@ const extensions14 = {
     type: ["TOPIC references:relational_topics", "STATUS references:relational_status"]
   })
 };
-const parts14 = ["js_reserved", "relational_items"];
-const relationalItemsIdentifier = sql.identifier(...parts14);
-const relationalItemsCodecSpec = {
+const relationalItemsCodec = recordCodec({
   name: "relationalItems",
-  identifier: relationalItemsIdentifier,
+  identifier: sql.identifier("js_reserved", "relational_items"),
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions14,
   executor: executor_mainPgExecutor
-};
-const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
-const extensions15 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "await"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts15 = ["js_reserved", "await"];
-const sqlIdent2 = sql.identifier(...parts15);
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "case"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts16 = ["js_reserved", "case"];
-const sqlIdent3 = sql.identifier(...parts16);
-const fromCallback2 = (...args) => sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "yield",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "__proto__",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "constructor",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "hasOwnProperty",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "valueOf"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts17 = ["js_reserved", "valueOf"];
-const sqlIdent4 = sql.identifier(...parts17);
-const fromCallback3 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters3 = [{
-  name: "yield",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "__proto__",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "constructor",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "hasOwnProperty",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions18 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "null_yield"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts18 = ["js_reserved", "null_yield"];
-const sqlIdent5 = sql.identifier(...parts18);
-const fromCallback4 = (...args) => sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-const parameters4 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: nullCodec
-}, {
-  name: "yield",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "__proto__",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "constructor",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "valueOf",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions19 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_topics"
-  },
-  tags: {}
-};
+});
+const sqlIdent2 = sql.identifier("js_reserved", "await");
+const sqlIdent3 = sql.identifier("js_reserved", "case");
+const sqlIdent4 = sql.identifier("js_reserved", "valueOf");
+const sqlIdent5 = sql.identifier("js_reserved", "null_yield");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -866,16 +689,15 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   uniques,
   isVirtual: false,
   description: undefined,
-  extensions: extensions19
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "__proto__"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_topics"
+    },
+    tags: {}
+  }
 };
 const uniques2 = [{
   isPrimary: true,
@@ -892,15 +714,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions21 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "building"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -925,16 +738,15 @@ const registryConfig_pgResources_building_building = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions21
-};
-const extensions22 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "constructor"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "building"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -958,15 +770,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions23 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "crop"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -982,15 +785,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions24 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "machine"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1008,16 +802,15 @@ const registryConfig_pgResources_machine_machine = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions24
-};
-const extensions25 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "material"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "machine"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -1041,15 +834,6 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions26 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "null"
-  },
-  tags: {}
-};
 const uniques8 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1072,15 +856,6 @@ const uniques8 = [{
     tags: Object.create(null)
   }
 }];
-const extensions27 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "project"
-  },
-  tags: {}
-};
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1096,15 +871,6 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions28 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_status"
-  },
-  tags: {}
-};
 const uniques10 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1122,16 +888,15 @@ const registryConfig_pgResources_relational_status_relational_status = {
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
-  extensions: extensions28
-};
-const extensions29 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "yield"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_status"
+    },
+    tags: {}
+  }
 };
 const uniques11 = [{
   isPrimary: true,
@@ -1148,15 +913,6 @@ const uniques11 = [{
     tags: Object.create(null)
   }
 }];
-const extensions30 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques12 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1186,18 +942,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions31 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_items"
-  },
-  tags: {
-    interface: "mode:relational type:type",
-    type: extensions14.tags.type
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1215,7 +959,18 @@ const registryConfig_pgResources_relational_items_relational_items = {
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_items"
+    },
+    tags: {
+      interface: "mode:relational type:type",
+      type: extensions14.tags.type
+    }
+  }
 };
 const registryConfig = {
   pgCodecs: Object.fromEntries([["int4", TYPES.int], ["relationalTopics", relationalTopicsCodec], ["text", TYPES.text], ["__proto__", __proto__Codec], ["building", buildingCodec], ["constructor", constructorCodec], ["crop", cropCodec], ["machine", machineCodec], ["material", materialCodec], ["null", nullCodec], ["project", projectCodec], ["relationalStatus", relationalStatusCodec], ["yield", yieldCodec], ["reserved", reservedCodec], ["relationalItems", relationalItemsCodec], ["itemType", itemTypeCodec], ["varchar", TYPES.varchar], ["bpchar", TYPES.bpchar]]),
@@ -1251,43 +1006,150 @@ const registryConfig = {
     codec: TYPES.int,
     uniques: [],
     isMutation: false,
-    extensions: extensions15,
+    extensions: {
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "await"
+      },
+      tags: {
+        behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      }
+    },
     description: undefined
   }], ["case", {
     executor: executor_mainPgExecutor,
     name: "case",
     identifier: "main.js_reserved.case(int4,int4,int4,int4)",
-    from: fromCallback2,
-    parameters: parameters2,
+    from(...args) {
+      return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+    },
+    parameters: [{
+      name: "yield",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "__proto__",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "constructor",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "hasOwnProperty",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }],
     isUnique: !false,
     codec: TYPES.int,
     uniques: [],
     isMutation: false,
-    extensions: extensions16,
+    extensions: {
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "case"
+      },
+      tags: {
+        behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      }
+    },
     description: undefined
   }], ["valueOf", {
     executor: executor_mainPgExecutor,
     name: "valueOf",
     identifier: "main.js_reserved.valueOf(int4,int4,int4,int4)",
-    from: fromCallback3,
-    parameters: parameters3,
+    from(...args) {
+      return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+    },
+    parameters: [{
+      name: "yield",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "__proto__",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "constructor",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "hasOwnProperty",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }],
     isUnique: !false,
     codec: TYPES.int,
     uniques: [],
     isMutation: false,
-    extensions: extensions17,
+    extensions: {
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "valueOf"
+      },
+      tags: {
+        behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      }
+    },
     description: undefined
   }], ["null_yield", {
     executor: executor_mainPgExecutor,
     name: "null_yield",
     identifier: "main.js_reserved.null_yield(js_reserved.null,int4,int4,int4,int4)",
-    from: fromCallback4,
-    parameters: parameters4,
+    from(...args) {
+      return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+    },
+    parameters: [{
+      name: "n",
+      required: true,
+      notNull: false,
+      codec: nullCodec
+    }, {
+      name: "yield",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "__proto__",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "constructor",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }, {
+      name: "valueOf",
+      required: true,
+      notNull: false,
+      codec: TYPES.int
+    }],
     isUnique: !false,
     codec: TYPES.int,
     uniques: [],
     isMutation: false,
-    extensions: extensions18,
+    extensions: {
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "null_yield"
+      },
+      tags: {
+        behavior: ["-queryField -mutationField typeField", "-filter -order"]
+      }
+    },
     description: undefined
   }], ["relational_topics", registryConfig_pgResources_relational_topics_relational_topics], ["__proto__", {
     executor: executor_mainPgExecutor,
@@ -1298,7 +1160,15 @@ const registryConfig = {
     uniques: uniques2,
     isVirtual: false,
     description: undefined,
-    extensions: extensions20
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "__proto__"
+      },
+      tags: {}
+    }
   }], ["building", registryConfig_pgResources_building_building], ["constructor", {
     executor: executor_mainPgExecutor,
     name: "constructor",
@@ -1308,7 +1178,15 @@ const registryConfig = {
     uniques: uniques4,
     isVirtual: false,
     description: undefined,
-    extensions: extensions22
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "constructor"
+      },
+      tags: {}
+    }
   }], ["crop", {
     executor: executor_mainPgExecutor,
     name: "crop",
@@ -1318,7 +1196,15 @@ const registryConfig = {
     uniques: uniques5,
     isVirtual: false,
     description: undefined,
-    extensions: extensions23
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "crop"
+      },
+      tags: {}
+    }
   }], ["machine", registryConfig_pgResources_machine_machine], ["material", {
     executor: executor_mainPgExecutor,
     name: "material",
@@ -1328,7 +1214,15 @@ const registryConfig = {
     uniques: uniques7,
     isVirtual: false,
     description: undefined,
-    extensions: extensions25
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "material"
+      },
+      tags: {}
+    }
   }], ["null", {
     executor: executor_mainPgExecutor,
     name: "null",
@@ -1338,7 +1232,15 @@ const registryConfig = {
     uniques: uniques8,
     isVirtual: false,
     description: undefined,
-    extensions: extensions26
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "null"
+      },
+      tags: {}
+    }
   }], ["project", {
     executor: executor_mainPgExecutor,
     name: "project",
@@ -1348,7 +1250,15 @@ const registryConfig = {
     uniques: uniques9,
     isVirtual: false,
     description: undefined,
-    extensions: extensions27
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "project"
+      },
+      tags: {}
+    }
   }], ["relational_status", registryConfig_pgResources_relational_status_relational_status], ["yield", {
     executor: executor_mainPgExecutor,
     name: "yield",
@@ -1358,7 +1268,15 @@ const registryConfig = {
     uniques: uniques11,
     isVirtual: false,
     description: undefined,
-    extensions: extensions29
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "yield"
+      },
+      tags: {}
+    }
   }], ["reserved", {
     executor: executor_mainPgExecutor,
     name: "reserved",
@@ -1368,7 +1286,15 @@ const registryConfig = {
     uniques: uniques12,
     isVirtual: false,
     description: undefined,
-    extensions: extensions30
+    extensions: {
+      description: undefined,
+      pg: {
+        serviceName: "main",
+        schemaName: "js_reserved",
+        name: "reserved"
+      },
+      tags: {}
+    }
   }], ["relational_items", registryConfig_pgResources_relational_items_relational_items]]),
   pgRelations: Object.assign(Object.create(null), {
     building: Object.assign(Object.create(null), {
@@ -1524,12 +1450,6 @@ const handler = {
     return obj[0] === "relational_topics";
   }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
@@ -1543,8 +1463,12 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
   base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const building_buildingPgResource = registry.pgResources["building"];
@@ -1576,21 +1500,6 @@ const specFromRecord = $record => {
     return memo;
   }, Object.create(null));
 };
-function Building_machinesByConstructor_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_machinesByConstructor_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_machinesByConstructor_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_machinesByConstructor_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_machinesByConstructor_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1609,49 +1518,12 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Building_machinesByConstructorList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_machinesByConstructorList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const specFromRecord2 = $record => {
   return registryConfig.pgRelations.building.relationalItemsByTheirConstructor.remoteAttributes.reduce((memo, remoteAttributeName, i) => {
     memo[remoteAttributeName] = $record.get(registryConfig.pgRelations.building.relationalItemsByTheirConstructor.localAttributes[i]);
     return memo;
   }, Object.create(null));
 };
-function Building_relationalItemsByConstructor_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_relationalItemsByConstructor_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_relationalItemsByConstructor_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_relationalItemsByConstructor_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_relationalItemsByConstructor_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Building_relationalItemsByConstructorList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_relationalItemsByConstructorList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function MachinesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MachinesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MachinesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler3 = {
   typeName: "Machine",
   codec: handler_codec_base64JSON,
@@ -1677,22 +1549,6 @@ const specFromRecord3 = $record => {
     return memo;
   }, Object.create(null));
 };
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function RelationalItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler4 = {
   typeName: "RelationalStatus",
   codec: handler_codec_base64JSON,
@@ -1712,9 +1568,6 @@ const handler4 = {
     return obj[0] === "relational_statuses";
   }
 };
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler5 = {
   typeName: "Query",
   codec: nodeIdCodecs.raw,
@@ -2246,279 +2099,6 @@ const fetcher12 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Reserved);
-function Query_allRelationalTopicsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalTopicsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalTopics_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalTopics_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalTopics_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalTopics_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalTopics_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProtoSList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProtoSList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProtoS_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProtoS_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProtoS_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProtoS_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProtoS_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildingsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildingsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allConstructorsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allConstructorsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allConstructors_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allConstructors_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allConstructors_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allConstructors_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allConstructors_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCropsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCropsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCrops_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCrops_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCrops_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCrops_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCrops_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMachinesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMachinesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMachines_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMachines_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMachines_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMachines_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMachines_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMaterialsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMaterialsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMaterials_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMaterials_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMaterials_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMaterials_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMaterials_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNulls_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNulls_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNulls_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNulls_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNulls_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProjectsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProjectsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProjects_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProjects_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProjects_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProjects_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProjects_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalStatusesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalStatusesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalStatuses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalStatuses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalStatuses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalStatuses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalStatuses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allYieldsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allYieldsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allYields_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allYields_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allYields_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allYields_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allYields_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -2592,169 +2172,14 @@ const makeArgs4 = (args, path = []) => {
   return selectArgs;
 };
 const resource_null_yieldPgResource = registry.pgResources["null_yield"];
-function RelationalTopicsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalTopicsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalTopicsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function _Proto__SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function _Proto__SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function _Proto__SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ConstructorsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ConstructorsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ConstructorsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CropsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CropsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CropsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MaterialsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MaterialsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MaterialsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ProjectsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ProjectsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ProjectsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalStatusesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalStatusesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalStatusesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function YieldsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function YieldsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function YieldsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createProto___input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createConstructor_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCrop_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMachine_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMaterial_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNull_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProject_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createYield_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName._Proto__, $nodeId);
 };
-function Mutation_updateProto___input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateProtoById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateProtoByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler2, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes = [["constructor", "constructor"]];
 const specFromArgs3 = args => {
   return uniqueAttributes.reduce((memo, [attributeName, fieldName]) => {
@@ -2762,61 +2187,22 @@ const specFromArgs3 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_updateBuildingByConstructor_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Constructor, $nodeId);
 };
-function Mutation_updateConstructor_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateConstructorById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateConstructorByExport_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateConstructorByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Crop, $nodeId);
 };
-function Mutation_updateCrop_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCropById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCropByYield_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler3, $nodeId);
 };
-function Mutation_updateMachine_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMachineById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Material, $nodeId);
 };
-function Mutation_updateMaterial_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMaterialById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMaterialByClass_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes2 = [["valueOf", "valueOf"]];
 const specFromArgs8 = args => {
   return uniqueAttributes2.reduce((memo, [attributeName, fieldName]) => {
@@ -2824,22 +2210,10 @@ const specFromArgs8 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_updateMaterialByValueOf_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Null, $nodeId);
 };
-function Mutation_updateNull_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullByBreak_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes3 = [["hasOwnProperty", "hasOwnProperty"]];
 const specFromArgs10 = args => {
   return uniqueAttributes3.reduce((memo, [attributeName, fieldName]) => {
@@ -2847,19 +2221,10 @@ const specFromArgs10 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_updateNullByHasOwnProperty_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Project, $nodeId);
 };
-function Mutation_updateProject_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateProjectById_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes4 = [["__proto__", "_proto__"]];
 const specFromArgs12 = args => {
   return uniqueAttributes4.reduce((memo, [attributeName, fieldName]) => {
@@ -2867,64 +2232,22 @@ const specFromArgs12 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_updateProjectByProto___input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Yield, $nodeId);
 };
-function Mutation_updateYield_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateYieldById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateYieldByExport_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedByCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedByDo_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedByNull_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName._Proto__, $nodeId);
 };
-function Mutation_deleteProto___input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteProtoById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteProtoByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler2, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes5 = [["constructor", "constructor"]];
 const specFromArgs17 = args => {
   return uniqueAttributes5.reduce((memo, [attributeName, fieldName]) => {
@@ -2932,61 +2255,22 @@ const specFromArgs17 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_deleteBuildingByConstructor_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Constructor, $nodeId);
 };
-function Mutation_deleteConstructor_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteConstructorById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteConstructorByExport_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteConstructorByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Crop, $nodeId);
 };
-function Mutation_deleteCrop_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCropById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCropByYield_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler3, $nodeId);
 };
-function Mutation_deleteMachine_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMachineById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Material, $nodeId);
 };
-function Mutation_deleteMaterial_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMaterialById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMaterialByClass_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes6 = [["valueOf", "valueOf"]];
 const specFromArgs22 = args => {
   return uniqueAttributes6.reduce((memo, [attributeName, fieldName]) => {
@@ -2994,22 +2278,10 @@ const specFromArgs22 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_deleteMaterialByValueOf_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Null, $nodeId);
 };
-function Mutation_deleteNull_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullByBreak_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes7 = [["hasOwnProperty", "hasOwnProperty"]];
 const specFromArgs24 = args => {
   return uniqueAttributes7.reduce((memo, [attributeName, fieldName]) => {
@@ -3017,19 +2289,10 @@ const specFromArgs24 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_deleteNullByHasOwnProperty_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Project, $nodeId);
 };
-function Mutation_deleteProject_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteProjectById_input_applyPlan(_, $object) {
-  return $object;
-}
 const uniqueAttributes8 = [["__proto__", "_proto__"]];
 const specFromArgs26 = args => {
   return uniqueAttributes8.reduce((memo, [attributeName, fieldName]) => {
@@ -3037,739 +2300,32 @@ const specFromArgs26 = args => {
     return memo;
   }, Object.create(null));
 };
-function Mutation_deleteProjectByProto___input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Yield, $nodeId);
 };
-function Mutation_deleteYield_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteYieldById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteYieldByExport_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedByCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedByDo_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedByNull_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateProtoPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateProtoPayload__proto__Plan($object) {
-  return $object.get("result");
-}
-function CreateProtoPayload_queryPlan() {
-  return rootValue();
-}
-function CreateProtoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateProtoInput__proto___applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateConstructorPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateConstructorPayload_constructorPlan($object) {
-  return $object.get("result");
-}
-function CreateConstructorPayload_queryPlan() {
-  return rootValue();
-}
-function CreateConstructorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateConstructorInput_constructor_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCropPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCropPayload_cropPlan($object) {
-  return $object.get("result");
-}
-function CreateCropPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCropInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCropInput_crop_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMachinePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMachinePayload_machinePlan($object) {
-  return $object.get("result");
-}
-function CreateMachinePayload_queryPlan() {
-  return rootValue();
-}
 const specFromRecord4 = $record => {
   return registryConfig.pgRelations.machine.buildingByMyConstructor.remoteAttributes.reduce((memo, remoteAttributeName, i) => {
     memo[remoteAttributeName] = $record.get(registryConfig.pgRelations.machine.buildingByMyConstructor.localAttributes[i]);
     return memo;
   }, Object.create(null));
 };
-function CreateMachineInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMachineInput_machine_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMaterialPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMaterialPayload_materialPlan($object) {
-  return $object.get("result");
-}
-function CreateMaterialPayload_queryPlan() {
-  return rootValue();
-}
-function CreateMaterialInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMaterialInput_material_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullPayload_nullPlan($object) {
-  return $object.get("result");
-}
-function CreateNullPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullInput_null_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateProjectPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateProjectPayload_projectPlan($object) {
-  return $object.get("result");
-}
-function CreateProjectPayload_queryPlan() {
-  return rootValue();
-}
-function CreateProjectInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateProjectInput_project_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateYieldPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateYieldPayload_yieldPlan($object) {
-  return $object.get("result");
-}
-function CreateYieldPayload_queryPlan() {
-  return rootValue();
-}
-function CreateYieldInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateYieldInput_yield_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProtoPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateProtoPayload__proto__Plan($object) {
-  return $object.get("result");
-}
-function UpdateProtoPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateProtoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProtoInput__protoPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProtoByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProtoByIdInput__protoPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProtoByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProtoByNameInput__protoPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByConstructorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByConstructorInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateConstructorPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateConstructorPayload_constructorPlan($object) {
-  return $object.get("result");
-}
-function UpdateConstructorPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateConstructorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateConstructorInput_constructorPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateConstructorByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateConstructorByIdInput_constructorPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateConstructorByExportInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateConstructorByExportInput_constructorPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateConstructorByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateConstructorByNameInput_constructorPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCropPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCropPayload_cropPlan($object) {
-  return $object.get("result");
-}
-function UpdateCropPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCropInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCropInput_cropPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCropByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCropByIdInput_cropPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCropByYieldInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCropByYieldInput_cropPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMachinePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMachinePayload_machinePlan($object) {
-  return $object.get("result");
-}
-function UpdateMachinePayload_queryPlan() {
-  return rootValue();
-}
 const specFromRecord5 = $record => {
   return registryConfig.pgRelations.machine.buildingByMyConstructor.remoteAttributes.reduce((memo, remoteAttributeName, i) => {
     memo[remoteAttributeName] = $record.get(registryConfig.pgRelations.machine.buildingByMyConstructor.localAttributes[i]);
     return memo;
   }, Object.create(null));
 };
-function UpdateMachineInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMachineInput_machinePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMachineByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMachineByIdInput_machinePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMaterialPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMaterialPayload_materialPlan($object) {
-  return $object.get("result");
-}
-function UpdateMaterialPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMaterialInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMaterialInput_materialPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMaterialByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMaterialByIdInput_materialPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMaterialByClassInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMaterialByClassInput_materialPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMaterialByValueOfInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMaterialByValueOfInput_materialPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullPayload_nullPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullInput_nullPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullByIdInput_nullPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullByBreakInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullByBreakInput_nullPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullByHasOwnPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullByHasOwnPropertyInput_nullPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProjectPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateProjectPayload_projectPlan($object) {
-  return $object.get("result");
-}
-function UpdateProjectPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateProjectInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProjectInput_projectPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProjectByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProjectByIdInput_projectPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateProjectByProtoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateProjectByProtoInput_projectPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateYieldPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateYieldPayload_yieldPlan($object) {
-  return $object.get("result");
-}
-function UpdateYieldPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateYieldInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateYieldInput_yieldPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateYieldByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateYieldByIdInput_yieldPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateYieldByExportInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateYieldByExportInput_yieldPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByCaseInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByDoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByDoInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByNullInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByNullInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteProtoPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteProtoPayload__proto__Plan($object) {
-  return $object.get("result");
-}
-function DeleteProtoPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteProtoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteProtoByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteProtoByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByConstructorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteConstructorPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteConstructorPayload_constructorPlan($object) {
-  return $object.get("result");
-}
-function DeleteConstructorPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteConstructorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteConstructorByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteConstructorByExportInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteConstructorByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCropPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCropPayload_cropPlan($object) {
-  return $object.get("result");
-}
-function DeleteCropPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCropInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCropByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCropByYieldInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMachinePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMachinePayload_machinePlan($object) {
-  return $object.get("result");
-}
-function DeleteMachinePayload_queryPlan() {
-  return rootValue();
-}
 const specFromRecord6 = $record => {
   return registryConfig.pgRelations.machine.buildingByMyConstructor.remoteAttributes.reduce((memo, remoteAttributeName, i) => {
     memo[remoteAttributeName] = $record.get(registryConfig.pgRelations.machine.buildingByMyConstructor.localAttributes[i]);
     return memo;
   }, Object.create(null));
 };
-function DeleteMachineInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMachineByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMaterialPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMaterialPayload_materialPlan($object) {
-  return $object.get("result");
-}
-function DeleteMaterialPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMaterialInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMaterialByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMaterialByClassInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMaterialByValueOfInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullPayload_nullPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullByBreakInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullByHasOwnPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteProjectPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteProjectPayload_projectPlan($object) {
-  return $object.get("result");
-}
-function DeleteProjectPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteProjectInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteProjectByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteProjectByProtoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteYieldPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteYieldPayload_yieldPlan($object) {
-  return $object.get("result");
-}
-function DeleteYieldPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteYieldInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteYieldByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteYieldByExportInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByDoInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByNullInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`type RelationalTopic implements Node & RelationalItem {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -8189,23 +6745,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructor_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructor_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructor_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructor_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructor_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -8232,11 +6798,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructorList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_machinesByConstructorList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -8261,23 +6831,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructor_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructor_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructor_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructor_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructor_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -8304,11 +6884,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructorList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_relationalItemsByConstructorList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -8329,9 +6913,16 @@ export const plans = {
   },
   MachinesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MachinesConnection_nodesPlan,
-    edges: MachinesConnection_edgesPlan,
-    pageInfo: MachinesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -8366,8 +6957,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -8587,9 +7182,16 @@ export const plans = {
   },
   RelationalItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemsConnection_nodesPlan,
-    edges: RelationalItemsConnection_edgesPlan,
-    pageInfo: RelationalItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -8881,7 +7483,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler5.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler5.codec.name].encode);
@@ -9313,11 +7917,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopicsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopicsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9342,23 +7950,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9385,11 +8003,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoSList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoSList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9414,23 +8036,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoS_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoS_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoS_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoS_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProtoS_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9457,11 +8089,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildingsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildingsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9486,23 +8122,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9529,11 +8175,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructorsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructorsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9558,23 +8208,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructors_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructors_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructors_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructors_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allConstructors_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9601,11 +8261,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCropsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCropsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9630,23 +8294,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCrops_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCrops_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCrops_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCrops_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCrops_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9673,11 +8347,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachinesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachinesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9702,23 +8380,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachines_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachines_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachines_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachines_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMachines_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9745,11 +8433,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterialsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterialsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9774,23 +8466,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterials_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterials_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterials_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterials_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMaterials_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9817,11 +8519,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9846,23 +8552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNulls_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNulls_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNulls_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNulls_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNulls_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9889,11 +8605,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjectsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjectsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9918,23 +8638,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjects_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjects_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjects_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjects_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProjects_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9961,11 +8691,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatusesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatusesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -9990,23 +8724,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatuses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatuses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatuses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatuses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalStatuses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10033,11 +8777,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYieldsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYieldsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10062,23 +8810,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYields_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYields_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYields_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYields_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allYields_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10105,11 +8863,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10134,23 +8896,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10177,11 +8949,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10206,23 +8982,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -10685,9 +9471,16 @@ export const plans = {
   },
   RelationalTopicsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalTopicsConnection_nodesPlan,
-    edges: RelationalTopicsConnection_edgesPlan,
-    pageInfo: RelationalTopicsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -10913,9 +9706,16 @@ export const plans = {
   },
   _Proto__SConnection: {
     __assertStep: ConnectionStep,
-    nodes: _Proto__SConnection_nodesPlan,
-    edges: _Proto__SConnection_edgesPlan,
-    pageInfo: _Proto__SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -11141,9 +9941,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -11369,9 +10176,16 @@ export const plans = {
   },
   ConstructorsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ConstructorsConnection_nodesPlan,
-    edges: ConstructorsConnection_edgesPlan,
-    pageInfo: ConstructorsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -11597,9 +10411,16 @@ export const plans = {
   },
   CropsConnection: {
     __assertStep: ConnectionStep,
-    nodes: CropsConnection_nodesPlan,
-    edges: CropsConnection_edgesPlan,
-    pageInfo: CropsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -11825,9 +10646,16 @@ export const plans = {
   },
   MaterialsConnection: {
     __assertStep: ConnectionStep,
-    nodes: MaterialsConnection_nodesPlan,
-    edges: MaterialsConnection_edgesPlan,
-    pageInfo: MaterialsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12053,9 +10881,16 @@ export const plans = {
   },
   NullsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullsConnection_nodesPlan,
-    edges: NullsConnection_edgesPlan,
-    pageInfo: NullsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12281,9 +11116,16 @@ export const plans = {
   },
   ProjectsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ProjectsConnection_nodesPlan,
-    edges: ProjectsConnection_edgesPlan,
-    pageInfo: ProjectsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12623,9 +11465,16 @@ export const plans = {
   },
   RelationalStatusesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalStatusesConnection_nodesPlan,
-    edges: RelationalStatusesConnection_edgesPlan,
-    pageInfo: RelationalStatusesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12851,9 +11700,16 @@ export const plans = {
   },
   YieldsConnection: {
     __assertStep: ConnectionStep,
-    nodes: YieldsConnection_nodesPlan,
-    edges: YieldsConnection_edgesPlan,
-    pageInfo: YieldsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -13136,9 +11992,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -13165,7 +12028,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProto___input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13180,7 +12045,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13195,7 +12062,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createConstructor_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13210,7 +12079,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCrop_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13225,7 +12096,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMachine_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13240,7 +12113,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMaterial_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13255,7 +12130,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNull_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13270,7 +12147,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProject_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13285,7 +12164,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createYield_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13300,7 +12181,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13314,7 +12197,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProto___input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13330,7 +12215,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProtoById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13346,7 +12233,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProtoByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13360,7 +12249,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13376,7 +12267,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13390,7 +12283,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingByConstructor_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13404,7 +12299,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateConstructor_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13420,7 +12317,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateConstructorById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13436,7 +12335,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateConstructorByExport_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13452,7 +12353,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateConstructorByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13466,7 +12369,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCrop_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13482,7 +12387,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCropById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13498,7 +12405,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCropByYield_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13512,7 +12421,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMachine_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13528,7 +12439,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMachineById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13542,7 +12455,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMaterial_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13558,7 +12473,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMaterialById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13574,7 +12491,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMaterialByClass_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13588,7 +12507,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMaterialByValueOf_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13602,7 +12523,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNull_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13618,7 +12541,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13634,7 +12559,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullByBreak_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13648,7 +12575,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullByHasOwnProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13662,7 +12591,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProject_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13678,7 +12609,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProjectById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13692,7 +12625,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProjectByProto___input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13706,7 +12641,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateYield_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13722,7 +12659,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateYieldById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13738,7 +12677,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateYieldByExport_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13752,7 +12693,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13768,7 +12711,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13784,7 +12729,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedByCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13800,7 +12747,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedByDo_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13816,7 +12765,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedByNull_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13830,7 +12781,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProto___input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13846,7 +12799,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProtoById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13862,7 +12817,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProtoByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13876,7 +12833,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13892,7 +12851,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13906,7 +12867,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingByConstructor_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13920,7 +12883,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteConstructor_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13936,7 +12901,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteConstructorById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13952,7 +12919,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteConstructorByExport_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13968,7 +12937,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteConstructorByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13982,7 +12953,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCrop_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13998,7 +12971,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCropById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14014,7 +12989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCropByYield_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14028,7 +13005,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMachine_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14044,7 +13023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMachineById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14058,7 +13039,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMaterial_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14074,7 +13057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMaterialById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14090,7 +13075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMaterialByClass_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14104,7 +13091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMaterialByValueOf_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14118,7 +13107,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNull_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14134,7 +13125,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14150,7 +13143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullByBreak_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14164,7 +13159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullByHasOwnProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14178,7 +13175,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProject_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14194,7 +13193,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProjectById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14208,7 +13209,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProjectByProto___input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14222,7 +13225,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteYield_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14238,7 +13243,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteYieldById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14254,7 +13261,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteYieldByExport_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14268,7 +13277,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14284,7 +13295,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14300,7 +13313,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedByCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14316,7 +13331,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedByDo_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -14332,16 +13349,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedByNull_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateProtoPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateProtoPayload_clientMutationIdPlan,
-    _proto__: CreateProtoPayload__proto__Plan,
-    query: CreateProtoPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    _proto__($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     _protoEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14376,11 +13401,16 @@ export const plans = {
   },
   CreateProtoInput: {
     clientMutationId: {
-      applyPlan: CreateProtoInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _proto__: {
-      applyPlan: CreateProtoInput__proto___applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14409,9 +13439,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14446,11 +13482,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14479,9 +13520,15 @@ export const plans = {
   },
   CreateConstructorPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateConstructorPayload_clientMutationIdPlan,
-    constructor: CreateConstructorPayload_constructorPlan,
-    query: CreateConstructorPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    constructor($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     constructorEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14516,11 +13563,16 @@ export const plans = {
   },
   CreateConstructorInput: {
     clientMutationId: {
-      applyPlan: CreateConstructorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     constructor: {
-      applyPlan: CreateConstructorInput_constructor_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14549,9 +13601,15 @@ export const plans = {
   },
   CreateCropPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCropPayload_clientMutationIdPlan,
-    crop: CreateCropPayload_cropPlan,
-    query: CreateCropPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    crop($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cropEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14586,11 +13644,16 @@ export const plans = {
   },
   CreateCropInput: {
     clientMutationId: {
-      applyPlan: CreateCropInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     crop: {
-      applyPlan: CreateCropInput_crop_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14619,9 +13682,15 @@ export const plans = {
   },
   CreateMachinePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMachinePayload_clientMutationIdPlan,
-    machine: CreateMachinePayload_machinePlan,
-    query: CreateMachinePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    machine($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     machineEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14660,11 +13729,16 @@ export const plans = {
   },
   CreateMachineInput: {
     clientMutationId: {
-      applyPlan: CreateMachineInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     machine: {
-      applyPlan: CreateMachineInput_machine_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14693,9 +13767,15 @@ export const plans = {
   },
   CreateMaterialPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMaterialPayload_clientMutationIdPlan,
-    material: CreateMaterialPayload_materialPlan,
-    query: CreateMaterialPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    material($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     materialEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14730,11 +13810,16 @@ export const plans = {
   },
   CreateMaterialInput: {
     clientMutationId: {
-      applyPlan: CreateMaterialInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     material: {
-      applyPlan: CreateMaterialInput_material_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14763,9 +13848,15 @@ export const plans = {
   },
   CreateNullPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullPayload_clientMutationIdPlan,
-    null: CreateNullPayload_nullPlan,
-    query: CreateNullPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    null($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14800,11 +13891,16 @@ export const plans = {
   },
   CreateNullInput: {
     clientMutationId: {
-      applyPlan: CreateNullInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     null: {
-      applyPlan: CreateNullInput_null_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14833,9 +13929,15 @@ export const plans = {
   },
   CreateProjectPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateProjectPayload_clientMutationIdPlan,
-    project: CreateProjectPayload_projectPlan,
-    query: CreateProjectPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    project($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     projectEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14870,11 +13972,16 @@ export const plans = {
   },
   CreateProjectInput: {
     clientMutationId: {
-      applyPlan: CreateProjectInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     project: {
-      applyPlan: CreateProjectInput_project_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14903,9 +14010,15 @@ export const plans = {
   },
   CreateYieldPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateYieldPayload_clientMutationIdPlan,
-    yield: CreateYieldPayload_yieldPlan,
-    query: CreateYieldPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    yield($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     yieldEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -14940,11 +14053,16 @@ export const plans = {
   },
   CreateYieldInput: {
     clientMutationId: {
-      applyPlan: CreateYieldInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     yield: {
-      applyPlan: CreateYieldInput_yield_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -14973,9 +14091,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15010,11 +14134,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -15050,9 +14179,15 @@ export const plans = {
   },
   UpdateProtoPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateProtoPayload_clientMutationIdPlan,
-    _proto__: UpdateProtoPayload__proto__Plan,
-    query: UpdateProtoPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    _proto__($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     _protoEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15087,11 +14222,16 @@ export const plans = {
   },
   UpdateProtoInput: {
     clientMutationId: {
-      applyPlan: UpdateProtoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     _protoPatch: {
-      applyPlan: UpdateProtoInput__protoPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   _ProtoPatch: {
@@ -15119,27 +14259,43 @@ export const plans = {
   },
   UpdateProtoByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateProtoByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     _protoPatch: {
-      applyPlan: UpdateProtoByIdInput__protoPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateProtoByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateProtoByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     _protoPatch: {
-      applyPlan: UpdateProtoByNameInput__protoPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15174,11 +14330,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -15206,27 +14367,43 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingByConstructorInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByConstructorInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     constructor: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByConstructorInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateConstructorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateConstructorPayload_clientMutationIdPlan,
-    constructor: UpdateConstructorPayload_constructorPlan,
-    query: UpdateConstructorPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    constructor($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     constructorEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15261,11 +14438,16 @@ export const plans = {
   },
   UpdateConstructorInput: {
     clientMutationId: {
-      applyPlan: UpdateConstructorInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     constructorPatch: {
-      applyPlan: UpdateConstructorInput_constructorPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ConstructorPatch: {
@@ -15293,36 +14475,57 @@ export const plans = {
   },
   UpdateConstructorByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateConstructorByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     constructorPatch: {
-      applyPlan: UpdateConstructorByIdInput_constructorPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateConstructorByExportInput: {
     clientMutationId: {
-      applyPlan: UpdateConstructorByExportInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     export: undefined,
     constructorPatch: {
-      applyPlan: UpdateConstructorByExportInput_constructorPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateConstructorByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateConstructorByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     constructorPatch: {
-      applyPlan: UpdateConstructorByNameInput_constructorPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCropPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCropPayload_clientMutationIdPlan,
-    crop: UpdateCropPayload_cropPlan,
-    query: UpdateCropPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    crop($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cropEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15357,11 +14560,16 @@ export const plans = {
   },
   UpdateCropInput: {
     clientMutationId: {
-      applyPlan: UpdateCropInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     cropPatch: {
-      applyPlan: UpdateCropInput_cropPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CropPatch: {
@@ -15389,27 +14597,43 @@ export const plans = {
   },
   UpdateCropByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCropByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     cropPatch: {
-      applyPlan: UpdateCropByIdInput_cropPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCropByYieldInput: {
     clientMutationId: {
-      applyPlan: UpdateCropByYieldInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     yield: undefined,
     cropPatch: {
-      applyPlan: UpdateCropByYieldInput_cropPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateMachinePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMachinePayload_clientMutationIdPlan,
-    machine: UpdateMachinePayload_machinePlan,
-    query: UpdateMachinePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    machine($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     machineEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15448,11 +14672,16 @@ export const plans = {
   },
   UpdateMachineInput: {
     clientMutationId: {
-      applyPlan: UpdateMachineInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     machinePatch: {
-      applyPlan: UpdateMachineInput_machinePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MachinePatch: {
@@ -15480,18 +14709,29 @@ export const plans = {
   },
   UpdateMachineByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMachineByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     machinePatch: {
-      applyPlan: UpdateMachineByIdInput_machinePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateMaterialPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMaterialPayload_clientMutationIdPlan,
-    material: UpdateMaterialPayload_materialPlan,
-    query: UpdateMaterialPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    material($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     materialEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15526,11 +14766,16 @@ export const plans = {
   },
   UpdateMaterialInput: {
     clientMutationId: {
-      applyPlan: UpdateMaterialInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     materialPatch: {
-      applyPlan: UpdateMaterialInput_materialPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MaterialPatch: {
@@ -15558,36 +14803,57 @@ export const plans = {
   },
   UpdateMaterialByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMaterialByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     materialPatch: {
-      applyPlan: UpdateMaterialByIdInput_materialPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateMaterialByClassInput: {
     clientMutationId: {
-      applyPlan: UpdateMaterialByClassInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     class: undefined,
     materialPatch: {
-      applyPlan: UpdateMaterialByClassInput_materialPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateMaterialByValueOfInput: {
     clientMutationId: {
-      applyPlan: UpdateMaterialByValueOfInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     valueOf: undefined,
     materialPatch: {
-      applyPlan: UpdateMaterialByValueOfInput_materialPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullPayload_clientMutationIdPlan,
-    null: UpdateNullPayload_nullPlan,
-    query: UpdateNullPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    null($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15622,11 +14888,16 @@ export const plans = {
   },
   UpdateNullInput: {
     clientMutationId: {
-      applyPlan: UpdateNullInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullPatch: {
-      applyPlan: UpdateNullInput_nullPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullPatch: {
@@ -15654,36 +14925,57 @@ export const plans = {
   },
   UpdateNullByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullPatch: {
-      applyPlan: UpdateNullByIdInput_nullPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullByBreakInput: {
     clientMutationId: {
-      applyPlan: UpdateNullByBreakInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     break: undefined,
     nullPatch: {
-      applyPlan: UpdateNullByBreakInput_nullPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullByHasOwnPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateNullByHasOwnPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     hasOwnProperty: undefined,
     nullPatch: {
-      applyPlan: UpdateNullByHasOwnPropertyInput_nullPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateProjectPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateProjectPayload_clientMutationIdPlan,
-    project: UpdateProjectPayload_projectPlan,
-    query: UpdateProjectPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    project($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     projectEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15718,11 +15010,16 @@ export const plans = {
   },
   UpdateProjectInput: {
     clientMutationId: {
-      applyPlan: UpdateProjectInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     projectPatch: {
-      applyPlan: UpdateProjectInput_projectPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ProjectPatch: {
@@ -15750,27 +15047,43 @@ export const plans = {
   },
   UpdateProjectByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateProjectByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     projectPatch: {
-      applyPlan: UpdateProjectByIdInput_projectPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateProjectByProtoInput: {
     clientMutationId: {
-      applyPlan: UpdateProjectByProtoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     _proto__: undefined,
     projectPatch: {
-      applyPlan: UpdateProjectByProtoInput_projectPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateYieldPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateYieldPayload_clientMutationIdPlan,
-    yield: UpdateYieldPayload_yieldPlan,
-    query: UpdateYieldPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    yield($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     yieldEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15805,11 +15118,16 @@ export const plans = {
   },
   UpdateYieldInput: {
     clientMutationId: {
-      applyPlan: UpdateYieldInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     yieldPatch: {
-      applyPlan: UpdateYieldInput_yieldPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   YieldPatch: {
@@ -15837,27 +15155,43 @@ export const plans = {
   },
   UpdateYieldByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateYieldByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     yieldPatch: {
-      applyPlan: UpdateYieldByIdInput_yieldPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateYieldByExportInput: {
     clientMutationId: {
-      applyPlan: UpdateYieldByExportInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     export: undefined,
     yieldPatch: {
-      applyPlan: UpdateYieldByExportInput_yieldPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -15892,11 +15226,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -15931,50 +15270,76 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedByCaseInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByCaseInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     case: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByCaseInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedByDoInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByDoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     do: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByDoInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedByNullInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByNullInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     null: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByNullInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteProtoPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteProtoPayload_clientMutationIdPlan,
-    _proto__: DeleteProtoPayload__proto__Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    _proto__($object) {
+      return $object.get("result");
+    },
     deletedProtoId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName._Proto__.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteProtoPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     _protoEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16009,32 +15374,44 @@ export const plans = {
   },
   DeleteProtoInput: {
     clientMutationId: {
-      applyPlan: DeleteProtoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteProtoByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteProtoByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteProtoByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteProtoByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler2.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16069,32 +15446,44 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteBuildingByConstructorInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByConstructorInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     constructor: undefined
   },
   DeleteConstructorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteConstructorPayload_clientMutationIdPlan,
-    constructor: DeleteConstructorPayload_constructorPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    constructor($object) {
+      return $object.get("result");
+    },
     deletedConstructorId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Constructor.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteConstructorPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     constructorEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16129,38 +15518,52 @@ export const plans = {
   },
   DeleteConstructorInput: {
     clientMutationId: {
-      applyPlan: DeleteConstructorInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteConstructorByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteConstructorByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteConstructorByExportInput: {
     clientMutationId: {
-      applyPlan: DeleteConstructorByExportInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     export: undefined
   },
   DeleteConstructorByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteConstructorByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeleteCropPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCropPayload_clientMutationIdPlan,
-    crop: DeleteCropPayload_cropPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    crop($object) {
+      return $object.get("result");
+    },
     deletedCropId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Crop.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteCropPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     cropEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16195,32 +15598,44 @@ export const plans = {
   },
   DeleteCropInput: {
     clientMutationId: {
-      applyPlan: DeleteCropInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCropByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCropByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCropByYieldInput: {
     clientMutationId: {
-      applyPlan: DeleteCropByYieldInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     yield: undefined
   },
   DeleteMachinePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMachinePayload_clientMutationIdPlan,
-    machine: DeleteMachinePayload_machinePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    machine($object) {
+      return $object.get("result");
+    },
     deletedMachineId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler3.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteMachinePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     machineEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16259,26 +15674,36 @@ export const plans = {
   },
   DeleteMachineInput: {
     clientMutationId: {
-      applyPlan: DeleteMachineInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMachineByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMachineByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMaterialPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMaterialPayload_clientMutationIdPlan,
-    material: DeleteMaterialPayload_materialPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    material($object) {
+      return $object.get("result");
+    },
     deletedMaterialId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Material.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteMaterialPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     materialEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16313,38 +15738,52 @@ export const plans = {
   },
   DeleteMaterialInput: {
     clientMutationId: {
-      applyPlan: DeleteMaterialInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMaterialByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMaterialByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMaterialByClassInput: {
     clientMutationId: {
-      applyPlan: DeleteMaterialByClassInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     class: undefined
   },
   DeleteMaterialByValueOfInput: {
     clientMutationId: {
-      applyPlan: DeleteMaterialByValueOfInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     valueOf: undefined
   },
   DeleteNullPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullPayload_clientMutationIdPlan,
-    null: DeleteNullPayload_nullPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    null($object) {
+      return $object.get("result");
+    },
     deletedNullId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Null.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteNullPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16379,38 +15818,52 @@ export const plans = {
   },
   DeleteNullInput: {
     clientMutationId: {
-      applyPlan: DeleteNullInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullByBreakInput: {
     clientMutationId: {
-      applyPlan: DeleteNullByBreakInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     break: undefined
   },
   DeleteNullByHasOwnPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteNullByHasOwnPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     hasOwnProperty: undefined
   },
   DeleteProjectPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteProjectPayload_clientMutationIdPlan,
-    project: DeleteProjectPayload_projectPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    project($object) {
+      return $object.get("result");
+    },
     deletedProjectId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Project.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteProjectPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     projectEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16445,32 +15898,44 @@ export const plans = {
   },
   DeleteProjectInput: {
     clientMutationId: {
-      applyPlan: DeleteProjectInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteProjectByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteProjectByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteProjectByProtoInput: {
     clientMutationId: {
-      applyPlan: DeleteProjectByProtoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     _proto__: undefined
   },
   DeleteYieldPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteYieldPayload_clientMutationIdPlan,
-    yield: DeleteYieldPayload_yieldPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    yield($object) {
+      return $object.get("result");
+    },
     deletedYieldId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Yield.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteYieldPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     yieldEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16505,32 +15970,44 @@ export const plans = {
   },
   DeleteYieldInput: {
     clientMutationId: {
-      applyPlan: DeleteYieldInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteYieldByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteYieldByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteYieldByExportInput: {
     clientMutationId: {
-      applyPlan: DeleteYieldByExportInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     export: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -16565,31 +16042,41 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedByCaseInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByCaseInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     case: undefined
   },
   DeleteReservedByDoInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByDoInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     do: undefined
   },
   DeleteReservedByNullInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByNullInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     null: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -68,7 +68,7 @@ const relationalTopicsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -93,7 +93,7 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const __proto__Attributes = Object.assign(Object.create(null), {
   id: {
@@ -138,7 +138,7 @@ const __proto__Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingAttributes = Object.assign(Object.create(null), {
   id: {
@@ -183,7 +183,7 @@ const buildingCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const constructorAttributes = Object.assign(Object.create(null), {
   id: {
@@ -228,7 +228,7 @@ const constructorCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cropAttributes = Object.assign(Object.create(null), {
   id: {
@@ -273,7 +273,7 @@ const cropCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const machineAttributes = Object.assign(Object.create(null), {
   id: {
@@ -318,7 +318,7 @@ const machineCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const materialAttributes = Object.assign(Object.create(null), {
   id: {
@@ -363,7 +363,7 @@ const materialCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullAttributes = Object.assign(Object.create(null), {
   id: {
@@ -408,7 +408,7 @@ const nullCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const projectAttributes = Object.fromEntries([["id", {
   description: undefined,
@@ -449,7 +449,7 @@ const projectCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalStatusAttributes = Object.assign(Object.create(null), {
   id: {
@@ -518,7 +518,7 @@ const relationalStatusCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const yieldAttributes = Object.assign(Object.create(null), {
   id: {
@@ -563,7 +563,7 @@ const yieldCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -617,7 +617,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -666,13 +666,13 @@ const relationalItemsCodec = recordCodec({
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions14,
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent2 = sql.identifier("js_reserved", "await");
-const sqlIdent3 = sql.identifier("js_reserved", "case");
-const sqlIdent4 = sql.identifier("js_reserved", "valueOf");
-const sqlIdent5 = sql.identifier("js_reserved", "null_yield");
-const uniques = [{
+const awaitFunctionIdentifer = sql.identifier("js_reserved", "await");
+const caseFunctionIdentifer = sql.identifier("js_reserved", "case");
+const valueOfFunctionIdentifer = sql.identifier("js_reserved", "valueOf");
+const null_yieldFunctionIdentifer = sql.identifier("js_reserved", "null_yield");
+const relational_topicsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -681,12 +681,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_topics",
   identifier: "main.js_reserved.relational_topics",
   from: relationalTopicsCodec.sqlType,
   codec: relationalTopicsCodec,
-  uniques,
+  uniques: relational_topicsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -699,7 +699,7 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
     tags: {}
   }
 };
-const uniques2 = [{
+const __proto__Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -714,7 +714,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const buildingUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -730,12 +730,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_building_building = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "building",
   identifier: "main.js_reserved.building",
   from: buildingCodec.sqlType,
   codec: buildingCodec,
-  uniques: uniques3,
+  uniques: buildingUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -748,7 +748,7 @@ const registryConfig_pgResources_building_building = {
     tags: {}
   }
 };
-const uniques4 = [{
+const constructorUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -770,7 +770,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const cropUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -785,7 +785,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const machineUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -794,12 +794,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_machine_machine = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "machine",
   identifier: "main.js_reserved.machine",
   from: machineCodec.sqlType,
   codec: machineCodec,
-  uniques: uniques6,
+  uniques: machineUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -812,7 +812,7 @@ const registryConfig_pgResources_machine_machine = {
     tags: {}
   }
 };
-const uniques7 = [{
+const materialUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -834,7 +834,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const uniques8 = [{
+const nullUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -856,7 +856,7 @@ const uniques8 = [{
     tags: Object.create(null)
   }
 }];
-const uniques9 = [{
+const projectUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -871,7 +871,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const uniques10 = [{
+const relational_statusUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -880,12 +880,12 @@ const uniques10 = [{
   }
 }];
 const registryConfig_pgResources_relational_status_relational_status = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_status",
   identifier: "main.js_reserved.relational_status",
   from: relationalStatusCodec.sqlType,
   codec: relationalStatusCodec,
-  uniques: uniques10,
+  uniques: relational_statusUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -898,7 +898,7 @@ const registryConfig_pgResources_relational_status_relational_status = {
     tags: {}
   }
 };
-const uniques11 = [{
+const yieldUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -913,7 +913,7 @@ const uniques11 = [{
     tags: Object.create(null)
   }
 }];
-const uniques12 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -942,7 +942,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const relational_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -951,12 +951,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_items",
   identifier: "main.js_reserved.relational_items",
   from: relationalItemsCodec.sqlType,
   codec: relationalItemsCodec,
-  uniques: uniques13,
+  uniques: relational_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -975,11 +975,11 @@ const registryConfig_pgResources_relational_items_relational_items = {
 const registryConfig = {
   pgCodecs: Object.fromEntries([["int4", TYPES.int], ["relationalTopics", relationalTopicsCodec], ["text", TYPES.text], ["__proto__", __proto__Codec], ["building", buildingCodec], ["constructor", constructorCodec], ["crop", cropCodec], ["machine", machineCodec], ["material", materialCodec], ["null", nullCodec], ["project", projectCodec], ["relationalStatus", relationalStatusCodec], ["yield", yieldCodec], ["reserved", reservedCodec], ["relationalItems", relationalItemsCodec], ["itemType", itemTypeCodec], ["varchar", TYPES.varchar], ["bpchar", TYPES.bpchar]]),
   pgResources: Object.fromEntries([["await", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "await",
     identifier: "main.js_reserved.await(int4,int4,int4,int4)",
     from(...args) {
-      return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      return sql`${awaitFunctionIdentifer}(${sqlFromArgDigests(args)})`;
     },
     parameters: [{
       name: "yield",
@@ -1018,11 +1018,11 @@ const registryConfig = {
     },
     description: undefined
   }], ["case", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "case",
     identifier: "main.js_reserved.case(int4,int4,int4,int4)",
     from(...args) {
-      return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      return sql`${caseFunctionIdentifer}(${sqlFromArgDigests(args)})`;
     },
     parameters: [{
       name: "yield",
@@ -1061,11 +1061,11 @@ const registryConfig = {
     },
     description: undefined
   }], ["valueOf", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "valueOf",
     identifier: "main.js_reserved.valueOf(int4,int4,int4,int4)",
     from(...args) {
-      return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      return sql`${valueOfFunctionIdentifer}(${sqlFromArgDigests(args)})`;
     },
     parameters: [{
       name: "yield",
@@ -1104,11 +1104,11 @@ const registryConfig = {
     },
     description: undefined
   }], ["null_yield", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "null_yield",
     identifier: "main.js_reserved.null_yield(js_reserved.null,int4,int4,int4,int4)",
     from(...args) {
-      return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      return sql`${null_yieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
     },
     parameters: [{
       name: "n",
@@ -1152,12 +1152,12 @@ const registryConfig = {
     },
     description: undefined
   }], ["relational_topics", registryConfig_pgResources_relational_topics_relational_topics], ["__proto__", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "__proto__",
     identifier: "main.js_reserved.__proto__",
     from: __proto__Codec.sqlType,
     codec: __proto__Codec,
-    uniques: uniques2,
+    uniques: __proto__Uniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1170,12 +1170,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["building", registryConfig_pgResources_building_building], ["constructor", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "constructor",
     identifier: "main.js_reserved.constructor",
     from: constructorCodec.sqlType,
     codec: constructorCodec,
-    uniques: uniques4,
+    uniques: constructorUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1188,12 +1188,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["crop", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "crop",
     identifier: "main.js_reserved.crop",
     from: cropCodec.sqlType,
     codec: cropCodec,
-    uniques: uniques5,
+    uniques: cropUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1206,12 +1206,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["machine", registryConfig_pgResources_machine_machine], ["material", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "material",
     identifier: "main.js_reserved.material",
     from: materialCodec.sqlType,
     codec: materialCodec,
-    uniques: uniques7,
+    uniques: materialUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1224,12 +1224,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["null", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "null",
     identifier: "main.js_reserved.null",
     from: nullCodec.sqlType,
     codec: nullCodec,
-    uniques: uniques8,
+    uniques: nullUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1242,12 +1242,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["project", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "project",
     identifier: "main.js_reserved.project",
     from: projectCodec.sqlType,
     codec: projectCodec,
-    uniques: uniques9,
+    uniques: projectUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1260,12 +1260,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["relational_status", registryConfig_pgResources_relational_status_relational_status], ["yield", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "yield",
     identifier: "main.js_reserved.yield",
     from: yieldCodec.sqlType,
     codec: yieldCodec,
-    uniques: uniques11,
+    uniques: yieldUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1278,12 +1278,12 @@ const registryConfig = {
       tags: {}
     }
   }], ["reserved", {
-    executor: executor_mainPgExecutor,
+    executor,
     name: "reserved",
     identifier: "main.js_reserved.reserved",
     from: reservedCodec.sqlType,
     codec: reservedCodec,
-    uniques: uniques12,
+    uniques: reservedUniques,
     isVirtual: false,
     description: undefined,
     extensions: {
@@ -1600,10 +1600,10 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
     codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
-      return list([constant("__proto__S", false), ...uniques2[0].attributes.map(attribute => $record.get(attribute))]);
+      return list([constant("__proto__S", false), ...__proto__Uniques[0].attributes.map(attribute => $record.get(attribute))]);
     },
     getSpec($list) {
-      const spec = uniques2[0].attributes.reduce((memo, attribute, index) => {
+      const spec = __proto__Uniques[0].attributes.reduce((memo, attribute, index) => {
         memo[attribute] = access($list, [index + 1]);
         return memo;
       }, Object.create(null));
@@ -6976,7 +6976,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        machineUniques[0].attributes.forEach(attributeName => {
           const attribute = machineCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6992,7 +6992,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        machineUniques[0].attributes.forEach(attributeName => {
           const attribute = machineCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7211,7 +7211,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7227,7 +7227,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9208,7 +9208,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9224,7 +9224,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9500,7 +9500,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        __proto__Uniques[0].attributes.forEach(attributeName => {
           const attribute = __proto__Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9516,7 +9516,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        __proto__Uniques[0].attributes.forEach(attributeName => {
           const attribute = __proto__Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9735,7 +9735,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        buildingUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9751,7 +9751,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        buildingUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9970,7 +9970,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        constructorUniques[0].attributes.forEach(attributeName => {
           const attribute = constructorCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -9986,7 +9986,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        constructorUniques[0].attributes.forEach(attributeName => {
           const attribute = constructorCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10205,7 +10205,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        cropUniques[0].attributes.forEach(attributeName => {
           const attribute = cropCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10221,7 +10221,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        cropUniques[0].attributes.forEach(attributeName => {
           const attribute = cropCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10440,7 +10440,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        materialUniques[0].attributes.forEach(attributeName => {
           const attribute = materialCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10456,7 +10456,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        materialUniques[0].attributes.forEach(attributeName => {
           const attribute = materialCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10675,7 +10675,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        nullUniques[0].attributes.forEach(attributeName => {
           const attribute = nullCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10691,7 +10691,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        nullUniques[0].attributes.forEach(attributeName => {
           const attribute = nullCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10910,7 +10910,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        projectUniques[0].attributes.forEach(attributeName => {
           const attribute = projectCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10926,7 +10926,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        projectUniques[0].attributes.forEach(attributeName => {
           const attribute = projectCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11145,7 +11145,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_statusUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalStatusCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11161,7 +11161,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_statusUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalStatusCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11494,7 +11494,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        yieldUniques[0].attributes.forEach(attributeName => {
           const attribute = yieldCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11510,7 +11510,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        yieldUniques[0].attributes.forEach(attributeName => {
           const attribute = yieldCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11729,7 +11729,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11745,7 +11745,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -13377,7 +13377,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = __proto__Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13458,7 +13458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13539,7 +13539,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = constructorUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13620,7 +13620,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = cropUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13701,7 +13701,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = machineUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13786,7 +13786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = materialUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13867,7 +13867,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques8[0].attributes.reduce((memo, attributeName) => {
+            const spec = nullUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13948,7 +13948,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = projectUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14029,7 +14029,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = yieldUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14110,7 +14110,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14198,7 +14198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = __proto__Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14306,7 +14306,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14414,7 +14414,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = constructorUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14536,7 +14536,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = cropUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14644,7 +14644,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = machineUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14742,7 +14742,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = materialUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14864,7 +14864,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques8[0].attributes.reduce((memo, attributeName) => {
+            const spec = nullUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -14986,7 +14986,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = projectUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15094,7 +15094,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = yieldUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15202,7 +15202,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15350,7 +15350,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = __proto__Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15422,7 +15422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15494,7 +15494,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = constructorUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15574,7 +15574,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = cropUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15646,7 +15646,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = machineUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15714,7 +15714,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = materialUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15794,7 +15794,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques8[0].attributes.reduce((memo, attributeName) => {
+            const spec = nullUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15874,7 +15874,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = projectUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -15946,7 +15946,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = yieldUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -16018,7 +16018,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -13,7 +13,7 @@ const handler_codec_base64JSON = {
   encode: base64JSONEncode,
   decode: base64JSONDecode
 };
-const attributes_type_codec_itemType = enumCodec({
+const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier(...["js_reserved", "item_type"]),
   values: ["TOPIC", "STATUS"],
@@ -27,7 +27,7 @@ const attributes_type_codec_itemType = enumCodec({
     tags: Object.create(null)
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const relationalTopicsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -48,7 +48,7 @@ const attributes = Object.assign(Object.create(null), {
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyId",
@@ -91,17 +91,17 @@ const extensions2 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts2 = ["js_reserved", "relational_topics"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_relationalTopics = {
+const relationalTopicsIdentifier = sql.identifier(...parts2);
+const relationalTopicsCodecSpec = {
   name: "relationalTopics",
-  identifier: sqlIdent2,
-  attributes,
+  identifier: relationalTopicsIdentifier,
+  attributes: relationalTopicsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalTopics_relationalTopics = recordCodec(spec_relationalTopics);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+const __proto__Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -140,17 +140,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["js_reserved", "__proto__"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec___proto__ = {
+const __proto__Identifier = sql.identifier(...parts3);
+const __proto__CodecSpec = {
   name: "__proto__",
-  identifier: sqlIdent3,
-  attributes: attributes_object_Object_,
+  identifier: __proto__Identifier,
+  attributes: __proto__Attributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs___proto_____proto__ = recordCodec(spec___proto__);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const __proto__Codec = recordCodec(__proto__CodecSpec);
+const buildingAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -189,17 +189,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["js_reserved", "building"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_building = {
+const buildingIdentifier = sql.identifier(...parts4);
+const buildingCodecSpec = {
   name: "building",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_2,
+  identifier: buildingIdentifier,
+  attributes: buildingAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_building_building = recordCodec(spec_building);
-const attributes_object_Object_3 = Object.assign(Object.create(null), {
+const buildingCodec = recordCodec(buildingCodecSpec);
+const constructorAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -238,17 +238,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["js_reserved", "constructor"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_constructor = {
+const constructorIdentifier = sql.identifier(...parts5);
+const constructorCodecSpec = {
   name: "constructor",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_3,
+  identifier: constructorIdentifier,
+  attributes: constructorAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_constructor_constructor = recordCodec(spec_constructor);
-const attributes2 = Object.assign(Object.create(null), {
+const constructorCodec = recordCodec(constructorCodecSpec);
+const cropAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -287,17 +287,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["js_reserved", "crop"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_crop = {
+const cropIdentifier = sql.identifier(...parts6);
+const cropCodecSpec = {
   name: "crop",
-  identifier: sqlIdent6,
-  attributes: attributes2,
+  identifier: cropIdentifier,
+  attributes: cropAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_crop_crop = recordCodec(spec_crop);
-const attributes3 = Object.assign(Object.create(null), {
+const cropCodec = recordCodec(cropCodecSpec);
+const machineAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -336,17 +336,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["js_reserved", "machine"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_machine = {
+const machineIdentifier = sql.identifier(...parts7);
+const machineCodecSpec = {
   name: "machine",
-  identifier: sqlIdent7,
-  attributes: attributes3,
+  identifier: machineIdentifier,
+  attributes: machineAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_machine_machine = recordCodec(spec_machine);
-const attributes4 = Object.assign(Object.create(null), {
+const machineCodec = recordCodec(machineCodecSpec);
+const materialAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -385,17 +385,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["js_reserved", "material"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_material = {
+const materialIdentifier = sql.identifier(...parts8);
+const materialCodecSpec = {
   name: "material",
-  identifier: sqlIdent8,
-  attributes: attributes4,
+  identifier: materialIdentifier,
+  attributes: materialAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_material_material = recordCodec(spec_material);
-const attributes5 = Object.assign(Object.create(null), {
+const materialCodec = recordCodec(materialCodecSpec);
+const nullAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -434,17 +434,17 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["js_reserved", "null"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_null = {
+const nullIdentifier = sql.identifier(...parts9);
+const nullCodecSpec = {
   name: "null",
-  identifier: sqlIdent9,
-  attributes: attributes5,
+  identifier: nullIdentifier,
+  attributes: nullAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_null_null = recordCodec(spec_null);
-const attributes6 = Object.fromEntries([["id", {
+const nullCodec = recordCodec(nullCodecSpec);
+const projectAttributes = Object.fromEntries([["id", {
   description: undefined,
   codec: TYPES.int,
   notNull: true,
@@ -479,17 +479,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["js_reserved", "project"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_project = {
+const projectIdentifier = sql.identifier(...parts10);
+const projectCodecSpec = {
   name: "project",
-  identifier: sqlIdent10,
-  attributes: attributes6,
+  identifier: projectIdentifier,
+  attributes: projectAttributes,
   description: undefined,
   extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_project_project = recordCodec(spec_project);
-const attributes7 = Object.assign(Object.create(null), {
+const projectCodec = recordCodec(projectCodecSpec);
+const relationalStatusAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -519,14 +519,14 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes.type.extensions.tags
+      tags: relationalTopicsAttributes.type.extensions.tags
     }
   },
   constructor: {
@@ -537,7 +537,7 @@ const attributes7 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes.constructor.extensions.tags
+      tags: relationalTopicsAttributes.constructor.extensions.tags
     }
   }
 });
@@ -552,17 +552,17 @@ const extensions11 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts11 = ["js_reserved", "relational_status"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_relationalStatus = {
+const relationalStatusIdentifier = sql.identifier(...parts11);
+const relationalStatusCodecSpec = {
   name: "relationalStatus",
-  identifier: sqlIdent11,
-  attributes: attributes7,
+  identifier: relationalStatusIdentifier,
+  attributes: relationalStatusAttributes,
   description: undefined,
   extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalStatus_relationalStatus = recordCodec(spec_relationalStatus);
-const attributes8 = Object.assign(Object.create(null), {
+const relationalStatusCodec = recordCodec(relationalStatusCodecSpec);
+const yieldAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -601,17 +601,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["js_reserved", "yield"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_yield = {
+const yieldIdentifier = sql.identifier(...parts12);
+const yieldCodecSpec = {
   name: "yield",
-  identifier: sqlIdent12,
-  attributes: attributes8,
+  identifier: yieldIdentifier,
+  attributes: yieldAttributes,
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_yield_yield = recordCodec(spec_yield);
-const attributes9 = Object.assign(Object.create(null), {
+const yieldCodec = recordCodec(yieldCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -659,17 +659,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts13 = ["js_reserved", "reserved"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_reserved = {
+const reservedIdentifier = sql.identifier(...parts13);
+const reservedCodecSpec = {
   name: "reserved",
-  identifier: sqlIdent13,
-  attributes: attributes9,
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
   description: undefined,
   extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes10 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -681,11 +681,11 @@ const attributes10 = Object.assign(Object.create(null), {
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes.type.extensions.tags
+      tags: relationalTopicsAttributes.type.extensions.tags
     }
   },
   constructor: {
@@ -694,7 +694,7 @@ const attributes10 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes.constructor.extensions.tags
+      tags: relationalTopicsAttributes.constructor.extensions.tags
     }
   }
 });
@@ -711,16 +711,16 @@ const extensions14 = {
   })
 };
 const parts14 = ["js_reserved", "relational_items"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_relationalItems = {
+const relationalItemsIdentifier = sql.identifier(...parts14);
+const relationalItemsCodecSpec = {
   name: "relationalItems",
-  identifier: sqlIdent14,
-  attributes: attributes10,
+  identifier: relationalItemsIdentifier,
+  attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItems_relationalItems = recordCodec(spec_relationalItems);
+const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
 const extensions15 = {
   pg: {
     serviceName: "main",
@@ -732,7 +732,7 @@ const extensions15 = {
   }
 };
 const parts15 = ["js_reserved", "await"];
-const sqlIdent15 = sql.identifier(...parts15);
+const sqlIdent2 = sql.identifier(...parts15);
 const extensions16 = {
   pg: {
     serviceName: "main",
@@ -744,8 +744,8 @@ const extensions16 = {
   }
 };
 const parts16 = ["js_reserved", "case"];
-const sqlIdent16 = sql.identifier(...parts16);
-const fromCallback2 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+const sqlIdent3 = sql.identifier(...parts16);
+const fromCallback2 = (...args) => sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "yield",
   required: true,
@@ -778,8 +778,8 @@ const extensions17 = {
   }
 };
 const parts17 = ["js_reserved", "valueOf"];
-const sqlIdent17 = sql.identifier(...parts17);
-const fromCallback3 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts17);
+const fromCallback3 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters3 = [{
   name: "yield",
   required: true,
@@ -812,13 +812,13 @@ const extensions18 = {
   }
 };
 const parts18 = ["js_reserved", "null_yield"];
-const sqlIdent18 = sql.identifier(...parts18);
-const fromCallback4 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+const sqlIdent5 = sql.identifier(...parts18);
+const fromCallback4 = (...args) => sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
 const parameters4 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_null_null
+  codec: nullCodec
 }, {
   name: "yield",
   required: true,
@@ -861,8 +861,8 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   executor: executor_mainPgExecutor,
   name: "relational_topics",
   identifier: "main.js_reserved.relational_topics",
-  from: registryConfig_pgCodecs_relationalTopics_relationalTopics.sqlType,
-  codec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+  from: relationalTopicsCodec.sqlType,
+  codec: relationalTopicsCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -920,8 +920,8 @@ const registryConfig_pgResources_building_building = {
   executor: executor_mainPgExecutor,
   name: "building",
   identifier: "main.js_reserved.building",
-  from: registryConfig_pgCodecs_building_building.sqlType,
-  codec: registryConfig_pgCodecs_building_building,
+  from: buildingCodec.sqlType,
+  codec: buildingCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -1003,8 +1003,8 @@ const registryConfig_pgResources_machine_machine = {
   executor: executor_mainPgExecutor,
   name: "machine",
   identifier: "main.js_reserved.machine",
-  from: registryConfig_pgCodecs_machine_machine.sqlType,
-  codec: registryConfig_pgCodecs_machine_machine,
+  from: machineCodec.sqlType,
+  codec: machineCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -1117,8 +1117,8 @@ const registryConfig_pgResources_relational_status_relational_status = {
   executor: executor_mainPgExecutor,
   name: "relational_status",
   identifier: "main.js_reserved.relational_status",
-  from: registryConfig_pgCodecs_relationalStatus_relationalStatus.sqlType,
-  codec: registryConfig_pgCodecs_relationalStatus_relationalStatus,
+  from: relationalStatusCodec.sqlType,
+  codec: relationalStatusCodec,
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
@@ -1210,21 +1210,21 @@ const registryConfig_pgResources_relational_items_relational_items = {
   executor: executor_mainPgExecutor,
   name: "relational_items",
   identifier: "main.js_reserved.relational_items",
-  from: registryConfig_pgCodecs_relationalItems_relationalItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+  from: relationalItemsCodec.sqlType,
+  codec: relationalItemsCodec,
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
   extensions: extensions31
 };
 const registryConfig = {
-  pgCodecs: Object.fromEntries([["int4", TYPES.int], ["relationalTopics", registryConfig_pgCodecs_relationalTopics_relationalTopics], ["text", TYPES.text], ["__proto__", registryConfig_pgCodecs___proto_____proto__], ["building", registryConfig_pgCodecs_building_building], ["constructor", registryConfig_pgCodecs_constructor_constructor], ["crop", registryConfig_pgCodecs_crop_crop], ["machine", registryConfig_pgCodecs_machine_machine], ["material", registryConfig_pgCodecs_material_material], ["null", registryConfig_pgCodecs_null_null], ["project", registryConfig_pgCodecs_project_project], ["relationalStatus", registryConfig_pgCodecs_relationalStatus_relationalStatus], ["yield", registryConfig_pgCodecs_yield_yield], ["reserved", registryConfig_pgCodecs_reserved_reserved], ["relationalItems", registryConfig_pgCodecs_relationalItems_relationalItems], ["itemType", attributes_type_codec_itemType], ["varchar", TYPES.varchar], ["bpchar", TYPES.bpchar]]),
+  pgCodecs: Object.fromEntries([["int4", TYPES.int], ["relationalTopics", relationalTopicsCodec], ["text", TYPES.text], ["__proto__", __proto__Codec], ["building", buildingCodec], ["constructor", constructorCodec], ["crop", cropCodec], ["machine", machineCodec], ["material", materialCodec], ["null", nullCodec], ["project", projectCodec], ["relationalStatus", relationalStatusCodec], ["yield", yieldCodec], ["reserved", reservedCodec], ["relationalItems", relationalItemsCodec], ["itemType", itemTypeCodec], ["varchar", TYPES.varchar], ["bpchar", TYPES.bpchar]]),
   pgResources: Object.fromEntries([["await", {
     executor: executor_mainPgExecutor,
     name: "await",
     identifier: "main.js_reserved.await(int4,int4,int4,int4)",
     from(...args) {
-      return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
     },
     parameters: [{
       name: "yield",
@@ -1293,8 +1293,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "__proto__",
     identifier: "main.js_reserved.__proto__",
-    from: registryConfig_pgCodecs___proto_____proto__.sqlType,
-    codec: registryConfig_pgCodecs___proto_____proto__,
+    from: __proto__Codec.sqlType,
+    codec: __proto__Codec,
     uniques: uniques2,
     isVirtual: false,
     description: undefined,
@@ -1303,8 +1303,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "constructor",
     identifier: "main.js_reserved.constructor",
-    from: registryConfig_pgCodecs_constructor_constructor.sqlType,
-    codec: registryConfig_pgCodecs_constructor_constructor,
+    from: constructorCodec.sqlType,
+    codec: constructorCodec,
     uniques: uniques4,
     isVirtual: false,
     description: undefined,
@@ -1313,8 +1313,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "crop",
     identifier: "main.js_reserved.crop",
-    from: registryConfig_pgCodecs_crop_crop.sqlType,
-    codec: registryConfig_pgCodecs_crop_crop,
+    from: cropCodec.sqlType,
+    codec: cropCodec,
     uniques: uniques5,
     isVirtual: false,
     description: undefined,
@@ -1323,8 +1323,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "material",
     identifier: "main.js_reserved.material",
-    from: registryConfig_pgCodecs_material_material.sqlType,
-    codec: registryConfig_pgCodecs_material_material,
+    from: materialCodec.sqlType,
+    codec: materialCodec,
     uniques: uniques7,
     isVirtual: false,
     description: undefined,
@@ -1333,8 +1333,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "null",
     identifier: "main.js_reserved.null",
-    from: registryConfig_pgCodecs_null_null.sqlType,
-    codec: registryConfig_pgCodecs_null_null,
+    from: nullCodec.sqlType,
+    codec: nullCodec,
     uniques: uniques8,
     isVirtual: false,
     description: undefined,
@@ -1343,8 +1343,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "project",
     identifier: "main.js_reserved.project",
-    from: registryConfig_pgCodecs_project_project.sqlType,
-    codec: registryConfig_pgCodecs_project_project,
+    from: projectCodec.sqlType,
+    codec: projectCodec,
     uniques: uniques9,
     isVirtual: false,
     description: undefined,
@@ -1353,8 +1353,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "yield",
     identifier: "main.js_reserved.yield",
-    from: registryConfig_pgCodecs_yield_yield.sqlType,
-    codec: registryConfig_pgCodecs_yield_yield,
+    from: yieldCodec.sqlType,
+    codec: yieldCodec,
     uniques: uniques11,
     isVirtual: false,
     description: undefined,
@@ -1363,8 +1363,8 @@ const registryConfig = {
     executor: executor_mainPgExecutor,
     name: "reserved",
     identifier: "main.js_reserved.reserved",
-    from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-    codec: registryConfig_pgCodecs_reserved_reserved,
+    from: reservedCodec.sqlType,
+    codec: reservedCodec,
     uniques: uniques12,
     isVirtual: false,
     description: undefined,
@@ -1373,7 +1373,7 @@ const registryConfig = {
   pgRelations: Object.assign(Object.create(null), {
     building: Object.assign(Object.create(null), {
       machinesByTheirConstructor: {
-        localCodec: registryConfig_pgCodecs_building_building,
+        localCodec: buildingCodec,
         remoteResourceOptions: registryConfig_pgResources_machine_machine,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["constructor"],
@@ -1388,7 +1388,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirConstructor: {
-        localCodec: registryConfig_pgCodecs_building_building,
+        localCodec: buildingCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["constructor"],
@@ -1405,7 +1405,7 @@ const registryConfig = {
     }),
     machine: Object.assign(Object.create(null), {
       buildingByMyConstructor: {
-        localCodec: registryConfig_pgCodecs_machine_machine,
+        localCodec: machineCodec,
         remoteResourceOptions: registryConfig_pgResources_building_building,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["constructor"],
@@ -1422,7 +1422,7 @@ const registryConfig = {
     }),
     relationalItems: Object.assign(Object.create(null), {
       buildingByMyConstructor: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_building_building,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["constructor"],
@@ -1437,7 +1437,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByTheirId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1452,7 +1452,7 @@ const registryConfig = {
         }
       },
       relationalStatusByTheirId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_status_relational_status,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1469,7 +1469,7 @@ const registryConfig = {
     }),
     relationalStatus: Object.assign(Object.create(null), {
       relationalItemsByMyId: {
-        localCodec: registryConfig_pgCodecs_relationalStatus_relationalStatus,
+        localCodec: relationalStatusCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1486,7 +1486,7 @@ const registryConfig = {
     }),
     relationalTopics: Object.assign(Object.create(null), {
       relationalItemsByMyId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8382,7 +8382,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_machine_machine.attributes[attributeName];
+          const attribute = machineCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -8398,7 +8398,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_machine_machine.attributes[attributeName];
+          const attribute = machineCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -8530,7 +8530,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.id.codec)}`;
             }
           });
         }
@@ -8553,7 +8553,7 @@ export const plans = {
             type: "attribute",
             attribute: "input",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.input.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.input.codec)}`;
             }
           });
         }
@@ -8576,7 +8576,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.constructor.codec)}`;
             }
           });
         }
@@ -8610,7 +8610,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -8626,7 +8626,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -8758,7 +8758,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -8781,7 +8781,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -8804,7 +8804,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.constructor.codec)}`;
             }
           });
         }
@@ -10423,7 +10423,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -10439,7 +10439,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -10605,7 +10605,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
             }
           });
         }
@@ -10628,7 +10628,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
             }
           });
         }
@@ -10651,7 +10651,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
             }
           });
         }
@@ -10674,7 +10674,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.constructor.codec)}`;
             }
           });
         }
@@ -10708,7 +10708,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs___proto_____proto__.attributes[attributeName];
+          const attribute = __proto__Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -10724,7 +10724,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs___proto_____proto__.attributes[attributeName];
+          const attribute = __proto__Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -10856,7 +10856,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.id.codec)}`;
             }
           });
         }
@@ -10879,7 +10879,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.name.codec)}`;
             }
           });
         }
@@ -10902,7 +10902,7 @@ export const plans = {
             type: "attribute",
             attribute: "brand",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.brand.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.brand.codec)}`;
             }
           });
         }
@@ -10936,7 +10936,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_building_building.attributes[attributeName];
+          const attribute = buildingCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -10952,7 +10952,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_building_building.attributes[attributeName];
+          const attribute = buildingCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11084,7 +11084,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.id.codec)}`;
             }
           });
         }
@@ -11107,7 +11107,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.name.codec)}`;
             }
           });
         }
@@ -11130,7 +11130,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.constructor.codec)}`;
             }
           });
         }
@@ -11164,7 +11164,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_constructor_constructor.attributes[attributeName];
+          const attribute = constructorCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11180,7 +11180,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_constructor_constructor.attributes[attributeName];
+          const attribute = constructorCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11312,7 +11312,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.id.codec)}`;
             }
           });
         }
@@ -11335,7 +11335,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.name.codec)}`;
             }
           });
         }
@@ -11358,7 +11358,7 @@ export const plans = {
             type: "attribute",
             attribute: "export",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.export.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.export.codec)}`;
             }
           });
         }
@@ -11392,7 +11392,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_crop_crop.attributes[attributeName];
+          const attribute = cropCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11408,7 +11408,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_crop_crop.attributes[attributeName];
+          const attribute = cropCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11540,7 +11540,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.id.codec)}`;
             }
           });
         }
@@ -11563,7 +11563,7 @@ export const plans = {
             type: "attribute",
             attribute: "yield",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.yield.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.yield.codec)}`;
             }
           });
         }
@@ -11586,7 +11586,7 @@ export const plans = {
             type: "attribute",
             attribute: "amount",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.amount.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.amount.codec)}`;
             }
           });
         }
@@ -11620,7 +11620,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_material_material.attributes[attributeName];
+          const attribute = materialCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11636,7 +11636,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_material_material.attributes[attributeName];
+          const attribute = materialCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11768,7 +11768,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.id.codec)}`;
             }
           });
         }
@@ -11791,7 +11791,7 @@ export const plans = {
             type: "attribute",
             attribute: "class",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.class.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.class.codec)}`;
             }
           });
         }
@@ -11814,7 +11814,7 @@ export const plans = {
             type: "attribute",
             attribute: "valueOf",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.valueOf.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.valueOf.codec)}`;
             }
           });
         }
@@ -11848,7 +11848,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_null_null.attributes[attributeName];
+          const attribute = nullCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11864,7 +11864,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_null_null.attributes[attributeName];
+          const attribute = nullCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11996,7 +11996,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.id.codec)}`;
             }
           });
         }
@@ -12019,7 +12019,7 @@ export const plans = {
             type: "attribute",
             attribute: "hasOwnProperty",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.hasOwnProperty.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.hasOwnProperty.codec)}`;
             }
           });
         }
@@ -12042,7 +12042,7 @@ export const plans = {
             type: "attribute",
             attribute: "break",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.break.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.break.codec)}`;
             }
           });
         }
@@ -12076,7 +12076,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_project_project.attributes[attributeName];
+          const attribute = projectCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12092,7 +12092,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_project_project.attributes[attributeName];
+          const attribute = projectCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12224,7 +12224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6["id"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["id"].codec)}`;
             }
           });
         }
@@ -12247,7 +12247,7 @@ export const plans = {
             type: "attribute",
             attribute: "brand",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6["brand"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["brand"].codec)}`;
             }
           });
         }
@@ -12270,7 +12270,7 @@ export const plans = {
             type: "attribute",
             attribute: "__proto__",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6["__proto__"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["__proto__"].codec)}`;
             }
           });
         }
@@ -12304,7 +12304,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalStatus_relationalStatus.attributes[attributeName];
+          const attribute = relationalStatusCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12320,7 +12320,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalStatus_relationalStatus.attributes[attributeName];
+          const attribute = relationalStatusCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12520,7 +12520,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.id.codec)}`;
             }
           });
         }
@@ -12543,7 +12543,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.description.codec)}`;
             }
           });
         }
@@ -12566,7 +12566,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.note.codec)}`;
             }
           });
         }
@@ -12589,7 +12589,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.type.codec)}`;
             }
           });
         }
@@ -12612,7 +12612,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.constructor.codec)}`;
             }
           });
         }
@@ -12646,7 +12646,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_yield_yield.attributes[attributeName];
+          const attribute = yieldCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12662,7 +12662,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_yield_yield.attributes[attributeName];
+          const attribute = yieldCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12794,7 +12794,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.id.codec)}`;
             }
           });
         }
@@ -12817,7 +12817,7 @@ export const plans = {
             type: "attribute",
             attribute: "crop",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.crop.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.crop.codec)}`;
             }
           });
         }
@@ -12840,7 +12840,7 @@ export const plans = {
             type: "attribute",
             attribute: "export",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.export.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.export.codec)}`;
             }
           });
         }
@@ -12874,7 +12874,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12890,7 +12890,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -13056,7 +13056,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -13079,7 +13079,7 @@ export const plans = {
             type: "attribute",
             attribute: "null",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.null.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.null.codec)}`;
             }
           });
         }
@@ -13102,7 +13102,7 @@ export const plans = {
             type: "attribute",
             attribute: "case",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.case.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.case.codec)}`;
             }
           });
         }
@@ -13125,7 +13125,7 @@ export const plans = {
             type: "attribute",
             attribute: "do",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.do.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.do.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -57,8 +57,8 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -70,7 +70,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -131,16 +131,63 @@ const extensions2 = {
   })
 };
 const parts2 = ["b", "updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts2);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent2,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
+  role: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  exp: {
+    description: undefined,
+    codec: TYPES.bigint,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  a: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  b: {
+    description: undefined,
+    codec: TYPES.numeric,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  c: {
+    description: undefined,
+    codec: TYPES.bigint,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const extensions3 = {
   isTableLike: false,
   pg: {
@@ -153,63 +200,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["b", "jwt_token"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts3);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent3,
-  attributes: Object.assign(Object.create(null), {
-    role: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    exp: {
-      description: undefined,
-      codec: TYPES.bigint,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    a: {
-      description: undefined,
-      codec: TYPES.int,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    b: {
-      description: undefined,
-      codec: TYPES.numeric,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    c: {
-      description: undefined,
-      codec: TYPES.bigint,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions4 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -217,16 +218,16 @@ const extensions4 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions4,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes2 = Object.assign(Object.create(null), {
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -252,7 +253,7 @@ const attributes2 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
+const extensions4 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -264,17 +265,17 @@ const extensions5 = {
   })
 };
 const parts4 = ["b", "auth_payload"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts4);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent4,
-  attributes: attributes2,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions6 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -283,16 +284,15 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts5 = ["b", "color"];
-const sqlIdent5 = sql.identifier(...parts5);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent5,
+  identifier: sql.identifier(...parts5),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions6
+  extensions: extensions5
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions7 = {
+const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -301,16 +301,16 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts6 = ["b", "enum_caps"];
-const sqlIdent6 = sql.identifier(...parts6);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts6);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent6,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions7
+  extensions: extensions6
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions8 = {
+const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -319,15 +319,15 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts7 = ["b", "enum_with_empty_string"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts7);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent7,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions8
+  extensions: extensions7
 });
-const attributes3 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -348,7 +348,7 @@ const attributes3 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -366,7 +366,7 @@ const attributes3 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -375,7 +375,7 @@ const attributes3 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -401,7 +401,7 @@ const attributes3 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
+const extensions8 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -411,17 +411,17 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "compound_type"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts8);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent8,
-  attributes: attributes3,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions9,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundType_compoundType = recordCodec(spec_compoundType);
-const extensions10 = {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -429,13 +429,13 @@ const extensions10 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions10,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions11 = {
+const extensions9 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -444,13 +444,13 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "an_int"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent9, {
+const anIntIdentifier = sql.identifier(...parts9);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   notNull: false
 });
-const extensions12 = {
+const extensions10 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -459,13 +459,13 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "another_int"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent10, {
+const anotherIntIdentifier = sql.identifier(...parts10);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   notNull: false
 });
-const extensions13 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -473,13 +473,13 @@ const extensions13 = {
   },
   tags: Object.create(null)
 };
-const attributes_text_array_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions13,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions14 = {
+const extensions11 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -488,12 +488,12 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts11 = ["pg_catalog", "numrange"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent11, {
+const sqlIdent4 = sql.identifier(...parts11);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent4, {
   description: "range of numerics",
-  extensions: extensions14
+  extensions: extensions11
 });
-const extensions15 = {
+const extensions12 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -502,12 +502,12 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts12 = ["pg_catalog", "daterange"];
-const sqlIdent12 = sql.identifier(...parts12);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent12, {
+const sqlIdent5 = sql.identifier(...parts12);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent5, {
   description: "range of dates",
-  extensions: extensions15
+  extensions: extensions12
 });
-const extensions16 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -516,12 +516,12 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_int_range"];
-const sqlIdent13 = sql.identifier(...parts13);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent13, {
+const sqlIdent6 = sql.identifier(...parts13);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent6, {
   description: undefined,
-  extensions: extensions16
+  extensions: extensions13
 });
-const extensions17 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -529,16 +529,16 @@ const extensions17 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions17,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes5 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: registryConfig_pgCodecs_compoundType_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -547,7 +547,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: registryConfig_pgCodecs_compoundType_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -564,7 +564,7 @@ const attributes5 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -574,17 +574,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts14 = ["b", "nested_compound_type"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts14);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent14,
-  attributes: attributes5,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions19 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions15 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -593,13 +593,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts15 = ["c", "text_array_domain"];
-const sqlIdent15 = sql.identifier(...parts15);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_text_array_codec_textArray, "textArrayDomain", sqlIdent15, {
+const textArrayDomainIdentifier = sql.identifier(...parts15);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions15,
   notNull: false
 });
-const extensions20 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -607,7 +607,7 @@ const extensions20 = {
   },
   tags: Object.create(null)
 };
-const extensions21 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -615,20 +615,20 @@ const extensions21 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions21,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts16 = ["c", "int8_array_domain"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent16, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts16);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions16,
   notNull: false
 });
-const extensions22 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -636,13 +636,13 @@ const extensions22 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions22,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -654,8 +654,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes4 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -721,7 +721,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -730,7 +730,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -739,7 +739,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -748,7 +748,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -757,7 +757,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_text_array_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -784,7 +784,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -793,7 +793,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -802,7 +802,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -811,7 +811,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -874,7 +874,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -892,7 +892,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: registryConfig_pgCodecs_compoundType_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -901,7 +901,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -910,7 +910,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: registryConfig_pgCodecs_compoundType_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -919,7 +919,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1045,7 +1045,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1054,7 +1054,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1072,7 +1072,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1081,7 +1081,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1090,7 +1090,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1098,7 +1098,7 @@ const attributes4 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions23 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1110,17 +1110,17 @@ const extensions23 = {
   })
 };
 const parts17 = ["b", "types"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts17);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent17,
-  attributes: attributes4,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions23,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions24 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1128,7 +1128,7 @@ const extensions24 = {
   },
   tags: Object.create(null)
 };
-const extensions25 = {
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1136,7 +1136,7 @@ const extensions25 = {
   },
   tags: Object.create(null)
 };
-const extensions26 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1144,7 +1144,7 @@ const extensions26 = {
   },
   tags: Object.create(null)
 };
-const extensions27 = {
+const extensions18 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1153,16 +1153,16 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "not_null_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const registryConfig_pgCodecs_notNullUrl_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent18, {
+const notNullUrlIdentifier = sql.identifier(...parts18);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions18,
   notNull: true
 });
-const attributes6 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: registryConfig_pgCodecs_notNullUrl_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1170,7 +1170,7 @@ const attributes6 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions19 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1180,16 +1180,16 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts19 = ["b", "wrapped_url"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts19);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent19,
-  attributes: attributes6,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const extensions29 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1200,8 +1200,8 @@ const extensions29 = {
   }
 };
 const parts20 = ["b", "mult_1"];
-const sqlIdent20 = sql.identifier(...parts20);
-const extensions30 = {
+const sqlIdent7 = sql.identifier(...parts20);
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1212,8 +1212,8 @@ const extensions30 = {
   }
 };
 const parts21 = ["b", "mult_2"];
-const sqlIdent21 = sql.identifier(...parts21);
-const fromCallback2 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+const sqlIdent8 = sql.identifier(...parts21);
+const fromCallback2 = (...args) => sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: null,
   required: true,
@@ -1225,7 +1225,7 @@ const parameters2 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions31 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1236,8 +1236,8 @@ const extensions31 = {
   }
 };
 const parts22 = ["b", "mult_3"];
-const sqlIdent22 = sql.identifier(...parts22);
-const fromCallback3 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+const sqlIdent9 = sql.identifier(...parts22);
+const fromCallback3 = (...args) => sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
 const parameters3 = [{
   name: null,
   required: true,
@@ -1249,7 +1249,7 @@ const parameters3 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions32 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1260,8 +1260,8 @@ const extensions32 = {
   }
 };
 const parts23 = ["b", "mult_4"];
-const sqlIdent23 = sql.identifier(...parts23);
-const fromCallback4 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts23);
+const fromCallback4 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters4 = [{
   name: null,
   required: true,
@@ -1273,7 +1273,7 @@ const parameters4 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions33 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1284,15 +1284,15 @@ const extensions33 = {
   }
 };
 const parts24 = ["b", "guid_fn"];
-const sqlIdent24 = sql.identifier(...parts24);
-const fromCallback5 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts24);
+const fromCallback5 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters5 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions34 = {
+const extensions25 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -1305,12 +1305,12 @@ const extensions34 = {
   }
 };
 const parts25 = ["b", "authenticate_fail"];
-const sqlIdent25 = sql.identifier(...parts25);
+const sqlIdent12 = sql.identifier(...parts25);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -1328,7 +1328,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions35 = {
+const extensions26 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -1344,20 +1344,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques2,
   isVirtual: true,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions26
 };
 const parts26 = ["b", "authenticate"];
-const sqlIdent26 = sql.identifier(...parts26);
+const sqlIdent13 = sql.identifier(...parts26);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -1390,7 +1390,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions36 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1401,13 +1401,13 @@ const extensions36 = {
   }
 };
 const parts27 = ["b", "list_bde_mutation"];
-const sqlIdent27 = sql.identifier(...parts27);
-const fromCallback6 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts27);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: attributes_text_array_codec_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -1420,12 +1420,12 @@ const parameters6 = [{
   codec: TYPES.text
 }];
 const parts28 = ["b", "authenticate_many"];
-const sqlIdent28 = sql.identifier(...parts28);
+const sqlIdent15 = sql.identifier(...parts28);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -1459,12 +1459,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts29 = ["b", "authenticate_payload"];
-const sqlIdent29 = sql.identifier(...parts29);
+const sqlIdent16 = sql.identifier(...parts29);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -1497,7 +1497,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions37 = {
+const extensions28 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -1514,26 +1514,26 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques3,
   isVirtual: true,
   description: undefined,
-  extensions: extensions37
+  extensions: extensions28
 };
 const parts30 = ["b", "compound_type_mutation"];
-const sqlIdent30 = sql.identifier(...parts30);
+const sqlIdent17 = sql.identifier(...parts30);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_compoundType_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -1551,22 +1551,22 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: registryConfig_pgCodecs_compoundType_compoundType,
+  codec: compoundTypeCodec,
   executor: executor_mainPgExecutor
 };
 const parts31 = ["b", "compound_type_query"];
-const sqlIdent31 = sql.identifier(...parts31);
+const sqlIdent18 = sql.identifier(...parts31);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_compoundType_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -1584,22 +1584,22 @@ const options_compound_type_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: registryConfig_pgCodecs_compoundType_compoundType,
+  codec: compoundTypeCodec,
   executor: executor_mainPgExecutor
 };
 const parts32 = ["b", "compound_type_set_mutation"];
-const sqlIdent32 = sql.identifier(...parts32);
+const sqlIdent19 = sql.identifier(...parts32);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_compoundType_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -1617,22 +1617,22 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const resourceConfig3 = {
-  codec: registryConfig_pgCodecs_compoundType_compoundType,
+  codec: compoundTypeCodec,
   executor: executor_mainPgExecutor
 };
 const parts33 = ["b", "compound_type_array_mutation"];
-const sqlIdent33 = sql.identifier(...parts33);
+const sqlIdent20 = sql.identifier(...parts33);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_compoundType_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -1650,22 +1650,22 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_compoundType_compoundType,
+  codec: compoundTypeCodec,
   executor: executor_mainPgExecutor
 };
 const parts34 = ["b", "compound_type_array_query"];
-const sqlIdent34 = sql.identifier(...parts34);
+const sqlIdent21 = sql.identifier(...parts34);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_compoundType_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -1683,10 +1683,10 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_compoundType_compoundType,
+  codec: compoundTypeCodec,
   executor: executor_mainPgExecutor
 };
-const extensions38 = {
+const extensions29 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -1694,7 +1694,7 @@ const extensions38 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions23.tags.foreignKey
+    foreignKey: extensions17.tags.foreignKey
   }
 };
 const uniques4 = [{
@@ -1709,20 +1709,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 };
 const parts35 = ["b", "type_function_connection"];
-const sqlIdent35 = sql.identifier(...parts35);
+const sqlIdent22 = sql.identifier(...parts35);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -1741,12 +1741,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts36 = ["b", "type_function_connection_mutation"];
-const sqlIdent36 = sql.identifier(...parts36);
+const sqlIdent23 = sql.identifier(...parts36);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -1765,12 +1765,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts37 = ["b", "type_function"];
-const sqlIdent37 = sql.identifier(...parts37);
+const sqlIdent24 = sql.identifier(...parts37);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -1794,12 +1794,12 @@ const options_type_function = {
   description: undefined
 };
 const parts38 = ["b", "type_function_mutation"];
-const sqlIdent38 = sql.identifier(...parts38);
+const sqlIdent25 = sql.identifier(...parts38);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -1823,12 +1823,12 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts39 = ["b", "type_function_list"];
-const sqlIdent39 = sql.identifier(...parts39);
+const sqlIdent26 = sql.identifier(...parts39);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -1847,12 +1847,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts40 = ["b", "type_function_list_mutation"];
-const sqlIdent40 = sql.identifier(...parts40);
+const sqlIdent27 = sql.identifier(...parts40);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -1873,41 +1873,41 @@ const options_type_function_list_mutation = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
+    updatableView: updatableViewCodec,
     text: TYPES.text,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     bool: TYPES.boolean,
-    compoundType: registryConfig_pgCodecs_compoundType_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     interval: TYPES.interval,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int2: TYPES.int2,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    textArray: attributes_text_array_codec_textArray,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    textArray: textArrayCodec,
     json: TYPES.json,
     jsonb: TYPES.jsonb,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     timestamp: TYPES.timestamp,
     timestamptz: TYPES.timestamptz,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -1920,34 +1920,34 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions24,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    compoundTypeArray: listOfCodec(registryConfig_pgCodecs_compoundType_compoundType, {
-      extensions: extensions25,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions26,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    notNullUrl: registryConfig_pgCodecs_notNullUrl_notNullUrl,
-    int8Array: innerCodec_int8Array,
-    wrappedUrl: recordCodec(spec_wrappedUrl)
+    notNullUrl: notNullUrlCodec,
+    int8Array: int8ArrayCodec,
+    wrappedUrl: recordCodec(wrappedUrlCodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     mult_1: {
@@ -1955,7 +1955,7 @@ const registry = makeRegistry({
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent7}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -1972,7 +1972,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions29,
+      extensions: extensions20,
       description: undefined
     },
     mult_2: {
@@ -1985,7 +1985,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions30,
+      extensions: extensions21,
       description: undefined
     },
     mult_3: {
@@ -1998,7 +1998,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions31,
+      extensions: extensions22,
       description: undefined
     },
     mult_4: {
@@ -2011,7 +2011,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions32,
+      extensions: extensions23,
       description: undefined
     },
     guid_fn: {
@@ -2021,18 +2021,18 @@ const registry = makeRegistry({
       from: fromCallback5,
       parameters: parameters5,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions33,
+      extensions: extensions24,
       description: undefined
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
         attributes: ["x"],
@@ -2045,7 +2045,7 @@ const registry = makeRegistry({
       }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions34
+      extensions: extensions25
     },
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
     authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
@@ -2056,10 +2056,10 @@ const registry = makeRegistry({
       from: fromCallback6,
       parameters: parameters6,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: extensions27,
       description: undefined
     },
     authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
@@ -2105,7 +2105,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
 const argDetailsSimple = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: registryConfig_pgCodecs_compoundType_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -2157,7 +2157,7 @@ const resource_compound_type_queryPgResource = registry.pgResources["compound_ty
 const argDetailsSimple2 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: registryConfig_pgCodecs_compoundType_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -2741,7 +2741,7 @@ function Mutation_mult4_input_applyPlan(_, $object) {
 const argDetailsSimple10 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -2912,7 +2912,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple13 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: attributes_text_array_codec_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -3113,7 +3113,7 @@ function Mutation_authenticatePayload_input_applyPlan(_, $object) {
 const argDetailsSimple16 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: registryConfig_pgCodecs_compoundType_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -3168,7 +3168,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple17 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: registryConfig_pgCodecs_compoundType_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -3223,7 +3223,7 @@ function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
 const argDetailsSimple18 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: registryConfig_pgCodecs_compoundType_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -6113,7 +6113,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -6136,7 +6136,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -6159,7 +6159,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -6182,7 +6182,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -6198,7 +6198,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6214,7 +6214,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7502,7 +7502,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -7525,7 +7525,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -7548,7 +7548,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -7571,7 +7571,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -7594,7 +7594,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -7617,7 +7617,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -7640,7 +7640,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -7663,7 +7663,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -7686,7 +7686,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -7709,7 +7709,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -7732,7 +7732,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -7755,7 +7755,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -7778,7 +7778,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -7801,7 +7801,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -7824,7 +7824,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -7847,7 +7847,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -7870,7 +7870,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -7893,7 +7893,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -7916,7 +7916,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -7939,7 +7939,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -7962,7 +7962,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -7985,7 +7985,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -8008,7 +8008,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -8031,7 +8031,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -8054,7 +8054,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -8077,7 +8077,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -8100,7 +8100,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -8123,7 +8123,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -8146,7 +8146,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -8169,7 +8169,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -8192,7 +8192,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -8215,7 +8215,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -8238,7 +8238,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -8261,7 +8261,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -8284,7 +8284,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -8307,7 +8307,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -8330,7 +8330,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -8353,7 +8353,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -8376,7 +8376,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -8399,7 +8399,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -8422,7 +8422,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -8445,7 +8445,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -8468,7 +8468,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -8491,7 +8491,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -8514,7 +8514,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -8537,7 +8537,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -8560,7 +8560,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -100,7 +100,7 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -127,7 +127,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -191,7 +191,7 @@ const jwtTokenCodec = recordCodec({
       behavior: ["-table", "jwt"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -250,7 +250,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -381,7 +381,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
@@ -521,7 +521,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1046,7 +1046,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions17,
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
@@ -1060,14 +1060,14 @@ const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifie
   },
   notNull: true
 });
-const sqlIdent7 = sql.identifier("b", "mult_1");
-const sqlIdent8 = sql.identifier("b", "mult_2");
-const sqlIdent9 = sql.identifier("b", "mult_3");
-const sqlIdent10 = sql.identifier("b", "mult_4");
-const sqlIdent11 = sql.identifier("b", "guid_fn");
-const sqlIdent12 = sql.identifier("b", "authenticate_fail");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -1087,16 +1087,16 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent13 = sql.identifier("b", "authenticate");
-const sqlIdent14 = sql.identifier("b", "list_bde_mutation");
-const sqlIdent15 = sql.identifier("b", "authenticate_many");
-const sqlIdent16 = sql.identifier("b", "authenticate_payload");
-const sqlIdent17 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent18 = sql.identifier("b", "compound_type_query");
-const sqlIdent19 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent20 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent21 = sql.identifier("b", "compound_type_array_query");
-const uniques4 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -1105,12 +1105,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques4,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -1125,12 +1125,12 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent22 = sql.identifier("b", "type_function_connection");
-const sqlIdent23 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent24 = sql.identifier("b", "type_function");
-const sqlIdent25 = sql.identifier("b", "type_function_mutation");
-const sqlIdent26 = sql.identifier("b", "type_function_list");
-const sqlIdent27 = sql.identifier("b", "type_function_list_mutation");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -1253,16 +1253,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent7}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -1292,11 +1292,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -1326,11 +1326,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -1360,11 +1360,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -1394,11 +1394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -1423,7 +1423,7 @@ const registry = makeRegistry({
       description: undefined
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -1457,7 +1457,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -1479,7 +1479,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -1513,11 +1513,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -1555,7 +1555,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -1589,7 +1589,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -1613,7 +1613,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -1648,12 +1648,12 @@ const registry = makeRegistry({
     }),
     compound_type_mutation: PgResource.functionResourceOptions({
       codec: compoundTypeCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -1678,12 +1678,12 @@ const registry = makeRegistry({
     }),
     compound_type_query: PgResource.functionResourceOptions({
       codec: compoundTypeCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -1708,12 +1708,12 @@ const registry = makeRegistry({
     }),
     compound_type_set_mutation: PgResource.functionResourceOptions({
       codec: compoundTypeCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -1738,12 +1738,12 @@ const registry = makeRegistry({
     }),
     compound_type_array_mutation: PgResource.functionResourceOptions({
       codec: compoundTypeCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -1768,12 +1768,12 @@ const registry = makeRegistry({
     }),
     compound_type_array_query: PgResource.functionResourceOptions({
       codec: compoundTypeCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -1801,7 +1801,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -1823,7 +1823,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -1845,7 +1845,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -1872,7 +1872,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -1899,7 +1899,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -1921,7 +1921,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -5748,7 +5748,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5764,7 +5764,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -8919,7 +8919,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -9048,7 +9048,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -9451,7 +9451,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -9872,7 +9872,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -4,9 +4,6 @@ import { valueFromASTUntyped } from "graphql";
 import jsonwebtoken from "jsonwebtoken";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -31,34 +28,29 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -118,526 +110,465 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts2 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts2);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions3 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.assign(Object.create(null), {
-    behavior: ["-table", "jwt"]
-  })
-};
-const parts3 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts3);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions3,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.assign(Object.create(null), {
+      behavior: ["-table", "jwt"]
+    })
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions4 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts4 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts4);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions4,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions5 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts5 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts5),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions5
-});
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions6 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts6);
-const enumCapsCodec = enumCodec({
-  name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
-  description: undefined,
-  extensions: extensions6
-});
-const enumLabels3 = ["", "one", "two"];
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts7);
-const enumWithEmptyStringCodec = enumCodec({
-  name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
-  description: undefined,
-  extensions: extensions7
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts8);
-const compoundTypeCodecSpec = {
+const enumCapsCodec = enumCodec({
+  name: "enumCaps",
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
+});
+const enumWithEmptyStringCodec = enumCodec({
+  name: "enumWithEmptyString",
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
+  }
+});
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts9);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts10);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["pg_catalog", "numrange"];
-const sqlIdent4 = sql.identifier(...parts11);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent4, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions11
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions12 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["pg_catalog", "daterange"];
-const sqlIdent5 = sql.identifier(...parts12);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent5, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions12
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_int_range"];
-const sqlIdent6 = sql.identifier(...parts13);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent6, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts14);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions15 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts15 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts15);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts16 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts16);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1109,594 +1040,62 @@ const extensions17 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts17 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts17);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const extensions18 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts18);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
-  description: undefined,
-  extensions: extensions18,
-  notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions19 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts19);
-const wrappedUrlCodecSpec = {
-  name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts20 = ["b", "mult_1"];
-const sqlIdent7 = sql.identifier(...parts20);
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts21 = ["b", "mult_2"];
-const sqlIdent8 = sql.identifier(...parts21);
-const fromCallback2 = (...args) => sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts22 = ["b", "mult_3"];
-const sqlIdent9 = sql.identifier(...parts22);
-const fromCallback3 = (...args) => sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
-const parameters3 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts23 = ["b", "mult_4"];
-const sqlIdent10 = sql.identifier(...parts23);
-const fromCallback4 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters4 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts24 = ["b", "guid_fn"];
-const sqlIdent11 = sql.identifier(...parts24);
-const fromCallback5 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters5 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions25 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const parts25 = ["b", "authenticate_fail"];
-const sqlIdent12 = sql.identifier(...parts25);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate_fail"
+      name: "not_null_url"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions26 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques2 = [];
+  notNull: true
+});
+const sqlIdent7 = sql.identifier("b", "mult_1");
+const sqlIdent8 = sql.identifier("b", "mult_2");
+const sqlIdent9 = sql.identifier("b", "mult_3");
+const sqlIdent10 = sql.identifier("b", "mult_4");
+const sqlIdent11 = sql.identifier("b", "guid_fn");
+const sqlIdent12 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques2,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions26
-};
-const parts26 = ["b", "authenticate"];
-const sqlIdent13 = sql.identifier(...parts26);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
   }
 };
-const parts27 = ["b", "list_bde_mutation"];
-const sqlIdent14 = sql.identifier(...parts27);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts28 = ["b", "authenticate_many"];
-const sqlIdent15 = sql.identifier(...parts28);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts29 = ["b", "authenticate_payload"];
-const sqlIdent16 = sql.identifier(...parts29);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions28 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques3 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques3,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions28
-};
-const parts30 = ["b", "compound_type_mutation"];
-const sqlIdent17 = sql.identifier(...parts30);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: compoundTypeCodec,
-  executor: executor_mainPgExecutor
-};
-const parts31 = ["b", "compound_type_query"];
-const sqlIdent18 = sql.identifier(...parts31);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: compoundTypeCodec,
-  executor: executor_mainPgExecutor
-};
-const parts32 = ["b", "compound_type_set_mutation"];
-const sqlIdent19 = sql.identifier(...parts32);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig3 = {
-  codec: compoundTypeCodec,
-  executor: executor_mainPgExecutor
-};
-const parts33 = ["b", "compound_type_array_mutation"];
-const sqlIdent20 = sql.identifier(...parts33);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: compoundTypeCodec,
-  executor: executor_mainPgExecutor
-};
-const parts34 = ["b", "compound_type_array_query"];
-const sqlIdent21 = sql.identifier(...parts34);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: compoundTypeCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions29 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions17.tags.foreignKey
-  }
-};
+const sqlIdent13 = sql.identifier("b", "authenticate");
+const sqlIdent14 = sql.identifier("b", "list_bde_mutation");
+const sqlIdent15 = sql.identifier("b", "authenticate_many");
+const sqlIdent16 = sql.identifier("b", "authenticate_payload");
+const sqlIdent17 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent18 = sql.identifier("b", "compound_type_query");
+const sqlIdent19 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent20 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent21 = sql.identifier("b", "compound_type_array_query");
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -1714,162 +1113,24 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions29
-};
-const parts35 = ["b", "type_function_connection"];
-const sqlIdent22 = sql.identifier(...parts35);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions17.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts36 = ["b", "type_function_connection_mutation"];
-const sqlIdent23 = sql.identifier(...parts36);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts37 = ["b", "type_function"];
-const sqlIdent24 = sql.identifier(...parts37);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts38 = ["b", "type_function_mutation"];
-const sqlIdent25 = sql.identifier(...parts38);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts39 = ["b", "type_function_list"];
-const sqlIdent26 = sql.identifier(...parts39);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts40 = ["b", "type_function_list_mutation"];
-const sqlIdent27 = sql.identifier(...parts40);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent22 = sql.identifier("b", "type_function_connection");
+const sqlIdent23 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent24 = sql.identifier("b", "type_function");
+const sqlIdent25 = sql.identifier("b", "type_function_mutation");
+const sqlIdent26 = sql.identifier("b", "type_function_list");
+const sqlIdent27 = sql.identifier("b", "type_function_list_mutation");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -1928,26 +1189,72 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
     notNullUrl: notNullUrlCodec,
     int8Array: int8ArrayCodec,
-    wrappedUrl: recordCodec(wrappedUrlCodecSpec)
+    wrappedUrl: recordCodec({
+      name: "wrappedUrl",
+      identifier: sql.identifier("b", "wrapped_url"),
+      attributes: Object.assign(Object.create(null), {
+        url: {
+          description: undefined,
+          codec: notNullUrlCodec,
+          notNull: true,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "wrapped_url"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     mult_1: {
@@ -1972,59 +1279,147 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions20,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent8}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions21,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions22,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions23,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions24,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     updatable_view: {
@@ -2045,37 +1440,505 @@ const registry = makeRegistry({
       }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions25
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions27,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig2, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig3, options_compound_type_set_mutation),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig4, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig5, options_compound_type_array_query),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions({
+      codec: compoundTypeCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions({
+      codec: compoundTypeCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions({
+      codec: compoundTypeCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions({
+      codec: compoundTypeCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions({
+      codec: compoundTypeCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.create(null)
 });
@@ -2256,25 +2119,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnectionPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -2400,21 +2244,6 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -2433,67 +2262,8 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -2552,9 +2322,6 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple7 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -2613,9 +2380,6 @@ const makeArgs7 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -2674,9 +2438,6 @@ const makeArgs8 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple9 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -2735,9 +2496,6 @@ const makeArgs9 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -2790,9 +2548,6 @@ const makeArgs10 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple11 = [];
 const makeArgs11 = (args, path = []) => {
   const selectArgs = [];
@@ -2839,9 +2594,6 @@ const makeArgs11 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple12 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -2906,9 +2658,6 @@ const makeArgs12 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple13 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -2973,9 +2722,6 @@ const makeArgs13 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple14 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -3040,9 +2786,6 @@ const makeArgs14 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple15 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -3107,9 +2850,6 @@ const makeArgs15 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -3162,9 +2902,6 @@ const makeArgs16 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple17 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -3217,9 +2954,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple18 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -3272,9 +3006,6 @@ const makeArgs18 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -3321,9 +3052,6 @@ const makeArgs19 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple20 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -3376,9 +3104,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple21 = [];
 const makeArgs21 = (args, path = []) => {
   const selectArgs = [];
@@ -3425,258 +3150,19 @@ const makeArgs21 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function JwtTokenPlan($in) {
-  const $record = $in;
-  return $record.record();
-}
 const attributeNames = ["role", "exp", "a", "b", "c"];
 function JwtTokenParseValue(value) {
   return value;
 }
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -5381,7 +4867,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -5423,27 +4911,40 @@ export const plans = {
       }
     },
     typeFunctionConnection: {
-      plan: Query_typeFunctionConnectionPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -5476,23 +4977,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5519,23 +5030,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5753,12 +5274,24 @@ export const plans = {
   AnIntRangeBound: {},
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   CompoundType: {
     __assertStep: assertPgClassSingleStep,
@@ -5896,9 +5429,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5914,8 +5454,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5925,9 +5469,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -8633,7 +8184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8648,7 +8201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8663,7 +8218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8678,7 +8235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8693,7 +8252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8708,7 +8269,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8723,7 +8286,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8738,7 +8303,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8753,7 +8320,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8768,7 +8337,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8783,7 +8354,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8798,7 +8371,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8813,7 +8388,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8828,7 +8405,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8843,7 +8422,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8858,7 +8439,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8873,7 +8456,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8888,7 +8473,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8902,7 +8489,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8918,7 +8507,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8932,7 +8523,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -8948,22 +8541,30 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -8971,15 +8572,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -8987,15 +8594,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -9003,15 +8616,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -9019,26 +8638,36 @@ export const plans = {
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     serialize(value) {
@@ -9063,25 +8692,36 @@ export const plans = {
     parseLiteral(node, variables) {
       return JwtTokenParseValue(valueFromASTUntyped(node, variables));
     },
-    plan: JwtTokenPlan
+    plan($in) {
+      const $record = $in;
+      return $record.record();
+    }
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -9090,15 +8730,21 @@ export const plans = {
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -9107,15 +8753,21 @@ export const plans = {
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -9124,11 +8776,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthPayload: {
     __assertStep: assertPgClassSingleStep,
@@ -9150,7 +8806,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -9159,70 +8817,98 @@ export const plans = {
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9257,38 +8943,57 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -9324,9 +9029,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9361,11 +9072,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -9716,9 +9432,15 @@ export const plans = {
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9753,11 +9475,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -10107,23 +9834,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -10158,13 +9896,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -103,10 +103,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_network = {
+const networkIdentifier = sql.identifier(...["network_types", "network"]);
+const networkCodecSpec = {
   name: "network",
-  identifier: sql.identifier(...["network_types", "network"]),
-  attributes,
+  identifier: networkIdentifier,
+  attributes: networkAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -119,7 +120,7 @@ const spec_network = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_network_network = recordCodec(spec_network);
+const networkCodec = recordCodec(networkCodecSpec);
 const extensions2 = {
   description: undefined,
   pg: {
@@ -144,7 +145,7 @@ const pgResource_networkPgResource = makeRegistry({
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
     inet: TYPES.inet,
-    network: registryConfig_pgCodecs_network_network,
+    network: networkCodec,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr
   }),
@@ -153,8 +154,8 @@ const pgResource_networkPgResource = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "network",
       identifier: "main.network_types.network",
-      from: registryConfig_pgCodecs_network_network.sqlType,
-      codec: registryConfig_pgCodecs_network_network,
+      from: networkCodec.sqlType,
+      codec: networkCodec,
       uniques,
       isVirtual: false,
       description: undefined,
@@ -831,7 +832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -847,7 +848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1013,7 +1014,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
             }
           });
         }
@@ -1036,7 +1037,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
             }
           });
         }
@@ -1059,7 +1060,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
             }
           });
         }
@@ -1082,7 +1083,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const networkAttributes = Object.assign(Object.create(null), {
@@ -103,10 +96,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const networkIdentifier = sql.identifier(...["network_types", "network"]);
-const networkCodecSpec = {
+const networkCodec = recordCodec({
   name: "network",
-  identifier: networkIdentifier,
+  identifier: sql.identifier("network_types", "network"),
   attributes: networkAttributes,
   description: undefined,
   extensions: {
@@ -119,17 +111,7 @@ const networkCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const networkCodec = recordCodec(networkCodecSpec);
-const extensions2 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "network_types",
-    name: "network"
-  },
-  tags: {}
-};
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -159,7 +141,15 @@ const pgResource_networkPgResource = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions2
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "network_types",
+          name: "network"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -212,21 +202,6 @@ const fetcher = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Network);
-function Query_allNetworks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNetworks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNetworks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNetworks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNetworks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -245,99 +220,14 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function NetworksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NetworksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NetworksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Mutation_createNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_updateNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_deleteNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function CreateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNetworkInput_network_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function UpdateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkByIdInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function DeleteNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -701,7 +591,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -740,23 +632,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -798,9 +700,16 @@ export const plans = {
   },
   NetworksConnection: {
     __assertStep: ConnectionStep,
-    nodes: NetworksConnection_nodesPlan,
-    edges: NetworksConnection_edgesPlan,
-    pageInfo: NetworksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -816,8 +725,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1105,7 +1018,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1119,7 +1034,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1135,7 +1052,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1149,7 +1068,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1165,16 +1086,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateNetworkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNetworkPayload_clientMutationIdPlan,
-    network: CreateNetworkPayload_networkPlan,
-    query: CreateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1209,11 +1138,16 @@ export const plans = {
   },
   CreateNetworkInput: {
     clientMutationId: {
-      applyPlan: CreateNetworkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     network: {
-      applyPlan: CreateNetworkInput_network_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -1249,9 +1183,15 @@ export const plans = {
   },
   UpdateNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNetworkPayload_clientMutationIdPlan,
-    network: UpdateNetworkPayload_networkPlan,
-    query: UpdateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1286,11 +1226,16 @@ export const plans = {
   },
   UpdateNetworkInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NetworkPatch: {
@@ -1325,23 +1270,34 @@ export const plans = {
   },
   UpdateNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkByIdInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNetworkPayload_clientMutationIdPlan,
-    network: DeleteNetworkPayload_networkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNetworkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1376,13 +1332,17 @@ export const plans = {
   },
   DeleteNetworkInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -86,7 +86,7 @@ const networkAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -110,9 +110,9 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const networkUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -133,12 +133,12 @@ const pgResource_networkPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     network: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "network",
       identifier: "main.network_types.network",
       from: networkCodec.sqlType,
       codec: networkCodec,
-      uniques,
+      uniques: networkUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -744,7 +744,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -760,7 +760,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1114,7 +1114,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1202,7 +1202,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1308,7 +1308,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const networkAttributes = Object.assign(Object.create(null), {
@@ -103,10 +96,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const networkIdentifier = sql.identifier(...["network_types", "network"]);
-const networkCodecSpec = {
+const networkCodec = recordCodec({
   name: "network",
-  identifier: networkIdentifier,
+  identifier: sql.identifier("network_types", "network"),
   attributes: networkAttributes,
   description: undefined,
   extensions: {
@@ -119,17 +111,7 @@ const networkCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const networkCodec = recordCodec(networkCodecSpec);
-const extensions2 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "network_types",
-    name: "network"
-  },
-  tags: {}
-};
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -159,7 +141,15 @@ const pgResource_networkPgResource = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions2
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "network_types",
+          name: "network"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -212,21 +202,6 @@ const fetcher = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Network);
-function Query_allNetworks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNetworks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNetworks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNetworks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNetworks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -245,99 +220,14 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function NetworksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NetworksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NetworksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Mutation_createNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_updateNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_deleteNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function CreateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNetworkInput_network_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function UpdateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkByIdInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function DeleteNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -707,7 +597,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -746,23 +638,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -804,9 +706,16 @@ export const plans = {
   },
   NetworksConnection: {
     __assertStep: ConnectionStep,
-    nodes: NetworksConnection_nodesPlan,
-    edges: NetworksConnection_edgesPlan,
-    pageInfo: NetworksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -822,8 +731,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1111,7 +1024,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1125,7 +1040,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1141,7 +1058,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1155,7 +1074,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1171,16 +1092,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateNetworkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNetworkPayload_clientMutationIdPlan,
-    network: CreateNetworkPayload_networkPlan,
-    query: CreateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1215,11 +1144,16 @@ export const plans = {
   },
   CreateNetworkInput: {
     clientMutationId: {
-      applyPlan: CreateNetworkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     network: {
-      applyPlan: CreateNetworkInput_network_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -1255,9 +1189,15 @@ export const plans = {
   },
   UpdateNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNetworkPayload_clientMutationIdPlan,
-    network: UpdateNetworkPayload_networkPlan,
-    query: UpdateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1292,11 +1232,16 @@ export const plans = {
   },
   UpdateNetworkInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NetworkPatch: {
@@ -1331,23 +1276,34 @@ export const plans = {
   },
   UpdateNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkByIdInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNetworkPayload_clientMutationIdPlan,
-    network: DeleteNetworkPayload_networkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNetworkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -1382,13 +1338,17 @@ export const plans = {
   },
   DeleteNetworkInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -86,7 +86,7 @@ const networkAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -110,9 +110,9 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const networkUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -133,12 +133,12 @@ const pgResource_networkPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     network: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "network",
       identifier: "main.network_types.network",
       from: networkCodec.sqlType,
       codec: networkCodec,
-      uniques,
+      uniques: networkUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -750,7 +750,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -766,7 +766,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1120,7 +1120,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1208,7 +1208,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -1314,7 +1314,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -103,10 +103,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_network = {
+const networkIdentifier = sql.identifier(...["network_types", "network"]);
+const networkCodecSpec = {
   name: "network",
-  identifier: sql.identifier(...["network_types", "network"]),
-  attributes,
+  identifier: networkIdentifier,
+  attributes: networkAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -119,7 +120,7 @@ const spec_network = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_network_network = recordCodec(spec_network);
+const networkCodec = recordCodec(networkCodecSpec);
 const extensions2 = {
   description: undefined,
   pg: {
@@ -144,7 +145,7 @@ const pgResource_networkPgResource = makeRegistry({
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
     inet: TYPES.inet,
-    network: registryConfig_pgCodecs_network_network,
+    network: networkCodec,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr
   }),
@@ -153,8 +154,8 @@ const pgResource_networkPgResource = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "network",
       identifier: "main.network_types.network",
-      from: registryConfig_pgCodecs_network_network.sqlType,
-      codec: registryConfig_pgCodecs_network_network,
+      from: networkCodec.sqlType,
+      codec: networkCodec,
       uniques,
       isVirtual: false,
       description: undefined,
@@ -837,7 +838,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -853,7 +854,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1019,7 +1020,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
             }
           });
         }
@@ -1042,7 +1043,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
             }
           });
         }
@@ -1065,7 +1066,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
             }
           });
         }
@@ -1088,7 +1089,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -492,17 +493,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -541,17 +542,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -599,17 +600,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -648,17 +649,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -706,16 +707,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -725,13 +726,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -743,7 +744,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -761,16 +762,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -780,10 +781,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -798,10 +798,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -816,15 +816,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -845,7 +845,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -863,7 +863,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -872,7 +872,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -908,17 +908,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -929,7 +929,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -939,7 +939,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,7 +949,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -960,7 +960,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -970,7 +970,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,7 +980,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -989,7 +989,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -998,21 +998,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1020,7 +1020,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1040,7 +1040,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1050,23 +1050,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1105,7 +1105,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1114,7 +1114,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1122,7 +1122,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1132,17 +1132,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1153,7 +1153,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1161,7 +1161,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1171,7 +1171,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,7 +1181,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1202,7 +1202,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,7 +1212,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1233,7 +1233,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,7 +1243,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1251,13 +1251,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1266,13 +1266,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1281,16 +1281,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1298,7 +1298,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1308,17 +1308,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1341,7 +1341,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1359,7 +1359,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1368,7 +1368,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1423,7 +1423,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1433,20 +1433,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1464,7 +1464,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,7 +1474,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1485,7 +1485,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1493,7 +1493,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1503,7 +1503,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,7 +1513,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1524,7 +1524,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1532,7 +1532,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1542,7 +1542,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,7 +1552,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1563,7 +1563,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1571,7 +1571,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1581,7 +1581,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,7 +1591,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1602,7 +1602,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1610,7 +1610,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1620,7 +1620,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,7 +1630,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1641,7 +1641,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1649,7 +1649,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1659,7 +1659,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,7 +1669,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1677,13 +1677,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1692,13 +1692,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1707,13 +1707,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1722,12 +1722,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1736,12 +1736,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1750,12 +1750,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1763,16 +1763,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1781,7 +1781,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1798,7 +1798,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1808,17 +1808,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1827,13 +1827,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1841,7 +1841,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1849,20 +1849,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1870,13 +1870,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1888,8 +1888,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1955,7 +1955,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1964,7 +1964,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1973,7 +1973,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1982,7 +1982,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1991,7 +1991,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2018,7 +2018,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2027,7 +2027,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2036,7 +2036,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2045,7 +2045,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2108,7 +2108,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2126,7 +2126,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2135,7 +2135,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2144,7 +2144,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2153,7 +2153,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2279,7 +2279,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2288,7 +2288,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2306,7 +2306,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2315,7 +2315,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2324,7 +2324,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2332,7 +2332,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2344,17 +2344,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2362,7 +2362,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2370,13 +2370,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2385,12 +2385,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2401,8 +2401,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2414,10 +2414,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2429,10 +2429,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2443,10 +2443,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2458,10 +2458,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2473,10 +2473,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2487,10 +2487,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2501,10 +2501,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2515,10 +2515,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2530,15 +2530,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2550,15 +2550,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2570,15 +2570,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2590,15 +2590,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2609,15 +2609,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2628,15 +2628,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2647,15 +2647,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2666,15 +2666,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2685,15 +2685,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2704,15 +2704,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2724,8 +2724,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2737,7 +2737,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2748,10 +2748,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2762,10 +2762,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2776,10 +2776,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2791,8 +2791,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2804,7 +2804,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2815,10 +2815,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2829,10 +2829,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2843,10 +2843,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2857,10 +2857,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2871,15 +2871,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2890,8 +2890,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2908,7 +2908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2919,8 +2919,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2937,7 +2937,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2948,10 +2948,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2962,15 +2962,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2982,10 +2982,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3002,7 +3002,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3025,14 +3025,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3053,14 +3053,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3077,7 +3077,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3088,21 +3088,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3120,7 +3120,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3130,7 +3130,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3158,26 +3158,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3199,7 +3199,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3220,20 +3220,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3252,12 +3252,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3275,7 +3275,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3286,8 +3286,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3307,7 +3307,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3317,9 +3317,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3330,8 +3330,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3351,7 +3351,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3361,9 +3361,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3374,15 +3374,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3393,15 +3393,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3412,15 +3412,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3431,8 +3431,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3450,12 +3450,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3473,7 +3473,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3489,20 +3489,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3526,16 +3526,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3559,10 +3559,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3577,15 +3577,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3597,15 +3597,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3616,15 +3616,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3636,20 +3636,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3660,20 +3660,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3685,20 +3685,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3709,15 +3709,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3728,8 +3728,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3741,7 +3741,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3752,8 +3752,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3765,7 +3765,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3776,8 +3776,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3789,7 +3789,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3800,8 +3800,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3813,7 +3813,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3824,13 +3824,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3842,7 +3842,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3870,26 +3870,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3907,16 +3907,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3936,12 +3936,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3960,12 +3960,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3984,12 +3984,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4008,12 +4008,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4032,12 +4032,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4056,12 +4056,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4082,12 +4082,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4106,18 +4106,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4136,18 +4136,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4166,18 +4166,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4195,22 +4195,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4233,22 +4233,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4266,7 +4266,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4287,40 +4287,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4331,21 +4331,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4355,22 +4355,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4378,14 +4378,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4398,7 +4398,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4411,7 +4411,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4424,7 +4424,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4437,7 +4437,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4450,7 +4450,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4463,7 +4463,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4476,7 +4476,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4489,7 +4489,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4502,7 +4502,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4515,7 +4515,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4528,7 +4528,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4541,7 +4541,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4567,7 +4567,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4580,7 +4580,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4593,7 +4593,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4606,7 +4606,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4619,7 +4619,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4632,7 +4632,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4645,7 +4645,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4658,7 +4658,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4671,7 +4671,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4684,7 +4684,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4697,7 +4697,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4710,7 +4710,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4723,7 +4723,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4736,7 +4736,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4749,7 +4749,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4762,7 +4762,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4775,7 +4775,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4788,7 +4788,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4801,7 +4801,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4814,19 +4814,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4834,12 +4834,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4851,7 +4851,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4859,12 +4859,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4881,7 +4881,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4894,7 +4894,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4907,7 +4907,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4920,7 +4920,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4933,7 +4933,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4946,7 +4946,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4962,7 +4962,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4975,7 +4975,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4988,7 +4988,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5001,7 +5001,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5014,7 +5014,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5027,7 +5027,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5040,7 +5040,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5053,7 +5053,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5066,7 +5066,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5079,7 +5079,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5092,7 +5092,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5105,7 +5105,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5127,7 +5127,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5142,7 +5142,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5159,7 +5159,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5176,7 +5176,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5193,7 +5193,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5208,7 +5208,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5223,7 +5223,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5240,7 +5240,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6417,7 +6417,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6429,7 +6429,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7613,7 +7613,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -9365,7 +9365,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9536,7 +9536,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9548,7 +9548,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -15132,7 +15132,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15148,7 +15148,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15806,7 +15806,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15822,7 +15822,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15954,7 +15954,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -15977,7 +15977,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -16000,7 +16000,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -16335,7 +16335,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -16358,7 +16358,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -16381,7 +16381,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -16404,7 +16404,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -16427,7 +16427,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -16450,7 +16450,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -16473,7 +16473,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -16496,7 +16496,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -16519,7 +16519,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -16542,7 +16542,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -16565,7 +16565,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -16623,7 +16623,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16639,7 +16639,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16737,7 +16737,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -16760,7 +16760,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -16794,7 +16794,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16810,7 +16810,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16908,7 +16908,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -16931,7 +16931,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -16965,7 +16965,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16981,7 +16981,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17147,7 +17147,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -17170,7 +17170,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -17193,7 +17193,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -17216,7 +17216,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -17412,7 +17412,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -17435,7 +17435,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -17458,7 +17458,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -17492,7 +17492,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17508,7 +17508,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17674,7 +17674,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -17697,7 +17697,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -17720,7 +17720,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -17743,7 +17743,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -17777,7 +17777,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17793,7 +17793,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17891,7 +17891,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -17914,7 +17914,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,28 +462,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -532,26 +509,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -590,26 +563,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -639,26 +608,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -697,39 +662,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -752,194 +710,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -948,29 +886,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,198 +917,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1180,29 +1100,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1211,29 +1130,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,81 +1161,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1423,48 +1329,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1473,37 +1374,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1512,37 +1412,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1551,37 +1450,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1590,37 +1488,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1629,37 +1526,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,209 +1565,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1889,1111 +1755,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3002,17 +2281,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3030,16 +2298,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3058,16 +2327,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3077,68 +2345,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3163,51 +2371,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3225,632 +2399,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3875,400 +2456,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4363,7 +2574,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4385,436 +2603,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4826,7 +3537,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4839,290 +3558,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5545,25 +5235,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5764,21 +5435,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6037,21 +5693,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs12(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6200,21 +5841,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs15(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6283,21 +5909,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs16(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6344,12 +5955,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6644,21 +6249,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs22(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6831,21 +6421,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs25(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6896,21 +6471,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs26(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -7007,21 +6567,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -7072,21 +6617,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs29(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7155,21 +6685,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs30(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7244,127 +6759,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -7938,21 +7333,6 @@ const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -8033,21 +7413,6 @@ const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -8147,36 +7512,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -8224,173 +7559,9 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -8437,26 +7608,6 @@ const makeArgs46 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -8503,9 +7654,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8552,9 +7700,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8601,9 +7746,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8650,9 +7792,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8705,9 +7844,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8760,9 +7896,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8815,9 +7948,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8870,9 +8000,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8925,9 +8052,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8980,9 +8104,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9041,9 +8162,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -9090,9 +8208,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -9139,9 +8254,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -9188,9 +8300,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -9255,9 +8364,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -9304,9 +8410,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9359,9 +8462,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9414,9 +8514,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -9463,9 +8560,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9512,9 +8606,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9597,9 +8688,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9652,9 +8740,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9707,9 +8792,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9768,9 +8850,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9829,9 +8908,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -9878,9 +8954,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -9927,9 +9000,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -9976,261 +9046,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -13132,7 +11947,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -13246,27 +12063,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13296,23 +12126,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13356,23 +12196,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13393,23 +12243,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13424,23 +12284,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13452,11 +12322,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -13506,23 +12380,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13555,23 +12439,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13583,23 +12477,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13615,23 +12519,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13643,23 +12557,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13687,23 +12611,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -13777,23 +12711,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13820,23 +12764,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13863,23 +12817,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13906,23 +12870,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13949,23 +12923,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -13992,23 +12976,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14035,23 +13029,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14078,23 +13082,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14521,23 +13535,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14558,23 +13582,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -14710,23 +13744,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14756,23 +13800,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14940,12 +13994,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -15038,9 +14104,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -15056,8 +14129,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -15504,9 +14581,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -15757,9 +14841,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16043,9 +15134,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16061,9 +15159,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16088,9 +15193,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16136,9 +15248,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16163,9 +15282,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16237,9 +15363,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16279,9 +15412,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16600,9 +15740,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16771,9 +15918,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16942,9 +16096,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17227,9 +16388,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17469,9 +16637,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17754,9 +16929,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17936,7 +17118,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -17951,7 +17135,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -17966,7 +17152,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -17981,7 +17169,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -17996,7 +17186,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18011,7 +17203,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18026,7 +17220,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18041,7 +17237,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18056,7 +17254,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18071,7 +17271,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18086,7 +17288,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18101,7 +17305,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18116,7 +17322,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18131,7 +17339,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18146,7 +17356,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18161,7 +17373,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18176,7 +17390,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18191,7 +17407,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18206,7 +17424,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18221,7 +17441,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18236,7 +17458,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18251,7 +17475,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18266,7 +17492,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18281,7 +17509,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18296,7 +17526,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18311,7 +17543,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18326,7 +17560,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18341,168 +17577,236 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -18510,11 +17814,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18527,17 +17835,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18550,17 +17864,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18573,21 +17893,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -18596,11 +17924,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18616,17 +17948,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18639,18 +17977,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -18690,7 +18034,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -18727,11 +18073,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -18766,35 +18116,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -18806,11 +18170,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18829,33 +18197,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18883,7 +18263,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -18891,11 +18273,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -18923,7 +18309,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -18931,11 +18319,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -18970,35 +18362,49 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -478,7 +478,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -523,7 +523,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -577,7 +577,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -622,7 +622,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -676,7 +676,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -724,7 +724,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -855,7 +855,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -884,7 +884,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -914,7 +914,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -977,7 +977,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1061,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1098,7 +1098,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1128,7 +1128,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1158,7 +1158,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1222,7 +1222,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1343,7 +1343,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1372,7 +1372,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1410,7 +1410,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1448,7 +1448,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1486,7 +1486,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1524,7 +1524,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1562,7 +1562,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1690,7 +1690,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2213,7 +2213,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2239,41 +2239,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2281,7 +2281,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2290,12 +2290,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2310,7 +2310,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2319,12 +2319,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2337,7 +2337,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2345,9 +2345,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2363,12 +2363,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2381,8 +2381,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2391,12 +2391,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2409,30 +2409,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2448,12 +2448,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2466,20 +2466,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2592,11 +2592,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2616,11 +2616,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2641,11 +2641,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2666,11 +2666,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2690,11 +2690,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2715,11 +2715,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2740,11 +2740,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2764,11 +2764,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2788,11 +2788,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2812,11 +2812,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2842,11 +2842,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2872,11 +2872,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2902,11 +2902,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2932,11 +2932,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2961,11 +2961,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2990,11 +2990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3019,11 +3019,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3048,11 +3048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3077,11 +3077,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3106,11 +3106,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3141,11 +3141,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3165,11 +3165,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3189,11 +3189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3213,11 +3213,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3248,11 +3248,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3272,11 +3272,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3296,11 +3296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3320,11 +3320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3344,11 +3344,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3373,11 +3373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3412,11 +3412,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3451,11 +3451,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3475,11 +3475,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3504,11 +3504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3529,12 +3529,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3550,12 +3550,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3569,11 +3569,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3601,7 +3601,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3620,7 +3620,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3643,7 +3643,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3698,7 +3698,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3717,11 +3717,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3771,11 +3771,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3825,11 +3825,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3854,11 +3854,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3883,11 +3883,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3912,11 +3912,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3951,7 +3951,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3974,7 +3974,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3994,12 +3994,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4024,12 +4024,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4053,11 +4053,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4086,11 +4086,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4116,11 +4116,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4145,11 +4145,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4180,11 +4180,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4214,11 +4214,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4249,11 +4249,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4278,11 +4278,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4312,11 +4312,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4346,11 +4346,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4380,11 +4380,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4414,11 +4414,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4455,12 +4455,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4487,7 +4487,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4510,7 +4510,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4532,7 +4532,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4576,7 +4576,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4598,7 +4598,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4620,7 +4620,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4644,7 +4644,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4666,7 +4666,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4694,7 +4694,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4720,12 +4720,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4750,12 +4750,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4785,12 +4785,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -14208,7 +14208,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14224,7 +14224,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14896,7 +14896,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14912,7 +14912,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15769,7 +15769,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15785,7 +15785,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15947,7 +15947,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15963,7 +15963,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16125,7 +16125,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16141,7 +16141,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16666,7 +16666,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16682,7 +16682,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16958,7 +16958,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16974,7 +16974,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18005,7 +18005,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -18092,7 +18092,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -18338,7 +18338,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -322,7 +322,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -366,7 +366,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -495,11 +495,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -507,7 +507,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -516,12 +516,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -534,7 +534,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -543,12 +543,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -561,7 +561,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -570,12 +570,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -588,7 +588,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -597,12 +597,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -615,10 +615,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -629,12 +629,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,11 +665,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -690,7 +690,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -714,7 +714,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -733,7 +733,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -754,12 +754,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -777,7 +777,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -800,7 +800,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -826,11 +826,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -863,7 +863,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4543,7 +4543,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4559,7 +4559,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4762,7 +4762,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4778,7 +4778,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5142,7 +5142,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5158,7 +5158,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5472,7 +5472,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5488,7 +5488,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5650,7 +5650,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5666,7 +5666,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5828,7 +5828,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5844,7 +5844,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6940,7 +6940,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7014,7 +7014,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7088,7 +7088,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7174,7 +7174,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7260,7 +7260,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7346,7 +7346,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7448,7 +7448,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7535,7 +7535,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7622,7 +7622,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7721,7 +7721,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7820,7 +7820,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7919,7 +7919,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8039,7 +8039,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8103,7 +8103,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8167,7 +8167,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8236,7 +8236,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8305,7 +8305,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8374,7 +8374,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -346,17 +348,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -395,17 +397,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -528,16 +530,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -550,14 +552,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -591,8 +593,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -648,8 +650,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,20 +734,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -786,8 +788,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -806,24 +808,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -870,8 +872,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -880,17 +882,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -899,7 +901,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -914,8 +916,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -925,8 +927,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -956,7 +958,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -975,7 +977,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -994,7 +996,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1011,7 +1013,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1028,7 +1030,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1043,7 +1045,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1256,7 +1258,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5187,7 +5189,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5203,7 +5205,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5335,7 +5337,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5358,7 +5360,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5381,7 +5383,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5406,7 +5408,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5422,7 +5424,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5554,7 +5556,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5577,7 +5579,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5600,7 +5602,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5769,7 +5771,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5785,7 +5787,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5917,7 +5919,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5940,7 +5942,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5963,7 +5965,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -6051,7 +6053,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6085,7 +6087,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6101,7 +6103,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6199,7 +6201,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6222,7 +6224,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6256,7 +6258,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6272,7 +6274,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6370,7 +6372,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6393,7 +6395,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6427,7 +6429,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6443,7 +6445,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6711,7 +6713,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6734,7 +6736,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6757,7 +6759,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6780,7 +6782,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6803,7 +6805,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6826,7 +6828,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6849,7 +6851,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -338,75 +308,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -520,107 +481,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -629,15 +507,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -655,16 +524,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -683,16 +551,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +578,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,125 +605,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -877,7 +637,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -908,20 +676,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -932,27 +762,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1365,25 +1299,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1433,21 +1348,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1466,152 +1366,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1660,71 +1414,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1771,9 +1460,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1826,508 +1512,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4516,7 +3748,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4603,28 +3837,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4689,23 +3936,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4732,23 +3989,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4775,23 +4042,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4818,23 +4095,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4861,23 +4148,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4904,23 +4201,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4947,23 +4254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5019,23 +4336,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5058,9 +4385,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5095,23 +4429,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5134,9 +4478,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5173,8 +4524,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5709,23 +5064,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5748,9 +5113,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5976,9 +5348,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6064,9 +5443,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6235,9 +5621,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6406,9 +5799,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6873,7 +6273,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6888,7 +6290,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6903,7 +6307,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6918,7 +6324,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6933,7 +6341,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6948,7 +6358,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6963,7 +6375,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6978,7 +6392,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6993,7 +6409,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7007,7 +6425,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7023,7 +6443,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7037,7 +6459,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7053,7 +6477,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7067,7 +6493,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7083,7 +6511,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7097,7 +6527,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7113,7 +6545,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7127,7 +6561,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7143,7 +6579,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7157,7 +6595,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7173,7 +6613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7187,7 +6629,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7203,7 +6647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7217,7 +6663,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7233,7 +6681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7247,7 +6697,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7263,7 +6715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7277,7 +6731,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7293,7 +6749,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7307,7 +6765,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7323,7 +6783,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7337,7 +6799,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7353,18 +6817,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7374,17 +6844,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7400,24 +6876,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7432,9 +6921,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7469,11 +6964,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7495,9 +6995,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7532,11 +7038,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7558,9 +7069,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7600,11 +7117,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7633,9 +7155,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7675,11 +7203,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7708,9 +7241,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7750,11 +7289,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7783,9 +7327,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7820,11 +7370,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7874,9 +7429,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7911,11 +7472,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7936,18 +7502,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7982,11 +7559,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -8007,18 +7589,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8058,11 +7651,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8090,18 +7688,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8141,11 +7750,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8173,18 +7787,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8224,11 +7849,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8256,18 +7886,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8302,11 +7943,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8355,23 +8001,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8406,26 +8063,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8460,26 +8127,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8519,26 +8196,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8578,26 +8265,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8637,26 +8334,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8691,13 +8398,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +311,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +484,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +510,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +527,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,16 +554,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -714,16 +581,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -742,125 +608,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -880,7 +640,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -911,20 +679,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -935,27 +765,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1368,25 +1302,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1436,21 +1351,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1469,152 +1369,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1663,71 +1417,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1774,9 +1463,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1829,508 +1515,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4518,7 +3750,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4605,28 +3839,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4691,23 +3938,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4734,23 +3991,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4777,23 +4044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4820,23 +4097,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4863,23 +4150,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4906,23 +4203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4949,23 +4256,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5021,23 +4338,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5060,9 +4387,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5097,23 +4431,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5136,9 +4480,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5175,8 +4526,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5711,23 +5066,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5750,9 +5115,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5978,9 +5350,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6066,9 +5445,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6237,9 +5623,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6408,9 +5801,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6875,7 +6275,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6890,7 +6292,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6905,7 +6309,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6920,7 +6326,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6935,7 +6343,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6950,7 +6360,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6965,7 +6377,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6980,7 +6394,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6995,7 +6411,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7009,7 +6427,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7025,7 +6445,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7039,7 +6461,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7055,7 +6479,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7069,7 +6495,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7085,7 +6513,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7099,7 +6529,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7115,7 +6547,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7129,7 +6563,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7145,7 +6581,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7159,7 +6597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7175,7 +6615,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7189,7 +6631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7205,7 +6649,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7219,7 +6665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7235,7 +6683,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7249,7 +6699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7265,7 +6717,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7279,7 +6733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7295,7 +6751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7309,7 +6767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7325,7 +6785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7339,7 +6801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7355,18 +6819,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7376,17 +6846,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7402,24 +6878,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7434,9 +6923,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7471,11 +6966,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7497,9 +6997,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7534,11 +7040,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7560,9 +7071,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7602,11 +7119,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7635,9 +7157,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7677,11 +7205,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7710,9 +7243,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7752,11 +7291,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7778,9 +7322,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7815,11 +7365,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7869,9 +7424,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7906,11 +7467,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7931,18 +7497,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7977,11 +7554,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -8002,18 +7584,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8053,11 +7646,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8085,18 +7683,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8136,11 +7745,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8168,18 +7782,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8219,11 +7844,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8251,18 +7881,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8297,11 +7938,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8350,23 +7996,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8401,26 +8058,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8455,26 +8122,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8514,26 +8191,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8573,26 +8260,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8632,26 +8329,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8686,13 +8393,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -325,7 +325,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -369,7 +369,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -498,11 +498,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -510,7 +510,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -519,12 +519,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -537,7 +537,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -546,12 +546,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -564,7 +564,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -573,12 +573,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -591,7 +591,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -600,12 +600,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -618,10 +618,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -632,12 +632,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -668,11 +668,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -693,7 +693,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -717,7 +717,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -736,7 +736,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -757,12 +757,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -780,7 +780,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -803,7 +803,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -829,11 +829,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -866,7 +866,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4545,7 +4545,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4561,7 +4561,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4764,7 +4764,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4780,7 +4780,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5144,7 +5144,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5160,7 +5160,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5474,7 +5474,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5490,7 +5490,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5652,7 +5652,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5668,7 +5668,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5830,7 +5830,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5846,7 +5846,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6942,7 +6942,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7016,7 +7016,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7090,7 +7090,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7176,7 +7176,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7262,7 +7262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7341,7 +7341,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7443,7 +7443,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7530,7 +7530,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7617,7 +7617,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7716,7 +7716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7815,7 +7815,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7914,7 +7914,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8034,7 +8034,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8098,7 +8098,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8162,7 +8162,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8231,7 +8231,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8300,7 +8300,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8369,7 +8369,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -707,8 +709,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -735,20 +737,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -789,8 +791,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -809,24 +811,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -873,8 +875,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -883,17 +885,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -902,7 +904,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -917,8 +919,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -928,8 +930,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -959,7 +961,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -997,7 +999,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1014,7 +1016,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1031,7 +1033,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1046,7 +1048,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1259,7 +1261,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5189,7 +5191,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5205,7 +5207,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5337,7 +5339,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5360,7 +5362,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5383,7 +5385,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5408,7 +5410,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5424,7 +5426,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5556,7 +5558,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5579,7 +5581,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5602,7 +5604,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5771,7 +5773,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5787,7 +5789,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5919,7 +5921,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5942,7 +5944,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5965,7 +5967,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -6053,7 +6055,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6087,7 +6089,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6103,7 +6105,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6201,7 +6203,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6224,7 +6226,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6258,7 +6260,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6274,7 +6276,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6372,7 +6374,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6395,7 +6397,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6429,7 +6431,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6445,7 +6447,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6713,7 +6715,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6736,7 +6738,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6759,7 +6761,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6782,7 +6784,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6805,7 +6807,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6828,7 +6830,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6851,7 +6853,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -322,7 +322,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -366,7 +366,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -495,11 +495,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -507,7 +507,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -516,12 +516,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -534,7 +534,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -543,12 +543,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -561,7 +561,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -570,12 +570,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -588,7 +588,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -597,12 +597,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -615,10 +615,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -629,12 +629,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,11 +665,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -690,7 +690,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -714,7 +714,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -733,7 +733,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -754,12 +754,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -777,7 +777,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -800,7 +800,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -826,11 +826,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -859,7 +859,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4420,7 +4420,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4436,7 +4436,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4639,7 +4639,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4655,7 +4655,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4985,7 +4985,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5001,7 +5001,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5315,7 +5315,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5331,7 +5331,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5493,7 +5493,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5509,7 +5509,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5671,7 +5671,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5687,7 +5687,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6783,7 +6783,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6857,7 +6857,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6931,7 +6931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7017,7 +7017,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7103,7 +7103,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7189,7 +7189,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7291,7 +7291,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7378,7 +7378,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7465,7 +7465,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7564,7 +7564,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7663,7 +7663,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7762,7 +7762,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7882,7 +7882,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7946,7 +7946,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8010,7 +8010,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8079,7 +8079,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8148,7 +8148,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8217,7 +8217,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -346,17 +348,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -395,17 +397,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -528,16 +530,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -550,14 +552,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -591,8 +593,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -648,8 +650,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,20 +734,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -786,8 +788,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -805,21 +807,21 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person
+  codec: personCodec
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -866,8 +868,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -876,17 +878,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -895,7 +897,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -910,8 +912,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -921,8 +923,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -952,7 +954,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -971,7 +973,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -990,7 +992,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1007,7 +1009,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1024,7 +1026,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1039,7 +1041,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -5064,7 +5066,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5080,7 +5082,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5212,7 +5214,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5235,7 +5237,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5258,7 +5260,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5283,7 +5285,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5299,7 +5301,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5431,7 +5433,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5454,7 +5456,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5477,7 +5479,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5612,7 +5614,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5628,7 +5630,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5760,7 +5762,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5783,7 +5785,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5806,7 +5808,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5894,7 +5896,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5928,7 +5930,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5944,7 +5946,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6042,7 +6044,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6065,7 +6067,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6099,7 +6101,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6115,7 +6117,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6213,7 +6215,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6236,7 +6238,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6270,7 +6272,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6286,7 +6288,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6554,7 +6556,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6577,7 +6579,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6600,7 +6602,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6623,7 +6625,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6646,7 +6648,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6669,7 +6671,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6692,7 +6694,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -338,75 +308,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -520,107 +481,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -629,15 +507,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -655,16 +524,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -683,16 +551,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +578,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,121 +605,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -873,7 +637,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -904,20 +676,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -928,27 +762,127 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1283,25 +1217,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs2(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -1369,21 +1284,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1402,217 +1302,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple3 = [];
 const makeArgs3 = (args, path = []) => {
   const selectArgs = [];
@@ -1659,9 +1348,6 @@ const makeArgs3 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple4 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1714,508 +1400,54 @@ const makeArgs4 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4402,7 +3634,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4480,28 +3714,41 @@ export const plans = {
       return resource_renamed_functionPgResource.execute(selectArgs);
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4566,23 +3813,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4609,23 +3866,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4652,23 +3919,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4695,23 +3972,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4738,23 +4025,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4781,23 +4078,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4824,23 +4131,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4896,23 +4213,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4935,9 +4262,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4972,23 +4306,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5011,9 +4355,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5050,8 +4401,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5552,23 +4907,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5591,9 +4956,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5819,9 +5191,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5907,9 +5286,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6078,9 +5464,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6249,9 +5642,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6716,7 +6116,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6731,7 +6133,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6746,7 +6150,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6761,7 +6167,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6776,7 +6184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6791,7 +6201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6806,7 +6218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6821,7 +6235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6836,7 +6252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6850,7 +6268,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6866,7 +6286,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6880,7 +6302,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6896,7 +6320,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6910,7 +6336,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6926,7 +6354,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6940,7 +6370,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6956,7 +6388,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6970,7 +6404,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6986,7 +6422,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7000,7 +6438,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7016,7 +6456,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7030,7 +6472,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7046,7 +6490,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7060,7 +6506,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7076,7 +6524,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7090,7 +6540,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7106,7 +6558,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7120,7 +6574,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7136,7 +6592,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7150,7 +6608,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7166,7 +6626,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7180,7 +6642,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7196,18 +6660,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7217,17 +6687,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7243,24 +6719,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7275,9 +6764,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7312,11 +6807,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7338,9 +6838,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7375,11 +6881,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7401,9 +6912,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7443,11 +6960,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7476,9 +6998,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7518,11 +7046,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7551,9 +7084,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7593,11 +7132,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7626,9 +7170,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7663,11 +7213,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7717,9 +7272,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7754,11 +7315,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7779,18 +7345,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7825,11 +7402,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7850,18 +7432,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7901,11 +7494,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7933,18 +7531,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7984,11 +7593,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8016,18 +7630,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8067,11 +7692,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8099,18 +7729,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8145,11 +7786,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8198,23 +7844,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8249,26 +7906,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8303,26 +7970,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8362,26 +8039,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8421,26 +8108,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8480,26 +8177,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8534,13 +8241,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -707,8 +709,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -735,20 +737,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -789,8 +791,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -809,24 +811,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -873,8 +875,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -883,17 +885,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -902,7 +904,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -917,8 +919,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -928,8 +930,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -959,7 +961,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -997,7 +999,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1014,7 +1016,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1031,7 +1033,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1046,7 +1048,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1259,7 +1261,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5184,7 +5186,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5200,7 +5202,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5332,7 +5334,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5355,7 +5357,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5378,7 +5380,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5403,7 +5405,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5419,7 +5421,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5551,7 +5553,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5574,7 +5576,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5597,7 +5599,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5766,7 +5768,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5782,7 +5784,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5914,7 +5916,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5937,7 +5939,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5960,7 +5962,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -6048,7 +6050,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6082,7 +6084,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6098,7 +6100,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6196,7 +6198,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6219,7 +6221,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6253,7 +6255,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6269,7 +6271,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6367,7 +6369,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6390,7 +6392,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6424,7 +6426,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6440,7 +6442,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6708,7 +6710,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6731,7 +6733,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6754,7 +6756,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6777,7 +6779,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6800,7 +6802,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6823,7 +6825,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6846,7 +6848,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +311,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +484,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +510,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +527,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,16 +554,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -714,16 +581,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -742,125 +608,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -880,7 +640,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -911,20 +679,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -935,27 +765,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1368,25 +1302,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1436,21 +1351,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1469,152 +1369,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1663,71 +1417,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1774,9 +1463,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1829,508 +1515,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4516,7 +3748,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4603,28 +3837,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4689,23 +3936,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4732,23 +3989,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4775,23 +4042,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4818,23 +4095,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4861,23 +4148,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4904,23 +4201,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4947,23 +4254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5019,23 +4336,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5058,9 +4385,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5092,23 +4426,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5131,9 +4475,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5170,8 +4521,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5706,23 +5061,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5745,9 +5110,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5973,9 +5345,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6061,9 +5440,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6232,9 +5618,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6403,9 +5796,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6870,7 +6270,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6885,7 +6287,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6900,7 +6304,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6915,7 +6321,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6930,7 +6338,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6945,7 +6355,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6960,7 +6372,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6975,7 +6389,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6990,7 +6406,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7004,7 +6422,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7020,7 +6440,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7034,7 +6456,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7050,7 +6474,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7064,7 +6490,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7080,7 +6508,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7094,7 +6524,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7110,7 +6542,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7124,7 +6558,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7140,7 +6576,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7154,7 +6592,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7170,7 +6610,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7184,7 +6626,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7200,7 +6644,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7214,7 +6660,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7230,7 +6678,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7244,7 +6694,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7260,7 +6712,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7274,7 +6728,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7290,7 +6746,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7304,7 +6762,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7320,7 +6780,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7334,7 +6796,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7350,18 +6814,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7371,17 +6841,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7397,24 +6873,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7429,9 +6918,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7466,11 +6961,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7492,9 +6992,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7529,11 +7035,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7555,9 +7066,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7597,11 +7114,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7630,9 +7152,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7672,11 +7200,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7705,9 +7238,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7747,11 +7286,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7773,9 +7317,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7810,11 +7360,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7864,9 +7419,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7901,11 +7462,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7926,18 +7492,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7972,11 +7549,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7997,18 +7579,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8048,11 +7641,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8080,18 +7678,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8131,11 +7740,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8163,18 +7777,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8214,11 +7839,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8239,18 +7869,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8285,11 +7926,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8338,23 +7984,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8389,26 +8046,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8443,26 +8110,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8502,26 +8179,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8561,26 +8248,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8620,26 +8317,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8674,13 +8381,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -325,7 +325,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -369,7 +369,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -498,11 +498,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -510,7 +510,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -519,12 +519,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -537,7 +537,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -546,12 +546,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -564,7 +564,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -573,12 +573,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -591,7 +591,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -600,12 +600,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -618,10 +618,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -632,12 +632,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -668,11 +668,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -693,7 +693,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -717,7 +717,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -736,7 +736,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -757,12 +757,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -780,7 +780,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -803,7 +803,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -829,11 +829,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -866,7 +866,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4540,7 +4540,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4556,7 +4556,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4759,7 +4759,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4775,7 +4775,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5139,7 +5139,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5155,7 +5155,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5469,7 +5469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5485,7 +5485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5647,7 +5647,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5663,7 +5663,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5825,7 +5825,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5841,7 +5841,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6937,7 +6937,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7011,7 +7011,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7085,7 +7085,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7171,7 +7171,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7257,7 +7257,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7336,7 +7336,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7438,7 +7438,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7525,7 +7525,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7612,7 +7612,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7711,7 +7711,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7810,7 +7810,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7902,7 +7902,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8022,7 +8022,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8086,7 +8086,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8150,7 +8150,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8219,7 +8219,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8288,7 +8288,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8357,7 +8357,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +266,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -344,75 +314,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -526,107 +487,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -635,15 +513,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +530,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +557,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +584,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +611,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +643,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +682,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +768,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1305,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1354,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1372,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1420,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1466,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,508 +1518,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4506,7 +3738,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4593,28 +3827,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4679,23 +3926,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4722,23 +3979,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4765,23 +4032,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4808,23 +4085,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4851,23 +4138,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4894,23 +4191,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4937,23 +4244,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5009,23 +4326,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5048,9 +4375,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5082,23 +4416,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5121,9 +4465,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5157,8 +4508,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5579,23 +4934,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5618,9 +4983,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5846,9 +5218,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5934,9 +5313,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6105,9 +5491,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6276,9 +5669,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6743,7 +6143,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6758,7 +6160,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6773,7 +6177,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6788,7 +6194,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6803,7 +6211,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6818,7 +6228,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6833,7 +6245,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6848,7 +6262,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6863,7 +6279,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6877,7 +6295,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6893,7 +6313,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6907,7 +6329,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6923,7 +6347,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6937,7 +6363,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6953,7 +6381,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6967,7 +6397,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6983,7 +6415,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6997,7 +6431,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7013,7 +6449,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7027,7 +6465,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7043,7 +6483,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7057,7 +6499,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7073,7 +6517,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7087,7 +6533,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7103,7 +6551,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7117,7 +6567,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7133,7 +6585,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7147,7 +6601,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7163,7 +6619,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7177,7 +6635,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7193,7 +6653,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7207,7 +6669,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7223,18 +6687,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7244,17 +6714,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7270,24 +6746,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7302,9 +6791,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7339,11 +6834,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7365,9 +6865,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7402,11 +6908,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7428,9 +6939,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7470,11 +6987,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7503,9 +7025,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7545,11 +7073,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7571,9 +7104,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7613,11 +7152,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7639,9 +7183,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7676,11 +7226,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7730,9 +7285,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7767,11 +7328,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7792,18 +7358,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7838,11 +7415,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7863,18 +7445,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7914,11 +7507,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7946,18 +7544,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7997,11 +7606,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8022,18 +7636,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8073,11 +7698,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8098,18 +7728,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8144,11 +7785,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8197,23 +7843,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8248,26 +7905,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8302,26 +7969,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8361,26 +8038,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8420,26 +8107,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8479,26 +8176,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8533,13 +8240,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -280,7 +280,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -328,7 +328,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -372,7 +372,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -501,11 +501,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -513,7 +513,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -522,12 +522,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -540,7 +540,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -549,12 +549,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -567,7 +567,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -576,12 +576,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -594,7 +594,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -603,12 +603,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -621,10 +621,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -635,12 +635,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -671,11 +671,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -696,7 +696,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -720,7 +720,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -739,7 +739,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -760,12 +760,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -783,7 +783,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -806,7 +806,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -832,11 +832,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -869,7 +869,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4527,7 +4527,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4543,7 +4543,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4689,7 +4689,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4705,7 +4705,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5012,7 +5012,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5028,7 +5028,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5342,7 +5342,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5358,7 +5358,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5520,7 +5520,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5536,7 +5536,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5698,7 +5698,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5714,7 +5714,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6810,7 +6810,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6884,7 +6884,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6958,7 +6958,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7044,7 +7044,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7123,7 +7123,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7202,7 +7202,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7304,7 +7304,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7391,7 +7391,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7478,7 +7478,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7577,7 +7577,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7669,7 +7669,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7761,7 +7761,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7881,7 +7881,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7945,7 +7945,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8009,7 +8009,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8078,7 +8078,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8147,7 +8147,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8216,7 +8216,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -352,17 +354,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -401,17 +403,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -534,16 +536,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -556,14 +558,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -597,8 +599,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5171,7 +5173,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5187,7 +5189,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5285,7 +5287,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5308,7 +5310,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5333,7 +5335,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5349,7 +5351,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5447,7 +5449,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5470,7 +5472,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5639,7 +5641,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5655,7 +5657,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5787,7 +5789,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5810,7 +5812,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5833,7 +5835,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5921,7 +5923,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5955,7 +5957,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5971,7 +5973,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6069,7 +6071,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6092,7 +6094,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6126,7 +6128,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6142,7 +6144,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6240,7 +6242,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6263,7 +6265,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6297,7 +6299,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6313,7 +6315,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6581,7 +6583,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6604,7 +6606,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6627,7 +6629,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6650,7 +6652,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6673,7 +6675,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6696,7 +6698,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6719,7 +6721,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +266,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +311,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +484,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +510,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +527,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,16 +554,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -714,16 +581,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -742,125 +608,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -880,7 +640,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -911,20 +679,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -935,27 +765,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1368,25 +1302,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1436,21 +1351,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1469,152 +1369,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1663,71 +1417,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1774,9 +1463,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1829,508 +1515,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4517,7 +3749,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4604,28 +3838,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4690,23 +3937,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4733,23 +3990,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4776,23 +4043,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4819,23 +4096,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4862,23 +4149,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4905,23 +4202,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4948,23 +4255,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5020,23 +4337,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5059,9 +4386,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5096,23 +4430,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5135,9 +4479,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5174,8 +4525,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5676,23 +5031,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5715,9 +5080,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5943,9 +5315,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6031,9 +5410,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6202,9 +5588,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6373,9 +5766,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6840,7 +6240,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6855,7 +6257,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6870,7 +6274,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6885,7 +6291,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6900,7 +6308,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6915,7 +6325,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6930,7 +6342,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6945,7 +6359,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6960,7 +6376,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6974,7 +6392,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6990,7 +6410,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7004,7 +6426,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7020,7 +6444,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7034,7 +6460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7050,7 +6478,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7064,7 +6494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7080,7 +6512,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7094,7 +6528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7110,7 +6546,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7124,7 +6562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7140,7 +6580,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7154,7 +6596,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7170,7 +6614,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7184,7 +6630,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7200,7 +6648,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7214,7 +6664,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7230,7 +6682,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7244,7 +6698,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7260,7 +6716,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7274,7 +6732,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7290,7 +6750,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7304,7 +6766,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7320,18 +6784,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7341,17 +6811,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7367,24 +6843,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7399,9 +6888,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7436,11 +6931,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7462,9 +6962,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7499,11 +7005,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7525,9 +7036,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7567,11 +7084,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7600,9 +7122,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7642,11 +7170,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7675,9 +7208,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7717,11 +7256,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7750,9 +7294,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7787,11 +7337,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7841,9 +7396,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7878,11 +7439,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7903,18 +7469,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7949,11 +7526,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7974,18 +7556,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8025,11 +7618,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8057,18 +7655,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8108,11 +7717,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8140,18 +7754,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8191,11 +7816,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8223,18 +7853,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8269,11 +7910,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8322,23 +7968,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8373,26 +8030,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8427,26 +8094,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8486,26 +8163,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8545,26 +8232,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8604,26 +8301,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8658,13 +8365,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -280,7 +280,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -325,7 +325,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -369,7 +369,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -498,11 +498,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -510,7 +510,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -519,12 +519,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -537,7 +537,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -546,12 +546,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -564,7 +564,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -573,12 +573,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -591,7 +591,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -600,12 +600,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -618,10 +618,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -632,12 +632,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -668,11 +668,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -693,7 +693,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -717,7 +717,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -736,7 +736,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -757,12 +757,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -780,7 +780,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -803,7 +803,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -829,11 +829,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -866,7 +866,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4544,7 +4544,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4560,7 +4560,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4729,7 +4729,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4745,7 +4745,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5109,7 +5109,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5125,7 +5125,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5439,7 +5439,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5455,7 +5455,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5617,7 +5617,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5633,7 +5633,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5795,7 +5795,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5811,7 +5811,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6907,7 +6907,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6981,7 +6981,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7055,7 +7055,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7141,7 +7141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7227,7 +7227,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7313,7 +7313,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7415,7 +7415,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7502,7 +7502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7589,7 +7589,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7688,7 +7688,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7787,7 +7787,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7886,7 +7886,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8006,7 +8006,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8070,7 +8070,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8134,7 +8134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8203,7 +8203,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8272,7 +8272,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8341,7 +8341,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -707,8 +709,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -735,20 +737,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -789,8 +791,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -809,24 +811,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -873,8 +875,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -883,17 +885,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -902,7 +904,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -917,8 +919,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -928,8 +930,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -959,7 +961,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -997,7 +999,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1014,7 +1016,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1031,7 +1033,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1046,7 +1048,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1259,7 +1261,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5188,7 +5190,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5204,7 +5206,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5302,7 +5304,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5325,7 +5327,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5348,7 +5350,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5373,7 +5375,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5389,7 +5391,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5521,7 +5523,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5544,7 +5546,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5567,7 +5569,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5736,7 +5738,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5752,7 +5754,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5884,7 +5886,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5907,7 +5909,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5930,7 +5932,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -6018,7 +6020,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6052,7 +6054,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6068,7 +6070,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6166,7 +6168,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6189,7 +6191,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6223,7 +6225,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6239,7 +6241,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6337,7 +6339,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6360,7 +6362,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6394,7 +6396,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6410,7 +6412,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6678,7 +6680,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6701,7 +6703,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6724,7 +6726,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6747,7 +6749,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6770,7 +6772,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6793,7 +6795,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6816,7 +6818,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +311,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +484,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +510,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +527,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,16 +554,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -714,16 +581,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -742,125 +608,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -880,7 +640,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -911,20 +679,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -935,27 +765,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1368,25 +1302,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1436,21 +1351,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1469,152 +1369,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1663,71 +1417,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1774,9 +1463,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1829,508 +1515,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4518,7 +3750,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4605,28 +3839,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4691,23 +3938,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4734,23 +3991,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4777,23 +4044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4820,23 +4097,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4863,23 +4150,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4906,23 +4203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4949,23 +4256,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5021,23 +4338,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5060,9 +4387,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5097,23 +4431,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5136,9 +4480,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5175,8 +4526,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5711,23 +5066,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5750,9 +5115,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5978,9 +5350,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6066,9 +5445,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6237,9 +5623,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6408,9 +5801,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6875,7 +6275,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6890,7 +6292,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6905,7 +6309,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6920,7 +6326,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6935,7 +6343,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6950,7 +6360,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6965,7 +6377,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6980,7 +6394,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6995,7 +6411,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7009,7 +6427,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7025,7 +6445,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7039,7 +6461,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7055,7 +6479,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7069,7 +6495,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7085,7 +6513,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7099,7 +6529,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7115,7 +6547,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7129,7 +6563,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7145,7 +6581,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7159,7 +6597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7175,7 +6615,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7189,7 +6631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7205,7 +6649,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7219,7 +6665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7235,7 +6683,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7249,7 +6699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7265,7 +6717,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7279,7 +6733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7295,7 +6751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7309,7 +6767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7325,7 +6785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7339,7 +6801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7355,18 +6819,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7376,17 +6846,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7402,24 +6878,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7434,9 +6923,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7471,11 +6966,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7497,9 +6997,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7534,11 +7040,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7560,9 +7071,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7602,11 +7119,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7635,9 +7157,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7677,11 +7205,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7710,9 +7243,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7752,11 +7291,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7785,9 +7329,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7822,11 +7372,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7876,9 +7431,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7913,11 +7474,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7938,18 +7504,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7984,11 +7561,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -8009,18 +7591,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8060,11 +7653,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8092,18 +7690,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8143,11 +7752,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8175,18 +7789,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8226,11 +7851,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8251,18 +7881,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8297,11 +7938,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8350,23 +7996,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8401,26 +8058,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8455,26 +8122,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8514,26 +8191,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8573,26 +8260,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8632,26 +8329,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8686,13 +8393,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -707,8 +709,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -735,20 +737,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -789,8 +791,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -809,24 +811,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -873,8 +875,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -883,17 +885,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -902,7 +904,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -917,8 +919,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -928,8 +930,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -959,7 +961,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -997,7 +999,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1014,7 +1016,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1031,7 +1033,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1046,7 +1048,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1259,7 +1261,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5189,7 +5191,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5205,7 +5207,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5337,7 +5339,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5360,7 +5362,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5383,7 +5385,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5408,7 +5410,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5424,7 +5426,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5556,7 +5558,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5579,7 +5581,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5602,7 +5604,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5771,7 +5773,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5787,7 +5789,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5919,7 +5921,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5942,7 +5944,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5965,7 +5967,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -6053,7 +6055,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6087,7 +6089,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6103,7 +6105,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6201,7 +6203,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6224,7 +6226,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6258,7 +6260,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6274,7 +6276,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6372,7 +6374,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6395,7 +6397,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6429,7 +6431,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6445,7 +6447,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6713,7 +6715,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6736,7 +6738,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6759,7 +6761,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6782,7 +6784,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6805,7 +6807,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6828,7 +6830,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6851,7 +6853,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -325,7 +325,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -369,7 +369,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -498,11 +498,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -510,7 +510,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -519,12 +519,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -537,7 +537,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -546,12 +546,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -564,7 +564,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -573,12 +573,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -591,7 +591,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -600,12 +600,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -618,10 +618,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -632,12 +632,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -668,11 +668,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -693,7 +693,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -717,7 +717,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -736,7 +736,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -757,12 +757,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -780,7 +780,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -803,7 +803,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -829,11 +829,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -866,7 +866,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4545,7 +4545,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4561,7 +4561,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4764,7 +4764,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4780,7 +4780,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5144,7 +5144,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5160,7 +5160,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5474,7 +5474,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5490,7 +5490,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5652,7 +5652,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5668,7 +5668,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5830,7 +5830,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5846,7 +5846,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6942,7 +6942,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7016,7 +7016,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7090,7 +7090,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7176,7 +7176,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7262,7 +7262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7348,7 +7348,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7450,7 +7450,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7537,7 +7537,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7624,7 +7624,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7723,7 +7723,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7822,7 +7822,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7914,7 +7914,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8034,7 +8034,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8098,7 +8098,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8162,7 +8162,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8231,7 +8231,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8300,7 +8300,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8369,7 +8369,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -163,17 +149,14 @@ const extensions3 = {
     behavior: ["-insert -update -delete"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +177,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +222,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +267,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +312,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,110 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "create,update,delete",
-    behavior: extensions3.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -635,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +555,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +582,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +609,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +641,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +680,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +766,134 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "create,update,delete",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1306,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1355,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1373,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1421,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1467,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,431 +1519,46 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4253,7 +3555,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4340,28 +3644,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4426,23 +3743,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4469,23 +3796,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4512,23 +3849,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4555,23 +3902,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4598,23 +3955,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4641,23 +4008,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4684,23 +4061,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4756,23 +4143,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4795,9 +4192,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4832,23 +4236,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4871,9 +4285,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4910,8 +4331,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5446,23 +4871,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5485,9 +4920,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5713,9 +5155,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5801,9 +5250,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5972,9 +5428,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6143,9 +5606,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6610,7 +6080,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6625,7 +6097,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6640,7 +6114,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6655,7 +6131,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6670,7 +6148,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6685,7 +6165,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6700,7 +6182,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6715,7 +6199,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6729,7 +6215,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6745,7 +6233,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6759,7 +6249,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6775,7 +6267,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6789,7 +6283,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6805,7 +6301,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6819,7 +6317,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6835,7 +6335,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6849,7 +6351,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6865,7 +6369,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6879,7 +6385,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6895,7 +6403,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6909,7 +6419,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6925,7 +6437,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6939,7 +6453,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6955,7 +6471,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6969,7 +6487,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6985,7 +6505,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6999,7 +6521,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7015,18 +6539,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7036,17 +6566,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7062,24 +6598,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7094,9 +6643,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7131,11 +6686,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7157,9 +6717,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7199,11 +6765,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7232,9 +6803,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7274,11 +6851,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7307,9 +6889,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7349,11 +6937,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7382,9 +6975,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7419,11 +7018,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7473,9 +7077,15 @@ export const plans = {
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7510,11 +7120,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7535,18 +7150,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7586,11 +7212,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7618,18 +7249,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7669,11 +7311,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7701,18 +7348,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7752,11 +7410,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -7784,18 +7447,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7830,11 +7504,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -7883,23 +7562,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7934,26 +7624,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7993,26 +7693,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8052,26 +7762,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8111,26 +7831,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8165,13 +7895,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -4924,7 +4926,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4940,7 +4942,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5072,7 +5074,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5095,7 +5097,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5118,7 +5120,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5143,7 +5145,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5159,7 +5161,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5291,7 +5293,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5314,7 +5316,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5337,7 +5339,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5506,7 +5508,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5522,7 +5524,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5654,7 +5656,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5677,7 +5679,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5700,7 +5702,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5788,7 +5790,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5822,7 +5824,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5838,7 +5840,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5936,7 +5938,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -5959,7 +5961,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -5993,7 +5995,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6009,7 +6011,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6107,7 +6109,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6130,7 +6132,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6164,7 +6166,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6180,7 +6182,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6448,7 +6450,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6471,7 +6473,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6494,7 +6496,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6517,7 +6519,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6540,7 +6542,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6563,7 +6565,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6586,7 +6588,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -155,7 +155,7 @@ const filmsCodec = recordCodec({
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -191,7 +191,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -236,7 +236,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -281,7 +281,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -592,7 +592,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -601,12 +601,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -619,10 +619,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -633,12 +633,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -669,11 +669,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -694,7 +694,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -718,7 +718,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -737,7 +737,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -758,12 +758,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -784,7 +784,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -807,7 +807,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -833,11 +833,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -870,7 +870,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4350,7 +4350,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4366,7 +4366,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4569,7 +4569,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4585,7 +4585,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4949,7 +4949,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4965,7 +4965,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5279,7 +5279,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5295,7 +5295,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5457,7 +5457,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5473,7 +5473,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5635,7 +5635,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5651,7 +5651,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6662,7 +6662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6736,7 +6736,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6822,7 +6822,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6908,7 +6908,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6994,7 +6994,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7096,7 +7096,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7183,7 +7183,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7282,7 +7282,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7381,7 +7381,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7480,7 +7480,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7600,7 +7600,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7664,7 +7664,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7733,7 +7733,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7802,7 +7802,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7871,7 +7871,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -301,17 +275,14 @@ const extensions6 = {
     behavior: ["-singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
   })
 };
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +312,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,18 +555,14 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {
-    omit: "many",
-    behavior: extensions6.tags.behavior
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
   }
 };
 const uniques6 = [{
@@ -717,16 +582,18 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {
+      omit: "many",
+      behavior: extensions6.tags.behavior
+    }
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +612,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +644,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +683,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +769,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1373,25 +1308,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1441,21 +1357,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1474,96 +1375,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1612,82 +1423,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1734,9 +1469,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1789,508 +1521,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4392,7 +3670,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4479,28 +3759,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4565,23 +3858,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4608,23 +3911,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4651,23 +3964,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4694,23 +4017,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4737,23 +4070,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4780,23 +4123,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4823,23 +4176,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5019,9 +4382,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5037,8 +4407,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5048,9 +4422,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5136,9 +4517,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5307,9 +4695,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5688,9 +5083,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5916,9 +5318,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6144,9 +5553,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6611,7 +6027,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6626,7 +6044,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6641,7 +6061,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6656,7 +6078,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6671,7 +6095,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6686,7 +6112,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6701,7 +6129,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6716,7 +6146,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6731,7 +6163,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6745,7 +6179,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6761,7 +6197,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6775,7 +6213,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6791,7 +6231,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6805,7 +6247,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6821,7 +6265,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6835,7 +6281,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6851,7 +6299,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6865,7 +6315,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6881,7 +6333,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6895,7 +6349,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6911,7 +6367,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6925,7 +6383,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6941,7 +6401,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6955,7 +6417,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6971,7 +6435,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6985,7 +6451,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7001,7 +6469,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7015,7 +6485,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7031,7 +6503,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7045,7 +6519,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7061,7 +6537,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7075,7 +6553,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7091,18 +6571,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7112,17 +6598,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7138,24 +6630,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7170,9 +6675,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7207,11 +6718,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7233,9 +6749,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7270,11 +6792,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7296,9 +6823,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7338,11 +6871,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7371,9 +6909,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7413,11 +6957,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7446,9 +6995,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7488,11 +7043,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7521,9 +7081,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7558,11 +7124,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7612,9 +7183,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7649,11 +7226,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7674,18 +7256,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7720,11 +7313,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7745,18 +7343,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7796,11 +7405,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7828,18 +7442,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7879,11 +7504,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7911,18 +7541,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7962,11 +7603,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -7994,18 +7640,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8040,11 +7697,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8093,23 +7755,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8144,26 +7817,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8198,26 +7881,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8257,26 +7950,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8316,26 +8019,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8375,26 +8088,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8429,13 +8152,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -281,7 +281,7 @@ const tvEpisodesCodec = recordCodec({
   attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -595,7 +595,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     }
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -604,12 +604,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -622,10 +622,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -636,12 +636,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -672,11 +672,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -697,7 +697,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -721,7 +721,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -740,7 +740,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -761,12 +761,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -784,7 +784,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -807,7 +807,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -833,11 +833,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -870,7 +870,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4546,7 +4546,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4562,7 +4562,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4724,7 +4724,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4740,7 +4740,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4877,7 +4877,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4893,7 +4893,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5112,7 +5112,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5128,7 +5128,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5347,7 +5347,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5363,7 +5363,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5582,7 +5582,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5598,7 +5598,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6694,7 +6694,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6768,7 +6768,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6842,7 +6842,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6928,7 +6928,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7014,7 +7014,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7100,7 +7100,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7202,7 +7202,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7289,7 +7289,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7376,7 +7376,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7475,7 +7475,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7574,7 +7574,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7673,7 +7673,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7793,7 +7793,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7857,7 +7857,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7921,7 +7921,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7990,7 +7990,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8059,7 +8059,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8128,7 +8128,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   })
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1018,7 +1020,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1035,7 +1037,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1051,7 +1053,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1264,7 +1266,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5123,7 +5125,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5157,7 +5159,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5173,7 +5175,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5271,7 +5273,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -5294,7 +5296,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -5328,7 +5330,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5344,7 +5346,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5442,7 +5444,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -5465,7 +5467,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -5481,7 +5483,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5497,7 +5499,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5629,7 +5631,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5652,7 +5654,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5675,7 +5677,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5709,7 +5711,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5725,7 +5727,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5857,7 +5859,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5880,7 +5882,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5903,7 +5905,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5937,7 +5939,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5953,7 +5955,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6085,7 +6087,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -6108,7 +6110,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -6131,7 +6133,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -6165,7 +6167,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6181,7 +6183,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6449,7 +6451,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6472,7 +6474,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6495,7 +6497,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6518,7 +6520,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6541,7 +6543,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6564,7 +6566,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6587,7 +6589,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,47 +99,23 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -163,17 +129,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
-  attributes: filmsAttributes,
+  identifier: sql.identifier("d", "films"),
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +176,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +221,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,54 +266,21 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions7 = {
   isTableLike: true,
@@ -353,66 +294,86 @@ const extensions7 = {
     behavior: ["-*"]
   })
 };
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
-  attributes: tvShowsAttributes,
+  identifier: sql.identifier("d", "tv_shows"),
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -526,127 +487,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "*",
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["code"],
-  description: undefined,
-  extensions: {
     tags: Object.create(null)
-  }
-}];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -664,16 +522,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -692,16 +549,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -720,156 +576,48 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions7.tags.behavior
-  }
-};
-const uniques7 = [{
-  isPrimary: true,
-  attributes: ["code"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
   }
-}];
+};
 const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["code"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
     tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      omit: true,
+      behavior: extensions7.tags.behavior
     }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -889,7 +637,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -920,20 +676,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -941,30 +759,144 @@ const registry = makeRegistry({
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["code"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "*",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1337,25 +1269,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1389,21 +1302,6 @@ const fetcher4 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1422,66 +1320,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1530,77 +1368,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1647,9 +1414,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1702,354 +1466,38 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -3572,7 +3020,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -3639,28 +3089,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -3707,23 +3170,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -3750,23 +3223,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -3793,23 +3276,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -3836,23 +3329,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -3879,23 +3382,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4027,23 +3540,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4066,9 +3589,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4084,8 +3614,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -4321,9 +3855,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4409,9 +3950,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4580,9 +4128,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4808,9 +4363,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5275,7 +4837,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5290,7 +4854,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5305,7 +4871,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5320,7 +4888,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5335,7 +4905,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5350,7 +4922,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5365,7 +4939,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5379,7 +4955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5395,7 +4973,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5409,7 +4989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5425,7 +5007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5439,7 +5023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5455,7 +5041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5469,7 +5057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5485,7 +5075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5499,7 +5091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5515,7 +5109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5529,7 +5125,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5545,7 +5143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5559,7 +5159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5575,7 +5177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5589,7 +5193,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5605,18 +5211,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -5626,17 +5238,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -5652,24 +5270,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -5684,9 +5315,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5721,11 +5358,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -5747,9 +5389,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5789,11 +5437,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -5822,9 +5475,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5859,11 +5518,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -5892,9 +5556,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5929,11 +5599,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -5983,9 +5658,15 @@ export const plans = {
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6020,11 +5701,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -6045,18 +5731,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6096,11 +5793,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -6128,18 +5830,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6174,11 +5887,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -6206,18 +5924,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6252,11 +5981,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -6305,23 +6039,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6356,26 +6101,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6415,26 +6170,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6469,26 +6234,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6523,13 +6298,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -154,7 +154,7 @@ const filmsCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -190,7 +190,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -280,7 +280,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions7 = {
   isTableLike: true,
@@ -328,7 +328,7 @@ const tvShowsCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions7,
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -372,7 +372,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -501,11 +501,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques4 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -514,12 +514,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -532,7 +532,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -541,12 +541,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -559,7 +559,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -568,12 +568,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -587,7 +587,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   }
 };
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
@@ -615,10 +615,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     }
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -629,12 +629,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,11 +665,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -690,7 +690,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -714,7 +714,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -733,7 +733,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -754,7 +754,7 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
@@ -787,7 +787,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -810,7 +810,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -836,11 +836,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -873,7 +873,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -3633,7 +3633,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3649,7 +3649,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3979,7 +3979,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3995,7 +3995,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4157,7 +4157,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4173,7 +4173,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4392,7 +4392,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4408,7 +4408,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5334,7 +5334,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5408,7 +5408,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5494,7 +5494,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5575,7 +5575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5677,7 +5677,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5764,7 +5764,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5863,7 +5863,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -5957,7 +5957,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6077,7 +6077,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6141,7 +6141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6210,7 +6210,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6274,7 +6274,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -352,17 +354,17 @@ const extensions7 = {
   })
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -401,17 +403,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -534,16 +536,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -556,14 +558,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -597,8 +599,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -657,8 +659,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -685,8 +687,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -713,8 +715,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -744,20 +746,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -798,8 +800,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -818,24 +820,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -882,8 +884,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -892,17 +894,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -911,7 +913,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -926,8 +928,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -937,8 +939,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -968,7 +970,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -987,7 +989,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1006,7 +1008,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1023,7 +1025,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1040,7 +1042,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1055,7 +1057,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1228,7 +1230,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -4098,7 +4100,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4114,7 +4116,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4246,7 +4248,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -4269,7 +4271,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -4292,7 +4294,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -4396,7 +4398,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -4430,7 +4432,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4446,7 +4448,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4544,7 +4546,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -4567,7 +4569,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -4601,7 +4603,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4617,7 +4619,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4749,7 +4751,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -4772,7 +4774,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -4795,7 +4797,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -4829,7 +4831,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4845,7 +4847,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5113,7 +5115,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -5136,7 +5138,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -5159,7 +5161,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -5182,7 +5184,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -5205,7 +5207,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -5228,7 +5230,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -5251,7 +5253,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -163,17 +149,14 @@ const extensions3 = {
     behavior: ["-insert"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +177,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +222,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +267,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +312,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,110 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "create",
-    behavior: extensions3.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -635,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +555,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +582,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +609,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +641,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +680,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +766,134 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "create",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1306,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1355,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1373,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1421,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1467,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,489 +1519,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4454,7 +3706,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4541,28 +3795,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4627,23 +3894,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4670,23 +3947,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4713,23 +4000,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4756,23 +4053,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4799,23 +4106,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4842,23 +4159,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4885,23 +4212,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4957,23 +4294,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4996,9 +4343,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5033,23 +4387,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5072,9 +4436,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5111,8 +4482,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5647,23 +5022,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5686,9 +5071,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5914,9 +5306,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6002,9 +5401,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6173,9 +5579,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6344,9 +5757,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6811,7 +6231,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6826,7 +6248,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6841,7 +6265,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6856,7 +6282,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6871,7 +6299,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6886,7 +6316,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6901,7 +6333,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6916,7 +6350,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6930,7 +6366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6946,7 +6384,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6960,7 +6400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6976,7 +6418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6990,7 +6434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7006,7 +6452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7020,7 +6468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7036,7 +6486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7050,7 +6502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7066,7 +6520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7080,7 +6536,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7096,7 +6554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7110,7 +6570,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7126,7 +6588,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7140,7 +6604,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7156,7 +6622,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7170,7 +6638,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7186,7 +6656,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7200,7 +6672,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7216,7 +6690,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7230,7 +6706,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7246,7 +6724,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7260,7 +6740,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7276,18 +6758,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7297,17 +6785,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7323,24 +6817,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7355,9 +6862,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7392,11 +6905,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7418,9 +6936,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7460,11 +6984,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7493,9 +7022,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7535,11 +7070,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7568,9 +7108,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7610,11 +7156,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7643,9 +7194,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7680,11 +7237,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7734,9 +7296,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7771,11 +7339,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7796,18 +7369,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7842,11 +7426,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7867,18 +7456,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7918,11 +7518,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7950,18 +7555,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8001,11 +7617,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8033,18 +7654,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8084,11 +7716,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8116,18 +7753,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8162,11 +7810,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8215,23 +7868,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8266,26 +7930,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8320,26 +7994,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8379,26 +8063,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8438,26 +8132,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8497,26 +8201,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8551,13 +8265,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -155,7 +155,7 @@ const filmsCodec = recordCodec({
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -191,7 +191,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -236,7 +236,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -281,7 +281,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -592,7 +592,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -601,12 +601,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -619,10 +619,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -633,12 +633,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -669,11 +669,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -694,7 +694,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -718,7 +718,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -737,7 +737,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -758,12 +758,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -784,7 +784,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -807,7 +807,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -833,11 +833,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -870,7 +870,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4501,7 +4501,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4517,7 +4517,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4720,7 +4720,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4736,7 +4736,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5100,7 +5100,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5116,7 +5116,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5430,7 +5430,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5446,7 +5446,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5608,7 +5608,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5624,7 +5624,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5786,7 +5786,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5802,7 +5802,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6881,7 +6881,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6955,7 +6955,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7041,7 +7041,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7127,7 +7127,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7213,7 +7213,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7315,7 +7315,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7402,7 +7402,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7489,7 +7489,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7588,7 +7588,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7687,7 +7687,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7786,7 +7786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7906,7 +7906,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7970,7 +7970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8034,7 +8034,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8103,7 +8103,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8172,7 +8172,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8241,7 +8241,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5125,7 +5127,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5141,7 +5143,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5273,7 +5275,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5296,7 +5298,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5319,7 +5321,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5344,7 +5346,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5360,7 +5362,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5492,7 +5494,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5515,7 +5517,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5538,7 +5540,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5707,7 +5709,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5723,7 +5725,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5855,7 +5857,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5878,7 +5880,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5901,7 +5903,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5989,7 +5991,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6023,7 +6025,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6039,7 +6041,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6137,7 +6139,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6160,7 +6162,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6194,7 +6196,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6210,7 +6212,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6308,7 +6310,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6331,7 +6333,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6365,7 +6367,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6381,7 +6383,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6649,7 +6651,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6672,7 +6674,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6695,7 +6697,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6718,7 +6720,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6741,7 +6743,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6764,7 +6766,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6787,7 +6789,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -155,7 +155,7 @@ const filmsCodec = recordCodec({
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -191,7 +191,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -236,7 +236,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -281,7 +281,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -592,7 +592,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -601,12 +601,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -619,10 +619,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -633,12 +633,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -669,11 +669,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -694,7 +694,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -718,7 +718,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -737,7 +737,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -758,12 +758,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -784,7 +784,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -807,7 +807,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -833,11 +833,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -870,7 +870,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4482,7 +4482,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4498,7 +4498,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4701,7 +4701,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4717,7 +4717,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5081,7 +5081,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5097,7 +5097,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5411,7 +5411,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5427,7 +5427,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5589,7 +5589,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5605,7 +5605,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5767,7 +5767,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5783,7 +5783,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6845,7 +6845,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6919,7 +6919,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6993,7 +6993,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7079,7 +7079,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7165,7 +7165,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7251,7 +7251,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7353,7 +7353,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7440,7 +7440,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7527,7 +7527,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7626,7 +7626,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7725,7 +7725,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7824,7 +7824,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7944,7 +7944,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8008,7 +8008,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8077,7 +8077,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8146,7 +8146,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8215,7 +8215,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5104,7 +5106,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5120,7 +5122,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5252,7 +5254,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5275,7 +5277,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5298,7 +5300,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5323,7 +5325,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5339,7 +5341,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5471,7 +5473,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5494,7 +5496,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5517,7 +5519,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5686,7 +5688,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5702,7 +5704,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5834,7 +5836,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5857,7 +5859,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5880,7 +5882,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5968,7 +5970,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -6002,7 +6004,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6018,7 +6020,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6116,7 +6118,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6139,7 +6141,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6173,7 +6175,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6189,7 +6191,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6287,7 +6289,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6310,7 +6312,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6344,7 +6346,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6360,7 +6362,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6628,7 +6630,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6651,7 +6653,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6674,7 +6676,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6697,7 +6699,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6720,7 +6722,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6743,7 +6745,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6766,7 +6768,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -163,17 +149,14 @@ const extensions3 = {
     behavior: ["-delete"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +177,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +222,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +267,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +312,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,110 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "delete",
-    behavior: extensions3.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -635,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +555,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +582,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +609,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +641,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +680,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +766,134 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "delete",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1306,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1355,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1373,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1421,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1467,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,483 +1519,50 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4433,7 +3687,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4520,28 +3776,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4606,23 +3875,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4649,23 +3928,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4692,23 +3981,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4735,23 +4034,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4778,23 +4087,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4821,23 +4140,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4864,23 +4193,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4936,23 +4275,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4975,9 +4324,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5012,23 +4368,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5051,9 +4417,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5090,8 +4463,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5626,23 +5003,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5665,9 +5052,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5893,9 +5287,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5981,9 +5382,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6152,9 +5560,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6323,9 +5738,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6790,7 +6212,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6805,7 +6229,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6820,7 +6246,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6835,7 +6263,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6850,7 +6280,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6865,7 +6297,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6880,7 +6314,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6895,7 +6331,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6910,7 +6348,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6924,7 +6364,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6940,7 +6382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6954,7 +6398,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6970,7 +6416,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6984,7 +6432,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7000,7 +6450,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7014,7 +6466,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7030,7 +6484,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7044,7 +6500,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7060,7 +6518,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7074,7 +6534,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7090,7 +6552,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7104,7 +6568,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7120,7 +6586,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7134,7 +6602,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7150,7 +6620,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7164,7 +6636,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7180,7 +6654,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7194,7 +6670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7210,7 +6688,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7224,7 +6704,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7240,18 +6722,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7261,17 +6749,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7287,24 +6781,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7319,9 +6826,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7356,11 +6869,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7382,9 +6900,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7419,11 +6943,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7445,9 +6974,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7487,11 +7022,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7520,9 +7060,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7562,11 +7108,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7595,9 +7146,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7637,11 +7194,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7670,9 +7232,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7707,11 +7275,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7761,9 +7334,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7798,11 +7377,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7823,18 +7407,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7869,11 +7464,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7894,18 +7494,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7945,11 +7556,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7977,18 +7593,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8028,11 +7655,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -8060,18 +7692,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8111,11 +7754,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8143,18 +7791,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8189,11 +7848,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8242,23 +7906,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8293,26 +7968,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8352,26 +8037,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8411,26 +8106,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8470,26 +8175,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8524,13 +8239,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -154,7 +154,7 @@ const filmsCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -190,7 +190,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -280,7 +280,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -325,7 +325,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -369,7 +369,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -498,11 +498,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques4 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -511,12 +511,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -529,7 +529,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -538,12 +538,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -556,7 +556,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -565,12 +565,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -583,7 +583,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -592,12 +592,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -610,10 +610,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -624,12 +624,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -660,11 +660,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -685,7 +685,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -709,7 +709,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -728,7 +728,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -749,7 +749,7 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
@@ -782,7 +782,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -805,7 +805,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -831,11 +831,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -868,7 +868,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4140,7 +4140,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4156,7 +4156,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4359,7 +4359,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4375,7 +4375,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4739,7 +4739,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4755,7 +4755,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5069,7 +5069,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5085,7 +5085,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5247,7 +5247,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5263,7 +5263,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6274,7 +6274,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6348,7 +6348,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6434,7 +6434,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6520,7 +6520,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6606,7 +6606,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6708,7 +6708,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6795,7 +6795,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6894,7 +6894,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6993,7 +6993,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7092,7 +7092,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7212,7 +7212,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7276,7 +7276,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7345,7 +7345,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7414,7 +7414,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7483,7 +7483,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1242,7 +1244,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -4701,7 +4703,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4717,7 +4719,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4849,7 +4851,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -4872,7 +4874,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -4895,7 +4897,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -4920,7 +4922,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4936,7 +4938,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5068,7 +5070,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5091,7 +5093,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5114,7 +5116,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5283,7 +5285,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5299,7 +5301,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5431,7 +5433,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5454,7 +5456,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5477,7 +5479,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5565,7 +5567,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5599,7 +5601,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5615,7 +5617,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5713,7 +5715,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -5736,7 +5738,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -5770,7 +5772,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5786,7 +5788,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6054,7 +6056,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6077,7 +6079,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6100,7 +6102,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6123,7 +6125,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6146,7 +6148,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6169,7 +6171,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6192,7 +6194,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,47 +99,23 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -163,17 +129,33 @@ const extensions3 = {
     behavior: ["-select -node -query:resource:list -query:resource:connection -update -insert -delete -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
-  attributes: filmsAttributes,
+  identifier: sql.identifier("d", "films"),
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +176,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +221,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +266,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +311,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,127 +484,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "read,all,update,create,delete,many",
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["code"],
-  description: undefined,
-  extensions: {
     tags: Object.create(null)
-  }
-}];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +519,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +546,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +573,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +600,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +632,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +671,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -935,30 +754,144 @@ const registry = makeRegistry({
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["code"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "read,all,update,create,delete,many",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1351,25 +1284,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1411,21 +1325,6 @@ const fetcher5 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1444,137 +1343,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1623,61 +1391,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1724,9 +1437,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1779,431 +1489,46 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4105,7 +3430,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4182,28 +3509,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4259,23 +3599,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4302,23 +3652,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4345,23 +3705,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4388,23 +3758,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4431,23 +3811,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4474,23 +3864,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4533,23 +3933,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4572,9 +3982,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4609,23 +4026,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4648,9 +4075,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4687,8 +4121,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5223,23 +4661,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5262,9 +4710,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5490,9 +4945,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5578,9 +5040,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5749,9 +5218,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6216,7 +5692,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6231,7 +5709,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6246,7 +5726,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6261,7 +5743,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6276,7 +5760,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6291,7 +5777,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6306,7 +5794,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6321,7 +5811,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6335,7 +5827,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6351,7 +5845,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6365,7 +5861,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6381,7 +5879,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6395,7 +5895,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6411,7 +5913,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6425,7 +5929,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6441,7 +5947,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6455,7 +5963,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6471,7 +5981,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6485,7 +5997,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6501,7 +6015,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6515,7 +6031,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6531,7 +6049,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6545,7 +6065,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6561,7 +6083,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6575,7 +6099,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6591,7 +6117,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6605,7 +6133,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6621,18 +6151,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -6642,17 +6178,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -6668,24 +6210,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6700,9 +6255,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6737,11 +6298,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6763,9 +6329,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6805,11 +6377,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6838,9 +6415,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6880,11 +6463,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6913,9 +6501,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6955,11 +6549,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6988,9 +6587,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7025,11 +6630,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7079,9 +6689,15 @@ export const plans = {
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7116,11 +6732,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7141,18 +6762,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7192,11 +6824,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7224,18 +6861,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7275,11 +6923,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7307,18 +6960,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7358,11 +7022,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -7390,18 +7059,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7436,11 +7116,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -7489,23 +7174,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7540,26 +7236,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7599,26 +7305,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7658,26 +7374,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7717,26 +7443,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7771,13 +7507,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -163,17 +149,14 @@ const extensions3 = {
     behavior: ["-update"]
   })
 };
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -194,26 +177,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -243,26 +222,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -292,26 +267,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -341,75 +312,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,110 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {
-    omit: "update",
-    behavior: extensions3.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -635,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -661,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -689,16 +555,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -717,16 +582,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -745,125 +609,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +641,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +680,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +766,134 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {
+          omit: "update",
+          behavior: extensions3.tags.behavior
+        }
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1306,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1355,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1373,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1421,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1467,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,475 +1519,50 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4410,7 +3672,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4497,28 +3761,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4583,23 +3860,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4626,23 +3913,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4669,23 +3966,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4712,23 +4019,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4755,23 +4072,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4798,23 +4125,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4841,23 +4178,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4913,23 +4260,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4952,9 +4309,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4989,23 +4353,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5028,9 +4402,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5067,8 +4448,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5603,23 +4988,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5642,9 +5037,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5870,9 +5272,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5958,9 +5367,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6129,9 +5545,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6300,9 +5723,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6767,7 +6197,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6782,7 +6214,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6797,7 +6231,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6812,7 +6248,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6827,7 +6265,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6842,7 +6282,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6857,7 +6299,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6872,7 +6316,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6887,7 +6333,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6901,7 +6349,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6917,7 +6367,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6931,7 +6383,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6947,7 +6401,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6961,7 +6417,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6977,7 +6435,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6991,7 +6451,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7007,7 +6469,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7021,7 +6485,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7037,7 +6503,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7051,7 +6519,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7067,7 +6537,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7081,7 +6553,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7097,7 +6571,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7111,7 +6587,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7127,7 +6605,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7141,7 +6621,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7157,7 +6639,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7171,7 +6655,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7187,7 +6673,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7201,7 +6689,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7217,18 +6707,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7238,17 +6734,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7264,24 +6766,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7296,9 +6811,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7333,11 +6854,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7359,9 +6885,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7396,11 +6928,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7422,9 +6959,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7464,11 +7007,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7497,9 +7045,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7539,11 +7093,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7572,9 +7131,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7614,11 +7179,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7647,9 +7217,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7684,11 +7260,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7738,9 +7319,15 @@ export const plans = {
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7775,11 +7362,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7800,18 +7392,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7851,11 +7454,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7883,18 +7491,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7934,11 +7553,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7966,18 +7590,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8017,11 +7652,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8049,18 +7689,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8095,11 +7746,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8148,23 +7804,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8199,26 +7866,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8253,26 +7930,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8312,26 +7999,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8371,26 +8068,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8430,26 +8137,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8484,13 +8201,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -162,17 +164,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -202,17 +204,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -654,8 +656,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -682,8 +684,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -710,8 +712,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5081,7 +5083,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5097,7 +5099,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5229,7 +5231,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5252,7 +5254,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5275,7 +5277,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5300,7 +5302,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5316,7 +5318,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5448,7 +5450,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5471,7 +5473,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5494,7 +5496,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5663,7 +5665,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5679,7 +5681,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5811,7 +5813,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5834,7 +5836,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5857,7 +5859,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5945,7 +5947,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5979,7 +5981,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5995,7 +5997,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6093,7 +6095,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6116,7 +6118,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6150,7 +6152,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6166,7 +6168,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6264,7 +6266,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6287,7 +6289,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6321,7 +6323,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6337,7 +6339,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6605,7 +6607,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6628,7 +6630,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6651,7 +6653,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6674,7 +6676,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6697,7 +6699,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6720,7 +6722,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6743,7 +6745,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -155,7 +155,7 @@ const filmsCodec = recordCodec({
   attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -191,7 +191,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -236,7 +236,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -281,7 +281,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -592,7 +592,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -601,12 +601,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -619,10 +619,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -633,12 +633,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -669,11 +669,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -694,7 +694,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -718,7 +718,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -737,7 +737,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -758,12 +758,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -784,7 +784,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -807,7 +807,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -833,11 +833,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -870,7 +870,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4467,7 +4467,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4483,7 +4483,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4686,7 +4686,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4702,7 +4702,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5066,7 +5066,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5082,7 +5082,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5396,7 +5396,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5412,7 +5412,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5574,7 +5574,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5590,7 +5590,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5752,7 +5752,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5768,7 +5768,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6830,7 +6830,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6904,7 +6904,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6978,7 +6978,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7064,7 +7064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7150,7 +7150,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7236,7 +7236,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7338,7 +7338,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7425,7 +7425,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7524,7 +7524,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7623,7 +7623,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7722,7 +7722,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7842,7 +7842,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7906,7 +7906,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7970,7 +7970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8039,7 +8039,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8108,7 +8108,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8177,7 +8177,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   })
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -398,17 +400,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -531,16 +533,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -553,14 +555,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -594,8 +596,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -651,8 +653,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -679,8 +681,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -707,8 +709,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -738,20 +740,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -792,8 +794,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -812,24 +814,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -876,8 +878,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -886,17 +888,17 @@ const registryConfig_pgResources_person_person = {
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -905,7 +907,7 @@ const registry = makeRegistry({
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -920,8 +922,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -931,8 +933,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -962,7 +964,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -981,7 +983,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -1000,7 +1002,7 @@ const registry = makeRegistry({
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1017,7 +1019,7 @@ const registry = makeRegistry({
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1034,7 +1036,7 @@ const registry = makeRegistry({
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1049,7 +1051,7 @@ const registry = makeRegistry({
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1262,7 +1264,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -5138,7 +5140,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5154,7 +5156,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5286,7 +5288,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
             }
           });
         }
@@ -5309,7 +5311,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5332,7 +5334,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
             }
           });
         }
@@ -5366,7 +5368,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
             }
           });
         }
@@ -5389,7 +5391,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5412,7 +5414,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
             }
           });
         }
@@ -5581,7 +5583,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5597,7 +5599,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5729,7 +5731,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -5752,7 +5754,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -5775,7 +5777,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -5863,7 +5865,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5897,7 +5899,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5913,7 +5915,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6011,7 +6013,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
             }
           });
         }
@@ -6034,7 +6036,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -6068,7 +6070,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6084,7 +6086,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6182,7 +6184,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
             }
           });
         }
@@ -6205,7 +6207,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -6239,7 +6241,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6255,7 +6257,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6523,7 +6525,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -6546,7 +6548,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -6569,7 +6571,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -6592,7 +6594,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6615,7 +6617,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6638,7 +6640,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6661,7 +6663,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -326,7 +326,7 @@ const tvShowsCodec = recordCodec({
   attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -370,7 +370,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -499,11 +499,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -511,7 +511,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -538,7 +538,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -547,12 +547,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -565,7 +565,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -574,12 +574,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -593,7 +593,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   }
 };
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
@@ -621,10 +621,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     }
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -635,12 +635,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -671,11 +671,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -696,7 +696,7 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -720,7 +720,7 @@ const registry = makeRegistry({
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -739,7 +739,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -760,12 +760,12 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -783,7 +783,7 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -806,7 +806,7 @@ const registry = makeRegistry({
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -832,11 +832,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -869,7 +869,7 @@ const registry = makeRegistry({
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4494,7 +4494,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4510,7 +4510,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4954,7 +4954,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4970,7 +4970,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5284,7 +5284,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5300,7 +5300,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5462,7 +5462,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5478,7 +5478,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5640,7 +5640,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5656,7 +5656,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6752,7 +6752,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6826,7 +6826,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6900,7 +6900,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6986,7 +6986,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7127,7 +7127,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7229,7 +7229,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7316,7 +7316,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7403,7 +7403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7502,7 +7502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7669,7 +7669,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7789,7 +7789,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7853,7 +7853,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7917,7 +7917,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7986,7 +7986,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8093,7 +8093,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -350,66 +320,58 @@ const extensions7 = {
     behavior: ["-order -orderBy"]
   })
 };
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -523,107 +485,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -632,15 +511,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -658,16 +528,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -686,16 +555,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -714,156 +582,48 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {
-    omit: "order",
-    behavior: extensions7.tags.behavior
-  }
-};
-const uniques7 = [{
-  isPrimary: true,
-  attributes: ["code"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
   }
-}];
+};
 const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["code"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
     tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      omit: "order",
+      behavior: extensions7.tags.behavior
     }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -883,7 +643,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -914,20 +682,82 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -938,27 +768,131 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1371,25 +1305,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1439,21 +1354,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1472,152 +1372,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1666,71 +1420,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1777,9 +1466,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1832,508 +1518,54 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFilmByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStudioById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvEpisodeByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTvShowByCode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmByCodeInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioByIdInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowByCodeInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFilmByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowByCodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4485,7 +3717,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4572,28 +3806,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4658,23 +3905,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4701,23 +3958,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4744,23 +4011,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4787,23 +4064,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4830,23 +4117,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4873,23 +4170,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         condition: {
           autoApplyAfterParentPlan: true,
@@ -4907,23 +4214,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4979,23 +4296,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         condition: {
           autoApplyAfterParentPlan: true,
@@ -5009,9 +4336,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5046,23 +4380,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5085,9 +4429,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5124,8 +4475,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5521,23 +4876,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5560,9 +4925,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5788,9 +5160,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5876,9 +5255,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6047,9 +5433,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6218,9 +5611,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6685,7 +6085,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6700,7 +6102,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6715,7 +6119,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6730,7 +6136,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6745,7 +6153,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6760,7 +6170,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6775,7 +6187,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6790,7 +6204,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6805,7 +6221,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6819,7 +6237,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6835,7 +6255,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6849,7 +6271,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6865,7 +6289,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6879,7 +6305,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6895,7 +6323,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6909,7 +6339,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6925,7 +6357,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6939,7 +6373,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6955,7 +6391,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6969,7 +6407,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6985,7 +6425,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6999,7 +6441,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7015,7 +6459,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilmByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7029,7 +6475,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7045,7 +6493,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudioById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7059,7 +6509,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7075,7 +6527,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7089,7 +6543,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7105,7 +6561,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisodeByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7119,7 +6577,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7135,7 +6595,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShowByCode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7149,7 +6611,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7165,18 +6629,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -7186,17 +6656,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -7212,24 +6688,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7244,9 +6733,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7281,11 +6776,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7307,9 +6807,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7344,11 +6850,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7370,9 +6881,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7412,11 +6929,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7445,9 +6967,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7487,11 +7015,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7520,9 +7053,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioByStudioId($record) {
       return pgResource_studiosPgResource.get({
         id: $record.get("result").get("studio_id")
@@ -7531,11 +7070,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7564,9 +7108,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7601,11 +7151,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7655,9 +7210,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7692,11 +7253,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -7717,18 +7283,29 @@ export const plans = {
   },
   UpdateFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmByCodeInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7763,11 +7340,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -7788,18 +7370,29 @@ export const plans = {
   },
   UpdateStudioByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioByIdInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7839,11 +7432,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7871,18 +7469,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7922,11 +7531,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7954,18 +7568,29 @@ export const plans = {
   },
   UpdateTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeByCodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioByStudioId($record) {
       return pgResource_studiosPgResource.get({
         id: $record.get("result").get("studio_id")
@@ -7974,11 +7599,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -8006,18 +7636,29 @@ export const plans = {
   },
   UpdateTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowByCodeInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8052,11 +7693,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -8105,23 +7751,34 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8156,26 +7813,36 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFilmByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8210,26 +7877,36 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStudioByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8269,26 +7946,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8328,26 +8015,36 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvEpisodeByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioByStudioId($record) {
       return pgResource_studiosPgResource.get({
         id: $record.get("result").get("studio_id")
@@ -8356,26 +8053,36 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTvShowByCodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowByCodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     code: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8410,13 +8117,17 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const usersAttributes = Object.assign(Object.create(null), {
@@ -85,10 +78,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const usersIdentifier = sql.identifier(...["partitions", "users"]);
-const usersCodecSpec = {
+const usersCodec = recordCodec({
   name: "users",
-  identifier: usersIdentifier,
+  identifier: sql.identifier("partitions", "users"),
   attributes: usersAttributes,
   description: undefined,
   extensions: {
@@ -101,8 +93,7 @@ const usersCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const usersCodec = recordCodec(usersCodecSpec);
+});
 const measurementsAttributes = Object.assign(Object.create(null), {
   timestamp: {
     description: undefined,
@@ -141,35 +132,22 @@ const measurementsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "partitions",
-    name: "measurements"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["partitions", "measurements"];
-const measurementsIdentifier = sql.identifier(...parts2);
-const measurementsCodecSpec = {
+const measurementsCodec = recordCodec({
   name: "measurements",
-  identifier: measurementsIdentifier,
+  identifier: sql.identifier("partitions", "measurements"),
   attributes: measurementsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const measurementsCodec = recordCodec(measurementsCodecSpec);
-const extensions3 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "partitions",
-    name: "users"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements"
+    },
+    tags: Object.create(null)
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -187,16 +165,15 @@ const registryConfig_pgResources_users_users = {
   uniques,
   isVirtual: false,
   description: undefined,
-  extensions: extensions3
-};
-const extensions4 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "partitions",
-    name: "measurements"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "users"
+    },
+    tags: {}
+  }
 };
 const uniques2 = [{
   isPrimary: true,
@@ -215,7 +192,15 @@ const registryConfig_pgResources_measurements_measurements = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions4
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "partitions",
+      name: "measurements"
+    },
+    tags: {}
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -347,21 +332,6 @@ const fetcher2 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Measurement);
-function Query_allUsers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUsers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUsers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUsers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUsers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -380,216 +350,22 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allMeasurements_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMeasurements_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMeasurements_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMeasurements_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMeasurements_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function User_measurementsByUserId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function User_measurementsByUserId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function User_measurementsByUserId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function User_measurementsByUserId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function User_measurementsByUserId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function MeasurementsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MeasurementsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MeasurementsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function UsersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UsersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UsersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMeasurement_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.User, $nodeId);
 };
-function Mutation_updateUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateUserById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Measurement, $nodeId);
 };
-function Mutation_updateMeasurement_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMeasurementByTimestampAndKey_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.User, $nodeId);
 };
-function Mutation_deleteUser_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteUserById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Measurement, $nodeId);
 };
-function Mutation_deleteMeasurement_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMeasurementByTimestampAndKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function CreateUserPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUserInput_user_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMeasurementPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMeasurementPayload_measurementPlan($object) {
-  return $object.get("result");
-}
-function CreateMeasurementPayload_queryPlan() {
-  return rootValue();
-}
-function CreateMeasurementInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMeasurementInput_measurement_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function UpdateUserPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserInput_userPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUserByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUserByIdInput_userPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMeasurementPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMeasurementPayload_measurementPlan($object) {
-  return $object.get("result");
-}
-function UpdateMeasurementPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMeasurementInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMeasurementInput_measurementPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMeasurementByTimestampAndKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMeasurementByTimestampAndKeyInput_measurementPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteUserPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteUserPayload_userPlan($object) {
-  return $object.get("result");
-}
-function DeleteUserPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteUserInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUserByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMeasurementPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMeasurementPayload_measurementPlan($object) {
-  return $object.get("result");
-}
-function DeleteMeasurementPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMeasurementInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMeasurementByTimestampAndKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -1294,7 +1070,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -1354,23 +1132,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUsers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1397,23 +1185,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMeasurements_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMeasurements_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMeasurements_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMeasurements_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMeasurements_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1456,23 +1254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_measurementsByUserId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_measurementsByUserId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_measurementsByUserId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_measurementsByUserId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: User_measurementsByUserId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1495,9 +1303,16 @@ export const plans = {
   },
   MeasurementsConnection: {
     __assertStep: ConnectionStep,
-    nodes: MeasurementsConnection_nodesPlan,
-    edges: MeasurementsConnection_edgesPlan,
-    pageInfo: MeasurementsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1537,8 +1352,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1815,9 +1634,16 @@ export const plans = {
   },
   UsersConnection: {
     __assertStep: ConnectionStep,
-    nodes: UsersConnection_nodesPlan,
-    edges: UsersConnection_edgesPlan,
-    pageInfo: UsersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1997,7 +1823,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2012,7 +1840,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMeasurement_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2026,7 +1856,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2042,7 +1874,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUserById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2056,7 +1890,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMeasurement_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2073,7 +1909,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMeasurementByTimestampAndKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2087,7 +1925,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUser_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2103,7 +1943,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUserById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2117,7 +1959,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMeasurement_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2134,16 +1978,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMeasurementByTimestampAndKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateUserPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUserPayload_clientMutationIdPlan,
-    user: CreateUserPayload_userPlan,
-    query: CreateUserPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2178,11 +2030,16 @@ export const plans = {
   },
   CreateUserInput: {
     clientMutationId: {
-      applyPlan: CreateUserInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     user: {
-      applyPlan: CreateUserInput_user_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2204,9 +2061,15 @@ export const plans = {
   },
   CreateMeasurementPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMeasurementPayload_clientMutationIdPlan,
-    measurement: CreateMeasurementPayload_measurementPlan,
-    query: CreateMeasurementPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    measurement($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     measurementEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2246,11 +2109,16 @@ export const plans = {
   },
   CreateMeasurementInput: {
     clientMutationId: {
-      applyPlan: CreateMeasurementInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     measurement: {
-      applyPlan: CreateMeasurementInput_measurement_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2286,9 +2154,15 @@ export const plans = {
   },
   UpdateUserPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateUserPayload_clientMutationIdPlan,
-    user: UpdateUserPayload_userPlan,
-    query: UpdateUserPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2323,11 +2197,16 @@ export const plans = {
   },
   UpdateUserInput: {
     clientMutationId: {
-      applyPlan: UpdateUserInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     userPatch: {
-      applyPlan: UpdateUserInput_userPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UserPatch: {
@@ -2348,18 +2227,29 @@ export const plans = {
   },
   UpdateUserByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateUserByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     userPatch: {
-      applyPlan: UpdateUserByIdInput_userPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateMeasurementPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMeasurementPayload_clientMutationIdPlan,
-    measurement: UpdateMeasurementPayload_measurementPlan,
-    query: UpdateMeasurementPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    measurement($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     measurementEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2399,11 +2289,16 @@ export const plans = {
   },
   UpdateMeasurementInput: {
     clientMutationId: {
-      applyPlan: UpdateMeasurementInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     measurementPatch: {
-      applyPlan: UpdateMeasurementInput_measurementPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MeasurementPatch: {
@@ -2438,24 +2333,35 @@ export const plans = {
   },
   UpdateMeasurementByTimestampAndKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateMeasurementByTimestampAndKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     timestamp: undefined,
     key: undefined,
     measurementPatch: {
-      applyPlan: UpdateMeasurementByTimestampAndKeyInput_measurementPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteUserPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteUserPayload_clientMutationIdPlan,
-    user: DeleteUserPayload_userPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    user($object) {
+      return $object.get("result");
+    },
     deletedUserId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.User.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteUserPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     userEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2490,26 +2396,36 @@ export const plans = {
   },
   DeleteUserInput: {
     clientMutationId: {
-      applyPlan: DeleteUserInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteUserByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteUserByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMeasurementPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMeasurementPayload_clientMutationIdPlan,
-    measurement: DeleteMeasurementPayload_measurementPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    measurement($object) {
+      return $object.get("result");
+    },
     deletedMeasurementId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Measurement.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMeasurementPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     measurementEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2549,13 +2465,17 @@ export const plans = {
   },
   DeleteMeasurementInput: {
     clientMutationId: {
-      applyPlan: DeleteMeasurementInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMeasurementByTimestampAndKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteMeasurementByTimestampAndKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     timestamp: undefined,
     key: undefined

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -68,7 +68,7 @@ const usersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -92,7 +92,7 @@ const usersCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const measurementsAttributes = Object.assign(Object.create(null), {
   timestamp: {
@@ -146,9 +146,9 @@ const measurementsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const usersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -157,12 +157,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_users_users = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "users",
   identifier: "main.partitions.users",
   from: usersCodec.sqlType,
   codec: usersCodec,
-  uniques,
+  uniques: usersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -175,7 +175,7 @@ const registryConfig_pgResources_users_users = {
     tags: {}
   }
 };
-const uniques2 = [{
+const measurementsUniques = [{
   isPrimary: true,
   attributes: ["timestamp", "key"],
   description: undefined,
@@ -184,12 +184,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_measurements_measurements = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "measurements",
   identifier: "main.partitions.measurements",
   from: measurementsCodec.sqlType,
   codec: measurementsCodec,
-  uniques: uniques2,
+  uniques: measurementsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -1371,7 +1371,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        measurementsUniques[0].attributes.forEach(attributeName => {
           const attribute = measurementsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1387,7 +1387,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        measurementsUniques[0].attributes.forEach(attributeName => {
           const attribute = measurementsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1663,7 +1663,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        usersUniques[0].attributes.forEach(attributeName => {
           const attribute = usersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1679,7 +1679,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        usersUniques[0].attributes.forEach(attributeName => {
           const attribute = usersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2006,7 +2006,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = usersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2080,7 +2080,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = measurementsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2173,7 +2173,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = usersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2260,7 +2260,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = measurementsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2372,7 +2372,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = usersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2436,7 +2436,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = measurementsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -87,10 +87,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_alwaysAsIdentity = {
+const alwaysAsIdentityIdentifier = sql.identifier(...["pg11", "always_as_identity"]);
+const alwaysAsIdentityCodecSpec = {
   name: "alwaysAsIdentity",
-  identifier: sql.identifier(...["pg11", "always_as_identity"]),
-  attributes,
+  identifier: alwaysAsIdentityIdentifier,
+  attributes: alwaysAsIdentityAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -103,8 +104,8 @@ const spec_alwaysAsIdentity = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity = recordCodec(spec_alwaysAsIdentity);
-const attributes2 = Object.assign(Object.create(null), {
+const alwaysAsIdentityCodec = recordCodec(alwaysAsIdentityCodecSpec);
+const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -134,17 +135,17 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["pg11", "by_default_as_identity"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_byDefaultAsIdentity = {
+const byDefaultAsIdentityIdentifier = sql.identifier(...parts2);
+const byDefaultAsIdentityCodecSpec = {
   name: "byDefaultAsIdentity",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: byDefaultAsIdentityIdentifier,
+  attributes: byDefaultAsIdentityAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity = recordCodec(spec_byDefaultAsIdentity);
-const attributes3 = Object.assign(Object.create(null), {
+const byDefaultAsIdentityCodec = recordCodec(byDefaultAsIdentityCodecSpec);
+const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -201,16 +202,16 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["pg11", "network"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_network = {
+const networkIdentifier = sql.identifier(...parts3);
+const networkCodecSpec = {
   name: "network",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: networkIdentifier,
+  attributes: networkAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_network_network = recordCodec(spec_network);
+const networkCodec = recordCodec(networkCodecSpec);
 const extensions4 = {
   pg: {
     serviceName: "main",
@@ -219,7 +220,7 @@ const extensions4 = {
   },
   tags: Object.create(null)
 };
-const extensions5 = {
+const bigintDomainArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -227,7 +228,7 @@ const extensions5 = {
   },
   tags: Object.create(null)
 };
-const extensions6 = {
+const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -236,26 +237,26 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "bigint_domain"];
-const sqlIdent4 = sql.identifier(...parts4);
-const innerCodec_bigintDomain = domainOfCodec(TYPES.bigint, "bigintDomain", sqlIdent4, {
+const bigintDomainIdentifier = sql.identifier(...parts4);
+const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", bigintDomainIdentifier, {
   description: undefined,
-  extensions: extensions6,
+  extensions: extensions5,
   notNull: false
 });
-const innerCodec_bigintDomainArray = listOfCodec(innerCodec_bigintDomain, {
-  extensions: extensions5,
+const bigintDomainArrayCodec = listOfCodec(bigintDomainCodec, {
+  extensions: bigintDomainArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "bigintDomainArray"
 });
 const parts5 = ["c", "bigint_domain_array_domain"];
-const sqlIdent5 = sql.identifier(...parts5);
-const registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain = domainOfCodec(innerCodec_bigintDomainArray, "bigintDomainArrayDomain", sqlIdent5, {
+const bigintDomainArrayDomainIdentifier = sql.identifier(...parts5);
+const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", bigintDomainArrayDomainIdentifier, {
   description: undefined,
   extensions: extensions4,
   notNull: false
 });
-const extensions7 = {
+const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "pg11",
@@ -263,7 +264,7 @@ const extensions7 = {
   },
   tags: Object.create(null)
 };
-const extensions8 = {
+const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -272,16 +273,15 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts6 = ["b", "color"];
-const sqlIdent6 = sql.identifier(...parts6);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent6,
+  identifier: sql.identifier(...parts6),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions8
+  extensions: extensions7
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions9 = {
+const extensions8 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -290,16 +290,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts7 = ["b", "enum_caps"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts7);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent7,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions9
+  extensions: extensions8
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions10 = {
+const extensions9 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -308,15 +308,15 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["b", "enum_with_empty_string"];
-const sqlIdent8 = sql.identifier(...parts8);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts8);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent8,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions10
+  extensions: extensions9
 });
-const attributes4 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -337,7 +337,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -355,7 +355,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -364,7 +364,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -390,7 +390,7 @@ const attributes4 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions10 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -400,24 +400,24 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["c", "compound_type"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts9);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent9,
-  attributes: attributes4,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions11,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const innerCodec_compoundType = recordCodec(spec_compoundType);
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
 const parts10 = ["pg11", "domain_constrained_compound_type"];
-const sqlIdent10 = sql.identifier(...parts10);
-const registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType = domainOfCodec(innerCodec_compoundType, "domainConstrainedCompoundType", sqlIdent10, {
+const domainConstrainedCompoundTypeIdentifier = sql.identifier(...parts10);
+const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", domainConstrainedCompoundTypeIdentifier, {
   description: undefined,
-  extensions: extensions7,
+  extensions: extensions6,
   notNull: false
 });
-const attributes5 = Object.assign(Object.create(null), {
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -447,7 +447,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   bigint_domain_array_domain: {
     description: undefined,
-    codec: registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain,
+    codec: bigintDomainArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -456,7 +456,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   domain_constrained_compound_type: {
     description: undefined,
-    codec: registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType,
+    codec: domainConstrainedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -464,7 +464,7 @@ const attributes5 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -474,17 +474,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts11 = ["pg11", "types"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts11);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent11,
-  attributes: attributes5,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions13 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const extensions12 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -501,7 +501,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
+const extensions13 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -518,7 +518,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions15 = {
+const extensions14 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -535,7 +535,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions16 = {
+const extensions15 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -554,11 +554,11 @@ const uniques4 = [{
 }];
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    alwaysAsIdentity: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity,
+    alwaysAsIdentity: alwaysAsIdentityCodec,
     int4: TYPES.int,
     text: TYPES.text,
-    byDefaultAsIdentity: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity,
-    network: registryConfig_pgCodecs_network_network,
+    byDefaultAsIdentity: byDefaultAsIdentityCodec,
+    network: networkCodec,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr,
@@ -567,63 +567,63 @@ const registry = makeRegistry({
     bpchar: TYPES.bpchar,
     regrole: TYPES.regrole,
     regnamespace: TYPES.regnamespace,
-    bigintDomainArrayDomain: registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain,
-    bigintDomain: innerCodec_bigintDomain,
+    bigintDomainArrayDomain: bigintDomainArrayDomainCodec,
+    bigintDomain: bigintDomainCodec,
     int8: TYPES.bigint,
-    bigintDomainArray: innerCodec_bigintDomainArray,
-    domainConstrainedCompoundType: registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType,
-    compoundType: innerCodec_compoundType,
-    color: attributes_c_codec_color,
+    bigintDomainArray: bigintDomainArrayCodec,
+    domainConstrainedCompoundType: domainConstrainedCompoundTypeCodec,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     interval: TYPES.interval,
-    types: registryConfig_pgCodecs_types_types
+    types: typesCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
       executor: executor_mainPgExecutor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
-      from: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.sqlType,
-      codec: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity,
+      from: alwaysAsIdentityCodec.sqlType,
+      codec: alwaysAsIdentityCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: extensions12
     },
     by_default_as_identity: {
       executor: executor_mainPgExecutor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
-      from: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.sqlType,
-      codec: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity,
+      from: byDefaultAsIdentityCodec.sqlType,
+      codec: byDefaultAsIdentityCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
-      extensions: extensions14
+      extensions: extensions13
     },
     network: {
       executor: executor_mainPgExecutor,
       name: "network",
       identifier: "main.pg11.network",
-      from: registryConfig_pgCodecs_network_network.sqlType,
-      codec: registryConfig_pgCodecs_network_network,
+      from: networkCodec.sqlType,
+      codec: networkCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions15
+      extensions: extensions14
     },
     types: {
       executor: executor_mainPgExecutor,
       name: "types",
       identifier: "main.pg11.types",
-      from: registryConfig_pgCodecs_types_types.sqlType,
-      codec: registryConfig_pgCodecs_types_types,
+      from: typesCodec.sqlType,
+      codec: typesCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions16
+      extensions: extensions15
     }
   }),
   pgRelations: Object.create(null)
@@ -3030,7 +3030,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.attributes[attributeName];
+          const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3046,7 +3046,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.attributes[attributeName];
+          const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3144,7 +3144,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.id.codec)}`;
             }
           });
         }
@@ -3167,7 +3167,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.t.codec)}`;
             }
           });
         }
@@ -3201,7 +3201,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.attributes[attributeName];
+          const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3217,7 +3217,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.attributes[attributeName];
+          const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3315,7 +3315,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.id.codec)}`;
             }
           });
         }
@@ -3338,7 +3338,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.t.codec)}`;
             }
           });
         }
@@ -3372,7 +3372,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3388,7 +3388,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3588,7 +3588,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
             }
           });
         }
@@ -3611,7 +3611,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
             }
           });
         }
@@ -3634,7 +3634,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
             }
           });
         }
@@ -3657,7 +3657,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -3680,7 +3680,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr8",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.macaddr8.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr8.codec)}`;
             }
           });
         }
@@ -3714,7 +3714,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3730,7 +3730,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3896,7 +3896,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -3919,7 +3919,7 @@ export const plans = {
             type: "attribute",
             attribute: "regrole",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.regrole.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regrole.codec)}`;
             }
           });
         }
@@ -3942,7 +3942,7 @@ export const plans = {
             type: "attribute",
             attribute: "regnamespace",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.regnamespace.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regnamespace.codec)}`;
             }
           });
         }
@@ -3965,7 +3965,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint_domain_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.bigint_domain_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint_domain_array_domain.codec)}`;
             }
           });
         }
@@ -3988,7 +3988,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain_constrained_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.domain_constrained_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain_constrained_compound_type.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
@@ -87,10 +80,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const alwaysAsIdentityIdentifier = sql.identifier(...["pg11", "always_as_identity"]);
-const alwaysAsIdentityCodecSpec = {
+const alwaysAsIdentityCodec = recordCodec({
   name: "alwaysAsIdentity",
-  identifier: alwaysAsIdentityIdentifier,
+  identifier: sql.identifier("pg11", "always_as_identity"),
   attributes: alwaysAsIdentityAttributes,
   description: undefined,
   extensions: {
@@ -103,8 +95,7 @@ const alwaysAsIdentityCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const alwaysAsIdentityCodec = recordCodec(alwaysAsIdentityCodecSpec);
+});
 const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -125,26 +116,22 @@ const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "by_default_as_identity"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["pg11", "by_default_as_identity"];
-const byDefaultAsIdentityIdentifier = sql.identifier(...parts2);
-const byDefaultAsIdentityCodecSpec = {
+const byDefaultAsIdentityCodec = recordCodec({
   name: "byDefaultAsIdentity",
-  identifier: byDefaultAsIdentityIdentifier,
+  identifier: sql.identifier("pg11", "by_default_as_identity"),
   attributes: byDefaultAsIdentityAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "by_default_as_identity"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const byDefaultAsIdentityCodec = recordCodec(byDefaultAsIdentityCodecSpec);
+});
 const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -192,229 +179,200 @@ const networkAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "network"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["pg11", "network"];
-const networkIdentifier = sql.identifier(...parts3);
-const networkCodecSpec = {
+const networkCodec = recordCodec({
   name: "network",
-  identifier: networkIdentifier,
+  identifier: sql.identifier("pg11", "network"),
   attributes: networkAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "network"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const networkCodec = recordCodec(networkCodecSpec);
-const extensions4 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "bigint_domain_array_domain"
-  },
-  tags: Object.create(null)
-};
-const bigintDomainArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_bigint_domain"
-  },
-  tags: Object.create(null)
-};
-const extensions5 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "bigint_domain"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "bigint_domain"];
-const bigintDomainIdentifier = sql.identifier(...parts4);
-const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", bigintDomainIdentifier, {
+});
+const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", sql.identifier("c", "bigint_domain"), {
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "bigint_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
 const bigintDomainArrayCodec = listOfCodec(bigintDomainCodec, {
-  extensions: bigintDomainArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_bigint_domain"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "bigintDomainArray"
 });
-const parts5 = ["c", "bigint_domain_array_domain"];
-const bigintDomainArrayDomainIdentifier = sql.identifier(...parts5);
-const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", bigintDomainArrayDomainIdentifier, {
+const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", sql.identifier("c", "bigint_domain_array_domain"), {
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "bigint_domain_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions6 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "domain_constrained_compound_type"
-  },
-  tags: Object.create(null)
-};
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["b", "color"];
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts6),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions7
-});
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions8 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts7);
-const enumCapsCodec = enumCodec({
-  name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
-  description: undefined,
-  extensions: extensions8
-});
-const enumLabels3 = ["", "one", "two"];
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts8);
-const enumWithEmptyStringCodec = enumCodec({
-  name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
-  description: undefined,
-  extensions: extensions9
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions10 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts9);
-const compoundTypeCodecSpec = {
-  name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
-  description: "Awesome feature!",
-  extensions: extensions10,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const parts10 = ["pg11", "domain_constrained_compound_type"];
-const domainConstrainedCompoundTypeIdentifier = sql.identifier(...parts10);
-const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", domainConstrainedCompoundTypeIdentifier, {
+const enumCapsCodec = enumCodec({
+  name: "enumCaps",
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
+});
+const enumWithEmptyStringCodec = enumCodec({
+  name: "enumWithEmptyString",
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
+  }
+});
+const compoundTypeCodec = recordCodec({
+  name: "compoundType",
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: "Awesome feature!",
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
+  },
+  executor: executor_mainPgExecutor
+});
+const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", sql.identifier("pg11", "domain_constrained_compound_type"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "domain_constrained_compound_type"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
 const typesAttributes = Object.assign(Object.create(null), {
@@ -464,35 +422,22 @@ const typesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "types"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["pg11", "types"];
-const typesIdentifier = sql.identifier(...parts11);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("pg11", "types"),
   attributes: typesAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "always_as_identity"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "types"
+    },
+    tags: Object.create(null)
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -501,15 +446,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "by_default_as_identity"
-  },
-  tags: {}
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -518,15 +454,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "network"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -535,15 +462,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "types"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -590,7 +508,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "always_as_identity"
+        },
+        tags: {}
+      }
     },
     by_default_as_identity: {
       executor: executor_mainPgExecutor,
@@ -601,7 +527,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "by_default_as_identity"
+        },
+        tags: {}
+      }
     },
     network: {
       executor: executor_mainPgExecutor,
@@ -612,7 +546,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions14
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "network"
+        },
+        tags: {}
+      }
     },
     types: {
       executor: executor_mainPgExecutor,
@@ -623,7 +565,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions15
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "types"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -761,21 +711,6 @@ const fetcher4 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Type);
-function Query_allAlwaysAsIdentities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAlwaysAsIdentities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -794,424 +729,39 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allByDefaultAsIdentities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allByDefaultAsIdentities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNetworks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNetworks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNetworks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNetworks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNetworks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_domainConstrainedCompoundTypePgResource = registry.pgResources["frmcdc_domainConstrainedCompoundType"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
-function AlwaysAsIdentitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AlwaysAsIdentitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AlwaysAsIdentitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function ByDefaultAsIdentitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ByDefaultAsIdentitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ByDefaultAsIdentitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NetworksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NetworksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NetworksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.AlwaysAsIdentity, $nodeId);
 };
-function Mutation_updateAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAlwaysAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ByDefaultAsIdentity, $nodeId);
 };
-function Mutation_updateByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateByDefaultAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_updateNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.AlwaysAsIdentity, $nodeId);
 };
-function Mutation_deleteAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAlwaysAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ByDefaultAsIdentity, $nodeId);
 };
-function Mutation_deleteByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteByDefaultAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_deleteNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function CreateAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAlwaysAsIdentityInput_alwaysAsIdentity_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function CreateByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateByDefaultAsIdentityInput_byDefaultAsIdentity_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function CreateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNetworkInput_network_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function UpdateAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAlwaysAsIdentityInput_alwaysAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAlwaysAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAlwaysAsIdentityByIdInput_alwaysAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function UpdateByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateByDefaultAsIdentityInput_byDefaultAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateByDefaultAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateByDefaultAsIdentityByIdInput_byDefaultAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function UpdateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkByIdInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function DeleteAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAlwaysAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function DeleteByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteByDefaultAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function DeleteNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -2593,7 +2143,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -2689,23 +2241,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2732,23 +2294,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2775,23 +2347,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2818,23 +2400,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2987,18 +2579,37 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   AlwaysAsIdentitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: AlwaysAsIdentitiesConnection_nodesPlan,
-    edges: AlwaysAsIdentitiesConnection_edgesPlan,
-    pageInfo: AlwaysAsIdentitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3014,8 +2625,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -3178,9 +2793,16 @@ export const plans = {
   },
   ByDefaultAsIdentitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ByDefaultAsIdentitiesConnection_nodesPlan,
-    edges: ByDefaultAsIdentitiesConnection_edgesPlan,
-    pageInfo: ByDefaultAsIdentitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3349,9 +2971,16 @@ export const plans = {
   },
   NetworksConnection: {
     __assertStep: ConnectionStep,
-    nodes: NetworksConnection_nodesPlan,
-    edges: NetworksConnection_edgesPlan,
-    pageInfo: NetworksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3691,9 +3320,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4076,7 +3712,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4091,7 +3729,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4106,7 +3746,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4121,7 +3763,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4135,7 +3779,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4151,7 +3797,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAlwaysAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4165,7 +3813,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4181,7 +3831,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateByDefaultAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4195,7 +3847,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4211,7 +3865,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4225,7 +3881,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4241,7 +3899,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4255,7 +3915,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4271,7 +3933,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAlwaysAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4285,7 +3949,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4301,7 +3967,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteByDefaultAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4315,7 +3983,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4331,7 +4001,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4345,7 +4017,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4361,16 +4035,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateAlwaysAsIdentityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: CreateAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
-    query: CreateAlwaysAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4405,11 +4087,16 @@ export const plans = {
   },
   CreateAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: CreateAlwaysAsIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     alwaysAsIdentity: {
-      applyPlan: CreateAlwaysAsIdentityInput_alwaysAsIdentity_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4424,9 +4111,15 @@ export const plans = {
   },
   CreateByDefaultAsIdentityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: CreateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
-    query: CreateByDefaultAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4461,11 +4154,16 @@ export const plans = {
   },
   CreateByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: CreateByDefaultAsIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     byDefaultAsIdentity: {
-      applyPlan: CreateByDefaultAsIdentityInput_byDefaultAsIdentity_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4487,9 +4185,15 @@ export const plans = {
   },
   CreateNetworkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNetworkPayload_clientMutationIdPlan,
-    network: CreateNetworkPayload_networkPlan,
-    query: CreateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4524,11 +4228,16 @@ export const plans = {
   },
   CreateNetworkInput: {
     clientMutationId: {
-      applyPlan: CreateNetworkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     network: {
-      applyPlan: CreateNetworkInput_network_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4571,9 +4280,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4608,11 +4323,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4655,9 +4375,15 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: UpdateAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
-    query: UpdateAlwaysAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4692,11 +4418,16 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: UpdateAlwaysAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     alwaysAsIdentityPatch: {
-      applyPlan: UpdateAlwaysAsIdentityInput_alwaysAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AlwaysAsIdentityPatch: {
@@ -4710,18 +4441,29 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAlwaysAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     alwaysAsIdentityPatch: {
-      applyPlan: UpdateAlwaysAsIdentityByIdInput_alwaysAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateByDefaultAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: UpdateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
-    query: UpdateByDefaultAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4756,11 +4498,16 @@ export const plans = {
   },
   UpdateByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: UpdateByDefaultAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     byDefaultAsIdentityPatch: {
-      applyPlan: UpdateByDefaultAsIdentityInput_byDefaultAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ByDefaultAsIdentityPatch: {
@@ -4781,18 +4528,29 @@ export const plans = {
   },
   UpdateByDefaultAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateByDefaultAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     byDefaultAsIdentityPatch: {
-      applyPlan: UpdateByDefaultAsIdentityByIdInput_byDefaultAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNetworkPayload_clientMutationIdPlan,
-    network: UpdateNetworkPayload_networkPlan,
-    query: UpdateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4827,11 +4585,16 @@ export const plans = {
   },
   UpdateNetworkInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NetworkPatch: {
@@ -4873,18 +4636,29 @@ export const plans = {
   },
   UpdateNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkByIdInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4919,11 +4693,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -4965,23 +4744,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteAlwaysAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: DeleteAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
     deletedAlwaysAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.AlwaysAsIdentity.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteAlwaysAsIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5016,26 +4806,36 @@ export const plans = {
   },
   DeleteAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: DeleteAlwaysAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteAlwaysAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAlwaysAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteByDefaultAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: DeleteByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
     deletedByDefaultAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ByDefaultAsIdentity.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteByDefaultAsIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5070,26 +4870,36 @@ export const plans = {
   },
   DeleteByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: DeleteByDefaultAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteByDefaultAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteByDefaultAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNetworkPayload_clientMutationIdPlan,
-    network: DeleteNetworkPayload_networkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNetworkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5124,26 +4934,36 @@ export const plans = {
   },
   DeleteNetworkInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5178,13 +4998,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -70,7 +70,7 @@ const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -94,7 +94,7 @@ const alwaysAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
@@ -130,7 +130,7 @@ const byDefaultAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const networkAttributes = Object.assign(Object.create(null), {
   id: {
@@ -193,7 +193,7 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", sql.identifier("c", "bigint_domain"), {
   description: undefined,
@@ -361,7 +361,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", sql.identifier("pg11", "domain_constrained_compound_type"), {
   description: undefined,
@@ -436,9 +436,9 @@ const typesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const always_as_identityUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -446,7 +446,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const by_default_as_identityUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -454,7 +454,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const networkUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -462,7 +462,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -500,12 +500,12 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
       from: alwaysAsIdentityCodec.sqlType,
       codec: alwaysAsIdentityCodec,
-      uniques,
+      uniques: always_as_identityUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -519,12 +519,12 @@ const registry = makeRegistry({
       }
     },
     by_default_as_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
       from: byDefaultAsIdentityCodec.sqlType,
       codec: byDefaultAsIdentityCodec,
-      uniques: uniques2,
+      uniques: by_default_as_identityUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -538,12 +538,12 @@ const registry = makeRegistry({
       }
     },
     network: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "network",
       identifier: "main.pg11.network",
       from: networkCodec.sqlType,
       codec: networkCodec,
-      uniques: uniques3,
+      uniques: networkUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -557,12 +557,12 @@ const registry = makeRegistry({
       }
     },
     types: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types",
       identifier: "main.pg11.types",
       from: typesCodec.sqlType,
       codec: typesCodec,
-      uniques: uniques4,
+      uniques: typesUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -2644,7 +2644,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        always_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2660,7 +2660,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        always_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2822,7 +2822,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        by_default_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2838,7 +2838,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        by_default_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3000,7 +3000,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3016,7 +3016,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3349,7 +3349,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3365,7 +3365,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4063,7 +4063,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4130,7 +4130,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4204,7 +4204,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4299,7 +4299,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4394,7 +4394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4474,7 +4474,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4561,7 +4561,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4669,7 +4669,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4782,7 +4782,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4846,7 +4846,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4910,7 +4910,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4974,7 +4974,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -70,7 +70,7 @@ const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -94,7 +94,7 @@ const alwaysAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
@@ -130,7 +130,7 @@ const byDefaultAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const networkAttributes = Object.assign(Object.create(null), {
   id: {
@@ -193,7 +193,7 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", sql.identifier("c", "bigint_domain"), {
   description: undefined,
@@ -361,7 +361,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", sql.identifier("pg11", "domain_constrained_compound_type"), {
   description: undefined,
@@ -436,9 +436,9 @@ const typesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const always_as_identityUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -446,7 +446,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const by_default_as_identityUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -454,7 +454,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const networkUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -462,7 +462,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -500,12 +500,12 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
       from: alwaysAsIdentityCodec.sqlType,
       codec: alwaysAsIdentityCodec,
-      uniques,
+      uniques: always_as_identityUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -519,12 +519,12 @@ const registry = makeRegistry({
       }
     },
     by_default_as_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
       from: byDefaultAsIdentityCodec.sqlType,
       codec: byDefaultAsIdentityCodec,
-      uniques: uniques2,
+      uniques: by_default_as_identityUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -538,12 +538,12 @@ const registry = makeRegistry({
       }
     },
     network: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "network",
       identifier: "main.pg11.network",
       from: networkCodec.sqlType,
       codec: networkCodec,
-      uniques: uniques3,
+      uniques: networkUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -557,12 +557,12 @@ const registry = makeRegistry({
       }
     },
     types: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types",
       identifier: "main.pg11.types",
       from: typesCodec.sqlType,
       codec: typesCodec,
-      uniques: uniques4,
+      uniques: typesUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -2653,7 +2653,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        always_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2669,7 +2669,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        always_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2831,7 +2831,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        by_default_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2847,7 +2847,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        by_default_as_identityUniques[0].attributes.forEach(attributeName => {
           const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3009,7 +3009,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3025,7 +3025,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        networkUniques[0].attributes.forEach(attributeName => {
           const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3358,7 +3358,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -3374,7 +3374,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4072,7 +4072,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4139,7 +4139,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4213,7 +4213,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4308,7 +4308,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4403,7 +4403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4483,7 +4483,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4570,7 +4570,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4678,7 +4678,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4791,7 +4791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = always_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4855,7 +4855,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = by_default_as_identityUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4919,7 +4919,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = networkUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -4983,7 +4983,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
@@ -87,10 +80,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const alwaysAsIdentityIdentifier = sql.identifier(...["pg11", "always_as_identity"]);
-const alwaysAsIdentityCodecSpec = {
+const alwaysAsIdentityCodec = recordCodec({
   name: "alwaysAsIdentity",
-  identifier: alwaysAsIdentityIdentifier,
+  identifier: sql.identifier("pg11", "always_as_identity"),
   attributes: alwaysAsIdentityAttributes,
   description: undefined,
   extensions: {
@@ -103,8 +95,7 @@ const alwaysAsIdentityCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const alwaysAsIdentityCodec = recordCodec(alwaysAsIdentityCodecSpec);
+});
 const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -125,26 +116,22 @@ const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "by_default_as_identity"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["pg11", "by_default_as_identity"];
-const byDefaultAsIdentityIdentifier = sql.identifier(...parts2);
-const byDefaultAsIdentityCodecSpec = {
+const byDefaultAsIdentityCodec = recordCodec({
   name: "byDefaultAsIdentity",
-  identifier: byDefaultAsIdentityIdentifier,
+  identifier: sql.identifier("pg11", "by_default_as_identity"),
   attributes: byDefaultAsIdentityAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "by_default_as_identity"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const byDefaultAsIdentityCodec = recordCodec(byDefaultAsIdentityCodecSpec);
+});
 const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -192,229 +179,200 @@ const networkAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "network"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["pg11", "network"];
-const networkIdentifier = sql.identifier(...parts3);
-const networkCodecSpec = {
+const networkCodec = recordCodec({
   name: "network",
-  identifier: networkIdentifier,
+  identifier: sql.identifier("pg11", "network"),
   attributes: networkAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "network"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const networkCodec = recordCodec(networkCodecSpec);
-const extensions4 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "bigint_domain_array_domain"
-  },
-  tags: Object.create(null)
-};
-const bigintDomainArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_bigint_domain"
-  },
-  tags: Object.create(null)
-};
-const extensions5 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "bigint_domain"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "bigint_domain"];
-const bigintDomainIdentifier = sql.identifier(...parts4);
-const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", bigintDomainIdentifier, {
+});
+const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", sql.identifier("c", "bigint_domain"), {
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "bigint_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
 const bigintDomainArrayCodec = listOfCodec(bigintDomainCodec, {
-  extensions: bigintDomainArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_bigint_domain"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "bigintDomainArray"
 });
-const parts5 = ["c", "bigint_domain_array_domain"];
-const bigintDomainArrayDomainIdentifier = sql.identifier(...parts5);
-const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", bigintDomainArrayDomainIdentifier, {
+const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", sql.identifier("c", "bigint_domain_array_domain"), {
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "bigint_domain_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions6 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "domain_constrained_compound_type"
-  },
-  tags: Object.create(null)
-};
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["b", "color"];
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts6),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions7
-});
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions8 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts7);
-const enumCapsCodec = enumCodec({
-  name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
-  description: undefined,
-  extensions: extensions8
-});
-const enumLabels3 = ["", "one", "two"];
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts8);
-const enumWithEmptyStringCodec = enumCodec({
-  name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
-  description: undefined,
-  extensions: extensions9
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions10 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts9);
-const compoundTypeCodecSpec = {
-  name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
-  description: "Awesome feature!",
-  extensions: extensions10,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const parts10 = ["pg11", "domain_constrained_compound_type"];
-const domainConstrainedCompoundTypeIdentifier = sql.identifier(...parts10);
-const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", domainConstrainedCompoundTypeIdentifier, {
+const enumCapsCodec = enumCodec({
+  name: "enumCaps",
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
+});
+const enumWithEmptyStringCodec = enumCodec({
+  name: "enumWithEmptyString",
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
+  }
+});
+const compoundTypeCodec = recordCodec({
+  name: "compoundType",
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: "Awesome feature!",
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
+  },
+  executor: executor_mainPgExecutor
+});
+const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", sql.identifier("pg11", "domain_constrained_compound_type"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "domain_constrained_compound_type"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
 const typesAttributes = Object.assign(Object.create(null), {
@@ -464,35 +422,22 @@ const typesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "types"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["pg11", "types"];
-const typesIdentifier = sql.identifier(...parts11);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("pg11", "types"),
   attributes: typesAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "always_as_identity"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "pg11",
+      name: "types"
+    },
+    tags: Object.create(null)
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -501,15 +446,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "by_default_as_identity"
-  },
-  tags: {}
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -518,15 +454,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "network"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -535,15 +462,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "pg11",
-    name: "types"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -590,7 +508,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "always_as_identity"
+        },
+        tags: {}
+      }
     },
     by_default_as_identity: {
       executor: executor_mainPgExecutor,
@@ -601,7 +527,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "by_default_as_identity"
+        },
+        tags: {}
+      }
     },
     network: {
       executor: executor_mainPgExecutor,
@@ -612,7 +546,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions14
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "network"
+        },
+        tags: {}
+      }
     },
     types: {
       executor: executor_mainPgExecutor,
@@ -623,7 +565,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions15
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "pg11",
+          name: "types"
+        },
+        tags: {}
+      }
     }
   }),
   pgRelations: Object.create(null)
@@ -761,21 +711,6 @@ const fetcher4 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Type);
-function Query_allAlwaysAsIdentities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAlwaysAsIdentities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAlwaysAsIdentities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -794,424 +729,39 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allByDefaultAsIdentities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allByDefaultAsIdentities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allByDefaultAsIdentities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNetworks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNetworks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNetworks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNetworks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNetworks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_domainConstrainedCompoundTypePgResource = registry.pgResources["frmcdc_domainConstrainedCompoundType"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
-function AlwaysAsIdentitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AlwaysAsIdentitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AlwaysAsIdentitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function ByDefaultAsIdentitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ByDefaultAsIdentitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ByDefaultAsIdentitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NetworksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NetworksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NetworksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.AlwaysAsIdentity, $nodeId);
 };
-function Mutation_updateAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAlwaysAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ByDefaultAsIdentity, $nodeId);
 };
-function Mutation_updateByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateByDefaultAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_updateNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.AlwaysAsIdentity, $nodeId);
 };
-function Mutation_deleteAlwaysAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAlwaysAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ByDefaultAsIdentity, $nodeId);
 };
-function Mutation_deleteByDefaultAsIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteByDefaultAsIdentityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
 };
-function Mutation_deleteNetwork_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNetworkById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function CreateAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAlwaysAsIdentityInput_alwaysAsIdentity_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function CreateByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateByDefaultAsIdentityInput_byDefaultAsIdentity_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function CreateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNetworkInput_network_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function UpdateAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAlwaysAsIdentityInput_alwaysAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAlwaysAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAlwaysAsIdentityByIdInput_alwaysAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function UpdateByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateByDefaultAsIdentityInput_byDefaultAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateByDefaultAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateByDefaultAsIdentityByIdInput_byDefaultAsIdentityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function UpdateNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNetworkByIdInput_networkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteAlwaysAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAlwaysAsIdentityPayload_alwaysAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function DeleteAlwaysAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAlwaysAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAlwaysAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteByDefaultAsIdentityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteByDefaultAsIdentityPayload_byDefaultAsIdentityPlan($object) {
-  return $object.get("result");
-}
-function DeleteByDefaultAsIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteByDefaultAsIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteByDefaultAsIdentityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNetworkPayload_networkPlan($object) {
-  return $object.get("result");
-}
-function DeleteNetworkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNetworkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNetworkByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -2602,7 +2152,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -2698,23 +2250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAlwaysAsIdentities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2741,23 +2303,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allByDefaultAsIdentities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2784,23 +2356,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNetworks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2827,23 +2409,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -2996,18 +2588,37 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   AlwaysAsIdentitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: AlwaysAsIdentitiesConnection_nodesPlan,
-    edges: AlwaysAsIdentitiesConnection_edgesPlan,
-    pageInfo: AlwaysAsIdentitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3023,8 +2634,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -3187,9 +2802,16 @@ export const plans = {
   },
   ByDefaultAsIdentitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ByDefaultAsIdentitiesConnection_nodesPlan,
-    edges: ByDefaultAsIdentitiesConnection_edgesPlan,
-    pageInfo: ByDefaultAsIdentitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3358,9 +2980,16 @@ export const plans = {
   },
   NetworksConnection: {
     __assertStep: ConnectionStep,
-    nodes: NetworksConnection_nodesPlan,
-    edges: NetworksConnection_edgesPlan,
-    pageInfo: NetworksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -3700,9 +3329,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4085,7 +3721,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4100,7 +3738,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4115,7 +3755,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4130,7 +3772,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4144,7 +3788,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4160,7 +3806,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAlwaysAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4174,7 +3822,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4190,7 +3840,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateByDefaultAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4204,7 +3856,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4220,7 +3874,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4234,7 +3890,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4250,7 +3908,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4264,7 +3924,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAlwaysAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4280,7 +3942,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAlwaysAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4294,7 +3958,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteByDefaultAsIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4310,7 +3976,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteByDefaultAsIdentityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4324,7 +3992,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetwork_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4340,7 +4010,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNetworkById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4354,7 +4026,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -4370,16 +4044,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateAlwaysAsIdentityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: CreateAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
-    query: CreateAlwaysAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4414,11 +4096,16 @@ export const plans = {
   },
   CreateAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: CreateAlwaysAsIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     alwaysAsIdentity: {
-      applyPlan: CreateAlwaysAsIdentityInput_alwaysAsIdentity_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4433,9 +4120,15 @@ export const plans = {
   },
   CreateByDefaultAsIdentityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: CreateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
-    query: CreateByDefaultAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4470,11 +4163,16 @@ export const plans = {
   },
   CreateByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: CreateByDefaultAsIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     byDefaultAsIdentity: {
-      applyPlan: CreateByDefaultAsIdentityInput_byDefaultAsIdentity_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4496,9 +4194,15 @@ export const plans = {
   },
   CreateNetworkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNetworkPayload_clientMutationIdPlan,
-    network: CreateNetworkPayload_networkPlan,
-    query: CreateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4533,11 +4237,16 @@ export const plans = {
   },
   CreateNetworkInput: {
     clientMutationId: {
-      applyPlan: CreateNetworkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     network: {
-      applyPlan: CreateNetworkInput_network_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4580,9 +4289,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4617,11 +4332,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -4664,9 +4384,15 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: UpdateAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
-    query: UpdateAlwaysAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4701,11 +4427,16 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: UpdateAlwaysAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     alwaysAsIdentityPatch: {
-      applyPlan: UpdateAlwaysAsIdentityInput_alwaysAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AlwaysAsIdentityPatch: {
@@ -4719,18 +4450,29 @@ export const plans = {
   },
   UpdateAlwaysAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAlwaysAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     alwaysAsIdentityPatch: {
-      applyPlan: UpdateAlwaysAsIdentityByIdInput_alwaysAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateByDefaultAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: UpdateByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
-    query: UpdateByDefaultAsIdentityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4765,11 +4507,16 @@ export const plans = {
   },
   UpdateByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: UpdateByDefaultAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     byDefaultAsIdentityPatch: {
-      applyPlan: UpdateByDefaultAsIdentityInput_byDefaultAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ByDefaultAsIdentityPatch: {
@@ -4790,18 +4537,29 @@ export const plans = {
   },
   UpdateByDefaultAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateByDefaultAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     byDefaultAsIdentityPatch: {
-      applyPlan: UpdateByDefaultAsIdentityByIdInput_byDefaultAsIdentityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNetworkPayload_clientMutationIdPlan,
-    network: UpdateNetworkPayload_networkPlan,
-    query: UpdateNetworkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4836,11 +4594,16 @@ export const plans = {
   },
   UpdateNetworkInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NetworkPatch: {
@@ -4882,18 +4645,29 @@ export const plans = {
   },
   UpdateNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     networkPatch: {
-      applyPlan: UpdateNetworkByIdInput_networkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -4928,11 +4702,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -4974,23 +4753,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteAlwaysAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAlwaysAsIdentityPayload_clientMutationIdPlan,
-    alwaysAsIdentity: DeleteAlwaysAsIdentityPayload_alwaysAsIdentityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    alwaysAsIdentity($object) {
+      return $object.get("result");
+    },
     deletedAlwaysAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.AlwaysAsIdentity.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteAlwaysAsIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     alwaysAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5025,26 +4815,36 @@ export const plans = {
   },
   DeleteAlwaysAsIdentityInput: {
     clientMutationId: {
-      applyPlan: DeleteAlwaysAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteAlwaysAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAlwaysAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteByDefaultAsIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteByDefaultAsIdentityPayload_clientMutationIdPlan,
-    byDefaultAsIdentity: DeleteByDefaultAsIdentityPayload_byDefaultAsIdentityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    byDefaultAsIdentity($object) {
+      return $object.get("result");
+    },
     deletedByDefaultAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ByDefaultAsIdentity.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteByDefaultAsIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     byDefaultAsIdentityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5079,26 +4879,36 @@ export const plans = {
   },
   DeleteByDefaultAsIdentityInput: {
     clientMutationId: {
-      applyPlan: DeleteByDefaultAsIdentityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteByDefaultAsIdentityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteByDefaultAsIdentityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNetworkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNetworkPayload_clientMutationIdPlan,
-    network: DeleteNetworkPayload_networkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    network($object) {
+      return $object.get("result");
+    },
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNetworkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     networkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5133,26 +4943,36 @@ export const plans = {
   },
   DeleteNetworkInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNetworkByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNetworkByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -5187,13 +5007,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes = Object.assign(Object.create(null), {
+const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -87,10 +87,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_alwaysAsIdentity = {
+const alwaysAsIdentityIdentifier = sql.identifier(...["pg11", "always_as_identity"]);
+const alwaysAsIdentityCodecSpec = {
   name: "alwaysAsIdentity",
-  identifier: sql.identifier(...["pg11", "always_as_identity"]),
-  attributes,
+  identifier: alwaysAsIdentityIdentifier,
+  attributes: alwaysAsIdentityAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -103,8 +104,8 @@ const spec_alwaysAsIdentity = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity = recordCodec(spec_alwaysAsIdentity);
-const attributes2 = Object.assign(Object.create(null), {
+const alwaysAsIdentityCodec = recordCodec(alwaysAsIdentityCodecSpec);
+const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -134,17 +135,17 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["pg11", "by_default_as_identity"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_byDefaultAsIdentity = {
+const byDefaultAsIdentityIdentifier = sql.identifier(...parts2);
+const byDefaultAsIdentityCodecSpec = {
   name: "byDefaultAsIdentity",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: byDefaultAsIdentityIdentifier,
+  attributes: byDefaultAsIdentityAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity = recordCodec(spec_byDefaultAsIdentity);
-const attributes3 = Object.assign(Object.create(null), {
+const byDefaultAsIdentityCodec = recordCodec(byDefaultAsIdentityCodecSpec);
+const networkAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -201,16 +202,16 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["pg11", "network"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_network = {
+const networkIdentifier = sql.identifier(...parts3);
+const networkCodecSpec = {
   name: "network",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: networkIdentifier,
+  attributes: networkAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_network_network = recordCodec(spec_network);
+const networkCodec = recordCodec(networkCodecSpec);
 const extensions4 = {
   pg: {
     serviceName: "main",
@@ -219,7 +220,7 @@ const extensions4 = {
   },
   tags: Object.create(null)
 };
-const extensions5 = {
+const bigintDomainArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -227,7 +228,7 @@ const extensions5 = {
   },
   tags: Object.create(null)
 };
-const extensions6 = {
+const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -236,26 +237,26 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "bigint_domain"];
-const sqlIdent4 = sql.identifier(...parts4);
-const innerCodec_bigintDomain = domainOfCodec(TYPES.bigint, "bigintDomain", sqlIdent4, {
+const bigintDomainIdentifier = sql.identifier(...parts4);
+const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", bigintDomainIdentifier, {
   description: undefined,
-  extensions: extensions6,
+  extensions: extensions5,
   notNull: false
 });
-const innerCodec_bigintDomainArray = listOfCodec(innerCodec_bigintDomain, {
-  extensions: extensions5,
+const bigintDomainArrayCodec = listOfCodec(bigintDomainCodec, {
+  extensions: bigintDomainArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "bigintDomainArray"
 });
 const parts5 = ["c", "bigint_domain_array_domain"];
-const sqlIdent5 = sql.identifier(...parts5);
-const registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain = domainOfCodec(innerCodec_bigintDomainArray, "bigintDomainArrayDomain", sqlIdent5, {
+const bigintDomainArrayDomainIdentifier = sql.identifier(...parts5);
+const bigintDomainArrayDomainCodec = domainOfCodec(bigintDomainArrayCodec, "bigintDomainArrayDomain", bigintDomainArrayDomainIdentifier, {
   description: undefined,
   extensions: extensions4,
   notNull: false
 });
-const extensions7 = {
+const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "pg11",
@@ -263,7 +264,7 @@ const extensions7 = {
   },
   tags: Object.create(null)
 };
-const extensions8 = {
+const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -272,16 +273,15 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts6 = ["b", "color"];
-const sqlIdent6 = sql.identifier(...parts6);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent6,
+  identifier: sql.identifier(...parts6),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions8
+  extensions: extensions7
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions9 = {
+const extensions8 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -290,16 +290,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts7 = ["b", "enum_caps"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts7);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent7,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions9
+  extensions: extensions8
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions10 = {
+const extensions9 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -308,15 +308,15 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["b", "enum_with_empty_string"];
-const sqlIdent8 = sql.identifier(...parts8);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts8);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent8,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions10
+  extensions: extensions9
 });
-const attributes4 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -337,7 +337,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -355,7 +355,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -364,7 +364,7 @@ const attributes4 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -390,7 +390,7 @@ const attributes4 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions10 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -400,24 +400,24 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["c", "compound_type"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts9);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent9,
-  attributes: attributes4,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions11,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const innerCodec_compoundType = recordCodec(spec_compoundType);
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
 const parts10 = ["pg11", "domain_constrained_compound_type"];
-const sqlIdent10 = sql.identifier(...parts10);
-const registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType = domainOfCodec(innerCodec_compoundType, "domainConstrainedCompoundType", sqlIdent10, {
+const domainConstrainedCompoundTypeIdentifier = sql.identifier(...parts10);
+const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", domainConstrainedCompoundTypeIdentifier, {
   description: undefined,
-  extensions: extensions7,
+  extensions: extensions6,
   notNull: false
 });
-const attributes5 = Object.assign(Object.create(null), {
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -447,7 +447,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   bigint_domain_array_domain: {
     description: undefined,
-    codec: registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain,
+    codec: bigintDomainArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -456,7 +456,7 @@ const attributes5 = Object.assign(Object.create(null), {
   },
   domain_constrained_compound_type: {
     description: undefined,
-    codec: registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType,
+    codec: domainConstrainedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -464,7 +464,7 @@ const attributes5 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -474,17 +474,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts11 = ["pg11", "types"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts11);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent11,
-  attributes: attributes5,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions13 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const extensions12 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -501,7 +501,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
+const extensions13 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -518,7 +518,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions15 = {
+const extensions14 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -535,7 +535,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions16 = {
+const extensions15 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -554,11 +554,11 @@ const uniques4 = [{
 }];
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    alwaysAsIdentity: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity,
+    alwaysAsIdentity: alwaysAsIdentityCodec,
     int4: TYPES.int,
     text: TYPES.text,
-    byDefaultAsIdentity: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity,
-    network: registryConfig_pgCodecs_network_network,
+    byDefaultAsIdentity: byDefaultAsIdentityCodec,
+    network: networkCodec,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
     macaddr: TYPES.macaddr,
@@ -567,63 +567,63 @@ const registry = makeRegistry({
     bpchar: TYPES.bpchar,
     regrole: TYPES.regrole,
     regnamespace: TYPES.regnamespace,
-    bigintDomainArrayDomain: registryConfig_pgCodecs_bigintDomainArrayDomain_bigintDomainArrayDomain,
-    bigintDomain: innerCodec_bigintDomain,
+    bigintDomainArrayDomain: bigintDomainArrayDomainCodec,
+    bigintDomain: bigintDomainCodec,
     int8: TYPES.bigint,
-    bigintDomainArray: innerCodec_bigintDomainArray,
-    domainConstrainedCompoundType: registryConfig_pgCodecs_domainConstrainedCompoundType_domainConstrainedCompoundType,
-    compoundType: innerCodec_compoundType,
-    color: attributes_c_codec_color,
+    bigintDomainArray: bigintDomainArrayCodec,
+    domainConstrainedCompoundType: domainConstrainedCompoundTypeCodec,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     interval: TYPES.interval,
-    types: registryConfig_pgCodecs_types_types
+    types: typesCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
       executor: executor_mainPgExecutor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
-      from: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.sqlType,
-      codec: registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity,
+      from: alwaysAsIdentityCodec.sqlType,
+      codec: alwaysAsIdentityCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: extensions12
     },
     by_default_as_identity: {
       executor: executor_mainPgExecutor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
-      from: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.sqlType,
-      codec: registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity,
+      from: byDefaultAsIdentityCodec.sqlType,
+      codec: byDefaultAsIdentityCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
-      extensions: extensions14
+      extensions: extensions13
     },
     network: {
       executor: executor_mainPgExecutor,
       name: "network",
       identifier: "main.pg11.network",
-      from: registryConfig_pgCodecs_network_network.sqlType,
-      codec: registryConfig_pgCodecs_network_network,
+      from: networkCodec.sqlType,
+      codec: networkCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions15
+      extensions: extensions14
     },
     types: {
       executor: executor_mainPgExecutor,
       name: "types",
       identifier: "main.pg11.types",
-      from: registryConfig_pgCodecs_types_types.sqlType,
-      codec: registryConfig_pgCodecs_types_types,
+      from: typesCodec.sqlType,
+      codec: typesCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions16
+      extensions: extensions15
     }
   }),
   pgRelations: Object.create(null)
@@ -3039,7 +3039,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.attributes[attributeName];
+          const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3055,7 +3055,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_alwaysAsIdentity_alwaysAsIdentity.attributes[attributeName];
+          const attribute = alwaysAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3153,7 +3153,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.id.codec)}`;
             }
           });
         }
@@ -3176,7 +3176,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.t.codec)}`;
             }
           });
         }
@@ -3210,7 +3210,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.attributes[attributeName];
+          const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3226,7 +3226,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_byDefaultAsIdentity_byDefaultAsIdentity.attributes[attributeName];
+          const attribute = byDefaultAsIdentityCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3324,7 +3324,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.id.codec)}`;
             }
           });
         }
@@ -3347,7 +3347,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.t.codec)}`;
             }
           });
         }
@@ -3381,7 +3381,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3397,7 +3397,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_network_network.attributes[attributeName];
+          const attribute = networkCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3597,7 +3597,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
             }
           });
         }
@@ -3620,7 +3620,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
             }
           });
         }
@@ -3643,7 +3643,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
             }
           });
         }
@@ -3666,7 +3666,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -3689,7 +3689,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr8",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.macaddr8.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr8.codec)}`;
             }
           });
         }
@@ -3723,7 +3723,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3739,7 +3739,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -3905,7 +3905,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -3928,7 +3928,7 @@ export const plans = {
             type: "attribute",
             attribute: "regrole",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.regrole.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regrole.codec)}`;
             }
           });
         }
@@ -3951,7 +3951,7 @@ export const plans = {
             type: "attribute",
             attribute: "regnamespace",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.regnamespace.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regnamespace.codec)}`;
             }
           });
         }
@@ -3974,7 +3974,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint_domain_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.bigint_domain_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint_domain_array_domain.codec)}`;
             }
           });
         }
@@ -3997,7 +3997,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain_constrained_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.domain_constrained_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain_constrained_compound_type.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -2,37 +2,15 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeDecodeNodeId, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const handler_codec_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
-};
-const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
   },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
   }
-});
+};
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -55,35 +33,32 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
-const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
-  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
-const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions2 = {
   isTableLike: true,
@@ -97,36 +72,32 @@ const extensions2 = {
     behavior: ["-*"]
   })
 };
-const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
-const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
-  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
-};
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
-const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions3 = {
   isTableLike: true,
@@ -140,36 +111,32 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
-const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
-  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
-const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions4 = {
   isTableLike: true,
@@ -183,17 +150,33 @@ const extensions4 = {
     behavior: ["-*"]
   })
 };
-const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
-const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
-  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+});
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
@@ -214,28 +197,24 @@ const organizationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization"
-  })
-};
-const parts5 = ["polymorphic", "organizations"];
-const organizationsIdentifier = sql.identifier(...parts5);
-const organizationsCodecSpec = {
+const organizationsCodec = recordCodec({
   name: "organizations",
-  identifier: organizationsIdentifier,
+  identifier: sql.identifier("polymorphic", "organizations"),
   attributes: organizationsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const organizationsCodec = recordCodec(organizationsCodecSpec);
+});
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -282,36 +261,13 @@ const extensions6 = {
     }
   })
 };
-const parts6 = ["polymorphic", "people"];
-const peopleIdentifier = sql.identifier(...parts6);
-const peopleCodecSpec = {
+const peopleCodec = recordCodec({
   name: "people",
-  identifier: peopleIdentifier,
+  identifier: sql.identifier("polymorphic", "people"),
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
-};
-const peopleCodec = recordCodec(peopleCodecSpec);
-const prioritiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions7 = {
   isTableLike: true,
@@ -325,32 +281,46 @@ const extensions7 = {
     behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
   })
 };
-const parts7 = ["polymorphic", "priorities"];
-const prioritiesIdentifier = sql.identifier(...parts7);
-const prioritiesCodecSpec = {
+const prioritiesCodec = recordCodec({
   name: "priorities",
-  identifier: prioritiesIdentifier,
-  attributes: prioritiesAttributes,
+  identifier: sql.identifier("polymorphic", "priorities"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
-};
-const prioritiesCodec = recordCodec(prioritiesCodecSpec);
-const extensions8 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "item_type"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["polymorphic", "item_type"];
+});
 const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sql.identifier(...parts8),
+  identifier: sql.identifier("polymorphic", "item_type"),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
-  extensions: extensions8
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "item_type"
+    },
+    tags: Object.create(null)
+  }
 });
 const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
@@ -482,27 +452,23 @@ const relationalChecklistsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts9 = ["polymorphic", "relational_checklists"];
-const relationalChecklistsIdentifier = sql.identifier(...parts9);
-const relationalChecklistsCodecSpec = {
+const relationalChecklistsCodec = recordCodec({
   name: "relationalChecklists",
-  identifier: relationalChecklistsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklists"),
   attributes: relationalChecklistsAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+});
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -523,26 +489,22 @@ const relationalItemRelationCompositePksAttributes = Object.assign(Object.create
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
-const relationalItemRelationCompositePksCodecSpec = {
+const relationalItemRelationCompositePksCodec = recordCodec({
   name: "relationalItemRelationCompositePks",
-  identifier: relationalItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
   attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+});
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
@@ -673,27 +635,23 @@ const relationalTopicsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts11 = ["polymorphic", "relational_topics"];
-const relationalTopicsIdentifier = sql.identifier(...parts11);
-const relationalTopicsCodecSpec = {
+const relationalTopicsCodec = recordCodec({
   name: "relationalTopics",
-  identifier: relationalTopicsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_topics"),
   attributes: relationalTopicsAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+});
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -714,26 +672,22 @@ const singleTableItemRelationCompositePksAttributes = Object.assign(Object.creat
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
-const singleTableItemRelationCompositePksCodecSpec = {
+const singleTableItemRelationCompositePksCodec = recordCodec({
   name: "singleTableItemRelationCompositePks",
-  identifier: singleTableItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
   attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+});
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
@@ -873,27 +827,23 @@ const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts13 = ["polymorphic", "relational_checklist_items"];
-const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
-const relationalChecklistItemsCodecSpec = {
+const relationalChecklistItemsCodec = recordCodec({
   name: "relationalChecklistItems",
-  identifier: relationalChecklistItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
   attributes: relationalChecklistItemsAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+});
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
@@ -1033,27 +983,23 @@ const relationalDividersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts14 = ["polymorphic", "relational_dividers"];
-const relationalDividersIdentifier = sql.identifier(...parts14);
-const relationalDividersCodecSpec = {
+const relationalDividersCodec = recordCodec({
   name: "relationalDividers",
-  identifier: relationalDividersIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_dividers"),
   attributes: relationalDividersAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+});
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1083,26 +1029,22 @@ const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["polymorphic", "relational_item_relations"];
-const relationalItemRelationsIdentifier = sql.identifier(...parts15);
-const relationalItemRelationsCodecSpec = {
+const relationalItemRelationsCodec = recordCodec({
   name: "relationalItemRelations",
-  identifier: relationalItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relations"),
   attributes: relationalItemRelationsAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+});
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1132,26 +1074,22 @@ const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["polymorphic", "single_table_item_relations"];
-const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
-const singleTableItemRelationsCodecSpec = {
+const singleTableItemRelationsCodec = recordCodec({
   name: "singleTableItemRelations",
-  identifier: singleTableItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
   attributes: singleTableItemRelationsAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+});
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1215,17 +1153,14 @@ const extensions17 = {
     }
   })
 };
-const parts17 = ["polymorphic", "log_entries"];
-const logEntriesIdentifier = sql.identifier(...parts17);
-const logEntriesCodecSpec = {
+const logEntriesCodec = recordCodec({
   name: "logEntries",
-  identifier: logEntriesIdentifier,
+  identifier: sql.identifier("polymorphic", "log_entries"),
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
-};
-const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+});
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
@@ -1374,27 +1309,23 @@ const relationalPostsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts18 = ["polymorphic", "relational_posts"];
-const relationalPostsIdentifier = sql.identifier(...parts18);
-const relationalPostsCodecSpec = {
+const relationalPostsCodec = recordCodec({
   name: "relationalPosts",
-  identifier: relationalPostsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_posts"),
   attributes: relationalPostsAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+});
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1470,17 +1401,14 @@ const extensions19 = {
     }
   })
 };
-const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
-const firstPartyVulnerabilitiesCodecSpec = {
+const firstPartyVulnerabilitiesCodec = recordCodec({
   name: "firstPartyVulnerabilities",
-  identifier: firstPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
-};
-const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+});
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1556,17 +1484,14 @@ const extensions20 = {
     }
   })
 };
-const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
-const thirdPartyVulnerabilitiesCodecSpec = {
+const thirdPartyVulnerabilitiesCodec = recordCodec({
   name: "thirdPartyVulnerabilities",
-  identifier: thirdPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
-};
-const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+});
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1660,17 +1585,14 @@ const extensions21 = {
     }
   })
 };
-const parts21 = ["polymorphic", "aws_applications"];
-const awsApplicationsIdentifier = sql.identifier(...parts21);
-const awsApplicationsCodecSpec = {
+const awsApplicationsCodec = recordCodec({
   name: "awsApplications",
-  identifier: awsApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "aws_applications"),
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
-};
-const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+});
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1764,17 +1686,14 @@ const extensions22 = {
     }
   })
 };
-const parts22 = ["polymorphic", "gcp_applications"];
-const gcpApplicationsIdentifier = sql.identifier(...parts22);
-const gcpApplicationsCodecSpec = {
+const gcpApplicationsCodec = recordCodec({
   name: "gcpApplications",
-  identifier: gcpApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "gcp_applications"),
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+});
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1949,17 +1868,14 @@ const extensions23 = {
     }
   })
 };
-const parts23 = ["polymorphic", "single_table_items"];
-const singleTableItemsIdentifier = sql.identifier(...parts23);
-const singleTableItemsCodecSpec = {
+const singleTableItemsCodec = recordCodec({
   name: "singleTableItems",
-  identifier: singleTableItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_items"),
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
-};
-const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+});
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2064,17 +1980,14 @@ const extensions24 = {
     type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
   })
 };
-const parts24 = ["polymorphic", "relational_items"];
-const relationalItemsIdentifier = sql.identifier(...parts24);
-const relationalItemsCodecSpec = {
+const relationalItemsCodec = recordCodec({
   name: "relationalItems",
-  identifier: relationalItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_items"),
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
-};
-const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+});
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2108,54 +2021,6 @@ const ApplicationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Application",
-    behavior: "node",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts25 = ["polymorphic", "applications"];
-const ApplicationIdentifier = sql.identifier(...parts25);
-const ApplicationCodecSpec = {
-  name: "Application",
-  identifier: ApplicationIdentifier,
-  attributes: ApplicationAttributes,
-  description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
 const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2191,54 +2056,6 @@ const VulnerabilityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Vulnerability",
-    behavior: "node",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts26 = ["polymorphic", "vulnerabilities"];
-const VulnerabilityIdentifier = sql.identifier(...parts26);
-const VulnerabilityCodecSpec = {
-  name: "Vulnerability",
-  identifier: VulnerabilityIdentifier,
-  attributes: VulnerabilityAttributes,
-  description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
 const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2259,41 +2076,6 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions27 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "zero_implementation"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "ZeroImplementation",
-    behavior: "node"
-  })
-};
-const parts27 = ["polymorphic", "zero_implementation"];
-const ZeroImplementationIdentifier = sql.identifier(...parts27);
-const ZeroImplementationCodecSpec = {
-  name: "ZeroImplementation",
-  identifier: ZeroImplementationIdentifier,
-  attributes: ZeroImplementationAttributes,
-  description: undefined,
-  extensions: extensions27,
-  executor: executor_mainPgExecutor
-};
-const extensions28 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "aws_application_first_party_vulnerabilities",
@@ -2310,110 +2092,104 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions28
-};
-const extensions29 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions2.tags.behavior
-  }
-};
-const uniques2 = [{
-  isPrimary: true,
-  attributes: ["aws_application_id", "third_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
   from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques2,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["aws_application_id", "third_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions29
-};
-const extensions30 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["gcp_application_id", "first_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions2.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
   from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["gcp_application_id", "first_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions30
-};
-const extensions31 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions4.tags.behavior
-  }
-};
-const uniques4 = [{
-  isPrimary: true,
-  attributes: ["gcp_application_id", "third_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
   from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques4,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["gcp_application_id", "third_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions31
-};
-const extensions32 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions4.tags.behavior
+    }
   }
 };
 const uniques5 = [{
@@ -2440,19 +2216,16 @@ const registryConfig_pgResources_organizations_organizations = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions32
-};
-const extensions33 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: extensions6.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization"
+    }
   }
 };
 const uniques6 = [{
@@ -2479,47 +2252,48 @@ const registryConfig_pgResources_people_people = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions33
-};
-const extensions34 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
-  },
-  tags: {
-    omit: "create,update,delete,filter,order",
-    behavior: extensions7.tags.behavior
-  }
-};
-const uniques7 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: extensions6.tags.refVia
+    }
   }
-}];
+};
 const registryConfig_pgResources_priorities_priorities = {
   executor: executor_mainPgExecutor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
   from: prioritiesCodec.sqlType,
   codec: prioritiesCodec,
-  uniques: uniques7,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions34
-};
-const extensions35 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: {
+      omit: "create,update,delete,filter,order",
+      behavior: extensions7.tags.behavior
+    }
+  }
 };
 const uniques8 = [{
   isPrimary: true,
@@ -2538,16 +2312,15 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions35
-};
-const extensions36 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: {}
+  }
 };
 const uniques9 = [{
   isPrimary: true,
@@ -2566,16 +2339,15 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions36
-};
-const extensions37 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques10 = [{
   isPrimary: true,
@@ -2594,16 +2366,15 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
-  extensions: extensions37
-};
-const extensions38 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: {}
+  }
 };
 const uniques11 = [{
   isPrimary: true,
@@ -2622,16 +2393,15 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions38
-};
-const extensions39 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -2650,16 +2420,15 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
-  extensions: extensions39
-};
-const extensions40 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: {}
+  }
 };
 const uniques13 = [{
   isPrimary: true,
@@ -2678,16 +2447,15 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
-  extensions: extensions40
-};
-const extensions41 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: {}
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -2713,16 +2481,15 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
-  extensions: extensions41
-};
-const extensions42 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: {}
+  }
 };
 const uniques15 = [{
   isPrimary: true,
@@ -2748,18 +2515,14 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions42
-};
-const extensions43 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: extensions17.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: {}
   }
 };
 const uniques16 = [{
@@ -2779,16 +2542,18 @@ const registryConfig_pgResources_log_entries_log_entries = {
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
-  extensions: extensions43
-};
-const extensions44 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: extensions17.tags.refVia
+    }
+  }
 };
 const uniques17 = [{
   isPrimary: true,
@@ -2807,19 +2572,14 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
-  extensions: extensions44
-};
-const extensions45 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions19.tags.ref,
-    refVia: extensions19.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: {}
   }
 };
 const uniques18 = [{
@@ -2839,19 +2599,18 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
-  extensions: extensions45
-};
-const extensions46 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions20.tags.ref,
-    refVia: extensions20.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions19.tags.ref,
+      refVia: extensions19.tags.refVia
+    }
   }
 };
 const uniques19 = [{
@@ -2871,19 +2630,18 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
-  extensions: extensions46
-};
-const extensions47 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions21.tags.ref,
-    refVia: extensions21.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions20.tags.ref,
+      refVia: extensions20.tags.refVia
+    }
   }
 };
 const uniques20 = [{
@@ -2903,19 +2661,18 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
-  extensions: extensions47
-};
-const extensions48 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions22.tags.ref,
-    refVia: extensions22.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions21.tags.ref,
+      refVia: extensions21.tags.refVia
+    }
   }
 };
 const uniques21 = [{
@@ -2935,34 +2692,21 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
-  extensions: extensions48
-};
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "custom_delete_relational_item"
-  },
-  tags: {
-    arg0variant: "nodeId",
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions22.tags.ref,
+      refVia: extensions22.tags.refVia
+    }
   }
 };
-const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent2 = sql.identifier(...parts28);
-const extensions50 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: {
-    interface: "mode:single type:type",
-    type: extensions23.tags.type,
-    ref: extensions23.tags.ref
-  }
-};
+const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
 const uniques22 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -2980,74 +2724,22 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
-  extensions: extensions50
-};
-const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent3 = sql.identifier(...parts29);
-const options_all_single_tables = {
-  name: "all_single_tables",
-  identifier: "main.polymorphic.all_single_tables()",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "polymorphic",
-      name: "all_single_tables"
+      name: "single_table_items"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      interface: "mode:single type:type",
+      type: extensions23.tags.type,
+      ref: extensions23.tags.ref
     }
-  },
-  description: undefined
-};
-const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent4 = sql.identifier(...parts30);
-const options_get_single_table_topic_by_id = {
-  name: "get_single_table_topic_by_id",
-  identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
-  from(...args) {
-    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "polymorphic",
-      name: "get_single_table_topic_by_id"
-    },
-    tags: {
-      returnType: "SingleTableTopic",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions51 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: {
-    interface: "mode:relational",
-    type: extensions24.tags.type
   }
 };
+const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
+const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3065,7 +2757,18 @@ const registryConfig_pgResources_relational_items_relational_items = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions51
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: {
+      interface: "mode:relational",
+      type: extensions24.tags.type
+    }
+  }
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
@@ -3101,9 +2804,116 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(ApplicationCodecSpec),
-    Vulnerability: recordCodec(VulnerabilityCodecSpec),
-    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
+    Application: recordCodec({
+      name: "Application",
+      identifier: sql.identifier("polymorphic", "applications"),
+      attributes: ApplicationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "applications"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Application",
+          behavior: "node",
+          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          vulnerabilities: {
+            singular: false,
+            graphqlType: "Vulnerability",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owner: {
+            singular: true,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    Vulnerability: recordCodec({
+      name: "Vulnerability",
+      identifier: sql.identifier("polymorphic", "vulnerabilities"),
+      attributes: VulnerabilityAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "vulnerabilities"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Vulnerability",
+          behavior: "node",
+          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          applications: {
+            singular: false,
+            graphqlType: "Application",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owners: {
+            singular: false,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    ZeroImplementation: recordCodec({
+      name: "ZeroImplementation",
+      identifier: sql.identifier("polymorphic", "zero_implementation"),
+      attributes: ZeroImplementationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "zero_implementation"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "ZeroImplementation",
+          behavior: "node"
+        })
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3147,12 +2957,70 @@ const registryConfig = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "custom_delete_relational_item"
+        },
+        tags: {
+          arg0variant: "nodeId",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     single_table_items: registryConfig_pgResources_single_table_items_single_table_items,
-    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_all_single_tables),
-    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_get_single_table_topic_by_id),
+    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "all_single_tables",
+      identifier: "main.polymorphic.all_single_tables()",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "all_single_tables"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "get_single_table_topic_by_id",
+      identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "get_single_table_topic_by_id"
+        },
+        tags: {
+          returnType: "SingleTableTopic",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     relational_items: registryConfig_pgResources_relational_items_relational_items
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -4245,12 +4113,6 @@ const handler = {
     return obj[0] === "SingleTableTopic";
   }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
@@ -4264,26 +4126,15 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
   base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const otherSource_peoplePgResource = registry.pgResources["people"];
-function SingleTableTopic_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -4303,67 +4154,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   });
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
-function SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler2 = {
   typeName: "Person",
   codec: handler_codec_base64JSON,
@@ -4384,84 +4175,9 @@ const handler2 = {
   }
 };
 const otherSource_log_entriesPgResource = registry.pgResources["log_entries"];
-function Person_logEntriesByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_logEntriesByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_logEntriesByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_logEntriesByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_logEntriesByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_singleTableItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_relational_itemsPgResource = registry.pgResources["relational_items"];
-function Person_relationalItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_relationalItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_aws_applicationsPgResource = registry.pgResources["aws_applications"];
-function Person_awsApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_awsApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_gcp_applicationsPgResource = registry.pgResources["gcp_applications"];
-function Person_gcpApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_gcpApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication",
@@ -4498,31 +4214,6 @@ const resourceByTypeName = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Person_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function LogEntriesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LogEntriesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LogEntriesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler3 = {
   typeName: "LogEntry",
   codec: handler_codec_base64JSON,
@@ -4599,61 +4290,6 @@ const handler4 = {
     return obj[0] === "organizations";
   }
 };
-function Organization_logEntriesByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_logEntriesByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function AwsApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AwsApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AwsApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler5 = {
   typeName: "AwsApplication",
   codec: handler_codec_base64JSON,
@@ -4729,21 +4365,6 @@ const resourceByTypeName3 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function AwsApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function AwsApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function AwsApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
@@ -4781,52 +4402,6 @@ const resourceByTypeName4 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function VulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function VulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function VulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function PersonOrOrganizationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonOrOrganizationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonOrOrganizationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function GcpApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GcpApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GcpApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler6 = {
   typeName: "GcpApplication",
   codec: handler_codec_base64JSON,
@@ -4900,21 +4475,6 @@ const resourceByTypeName5 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function GcpApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function GcpApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function GcpApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes3 = {};
 const members6 = [{
   resource: otherSource_peoplePgResource,
@@ -4952,36 +4512,6 @@ const resourceByTypeName6 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function SingleTableItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemRelationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const pgResource_relational_item_relationsPgResource = registry.pgResources["relational_item_relations"];
 const handler7 = {
   typeName: "RelationalItemRelation",
@@ -5002,16 +4532,6 @@ const handler7 = {
     return obj[0] === "relational_item_relations";
   }
 };
-function RelationalItemRelationCompositePksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationCompositePksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationCompositePksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const pgResource_relational_item_relation_composite_pksPgResource = registry.pgResources["relational_item_relation_composite_pks"];
 const handler8 = {
   typeName: "RelationalItemRelationCompositePk",
@@ -5033,16 +4553,6 @@ const handler8 = {
     return obj[0] === "relational_item_relation_composite_pks";
   }
 };
-function SingleTableItemRelationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler9 = {
   typeName: "SingleTableItemRelation",
   codec: handler_codec_base64JSON,
@@ -5062,16 +4572,6 @@ const handler9 = {
     return obj[0] === "single_table_item_relations";
   }
 };
-function SingleTableItemRelationCompositePksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationCompositePksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationCompositePksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const handler10 = {
   typeName: "SingleTableItemRelationCompositePk",
   codec: handler_codec_base64JSON,
@@ -5112,81 +4612,6 @@ const handler11 = {
   }
 };
 const otherSource_prioritiesPgResource = registry.pgResources["priorities"];
-function SingleTablePost_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler12 = {
   typeName: "Priority",
   codec: handler_codec_base64JSON,
@@ -5206,21 +4631,6 @@ const handler12 = {
     return obj[0] === "priorities";
   }
 };
-function Priority_singleTableItemsByPriorityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler13 = {
   typeName: "SingleTableDivider",
   codec: handler_codec_base64JSON,
@@ -5240,81 +4650,6 @@ const handler13 = {
     return obj[0] === "SingleTableDivider";
   }
 };
-function SingleTableDivider_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler14 = {
   typeName: "SingleTableChecklist",
   codec: handler_codec_base64JSON,
@@ -5334,81 +4669,6 @@ const handler14 = {
     return obj[0] === "SingleTableChecklist";
   }
 };
-function SingleTableChecklist_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler15 = {
   typeName: "SingleTableChecklistItem",
   codec: handler_codec_base64JSON,
@@ -5428,81 +4688,6 @@ const handler15 = {
     return obj[0] === "SingleTableChecklistItem";
   }
 };
-function SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const pgResource_relational_topicsPgResource = registry.pgResources["relational_topics"];
 const handler16 = {
   typeName: "RelationalTopic",
@@ -5523,100 +4708,10 @@ const handler16 = {
     return obj[0] === "relational_topics";
   }
 };
-function RelationalTopic_relationalItemsByRootTopicId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_posts_relational_postsPgResource = registry.pgResources["relational_posts"];
 const relational_dividers_relational_dividersPgResource = registry.pgResources["relational_dividers"];
 const relational_checklists_relational_checklistsPgResource = registry.pgResources["relational_checklists"];
 const relational_checklist_items_relational_checklist_itemsPgResource = registry.pgResources["relational_checklist_items"];
-function RelationalTopic_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler17 = {
   typeName: "RelationalPost",
   codec: handler_codec_base64JSON,
@@ -5636,81 +4731,6 @@ const handler17 = {
     return obj[0] === "relational_posts";
   }
 };
-function RelationalPost_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler18 = {
   typeName: "RelationalDivider",
   codec: handler_codec_base64JSON,
@@ -5730,81 +4750,6 @@ const handler18 = {
     return obj[0] === "relational_dividers";
   }
 };
-function RelationalDivider_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler19 = {
   typeName: "RelationalChecklist",
   codec: handler_codec_base64JSON,
@@ -5824,81 +4769,6 @@ const handler19 = {
     return obj[0] === "relational_checklists";
   }
 };
-function RelationalChecklist_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const handler20 = {
   typeName: "RelationalChecklistItem",
   codec: handler_codec_base64JSON,
@@ -5918,84 +4788,6 @@ const handler20 = {
     return obj[0] === "relational_checklist_items";
   }
 };
-function RelationalChecklistItem_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler21 = {
   typeName: "Query",
   codec: nodeIdCodecs.raw,
@@ -6123,25 +4915,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs(args);
   return resource_all_single_tablesPgResource.execute(selectArgs);
 };
-function Query_allSingleTablesPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_allSingleTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple2 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6399,21 +5172,6 @@ const resourceByTypeName7 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function Query_allVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members8 = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication"
@@ -6425,323 +5183,8 @@ const resourceByTypeName8 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Query_allApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members9 = [];
 const resourceByTypeName9 = Object.create(null);
-function Query_allZeroImplementations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allZeroImplementations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allZeroImplementations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allZeroImplementations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allZeroImplementations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allOrganizations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOrganizations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOrganizations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOrganizations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOrganizations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPriorities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPriorities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPriorities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPriorities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPriorities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklists_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklists_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklists_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklists_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklists_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalTopics_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalTopics_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalTopics_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalTopics_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalTopics_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklistItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklistItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklistItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklistItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklistItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalDividers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalDividers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalDividers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalDividers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalDividers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLogEntries_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLogEntries_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLogEntries_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLogEntries_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLogEntries_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allAwsApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAwsApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAwsApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAwsApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAwsApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allGcpApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGcpApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGcpApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGcpApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGcpApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members10 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "AwsApplication",
@@ -6794,21 +5237,6 @@ const resourceByTypeName10 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function FirstPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function FirstPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function FirstPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes4 = {};
 const members11 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
@@ -6992,21 +5420,6 @@ const resourceByTypeName12 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function ThirdPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function ThirdPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes5 = {};
 const members13 = [{
   resource: members_1_resource_aws_application_third_party_vulnerabilitiesPgResource,
@@ -7138,116 +5551,6 @@ const resourceByTypeName13 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function ZeroImplementationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ZeroImplementationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ZeroImplementationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function OrganizationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OrganizationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OrganizationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PrioritiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PrioritiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PrioritiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalTopicsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalTopicsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalTopicsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalDividersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalDividersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalDividersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalPostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalPostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalPostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FirstPartyVulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FirstPartyVulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FirstPartyVulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ThirdPartyVulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ThirdPartyVulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ThirdPartyVulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const decodeNodeId = makeDecodeNodeId([handler16, handler17, handler18, handler19, handler20]);
 const details = [{
   pkAttributes: uniques10[0].attributes,
@@ -7343,929 +5646,94 @@ const makeArgs3 = (args, path = []) => {
   return selectArgs;
 };
 const resource_custom_delete_relational_itemPgResource = registry.pgResources["custom_delete_relational_item"];
-function Mutation_customDeleteRelationalItem_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOrganization_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLogEntry_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createAwsApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createGcpApplication_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler4, $nodeId);
 };
-function Mutation_updateOrganization_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler2, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler8, $nodeId);
 };
-function Mutation_updateRelationalItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler10, $nodeId);
 };
-function Mutation_updateSingleTableItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler7, $nodeId);
 };
-function Mutation_updateRelationalItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler9, $nodeId);
 };
-function Mutation_updateSingleTableItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler3, $nodeId);
 };
-function Mutation_updateLogEntry_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLogEntryById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.FirstPartyVulnerability, $nodeId);
 };
-function Mutation_updateFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFirstPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ThirdPartyVulnerability, $nodeId);
 };
-function Mutation_updateThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateThirdPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler5, $nodeId);
 };
-function Mutation_updateAwsApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAwsApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler6, $nodeId);
 };
-function Mutation_updateGcpApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGcpApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler4, $nodeId);
 };
-function Mutation_deleteOrganization_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler2, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler8, $nodeId);
 };
-function Mutation_deleteRelationalItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler10, $nodeId);
 };
-function Mutation_deleteSingleTableItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler7, $nodeId);
 };
-function Mutation_deleteRelationalItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler9, $nodeId);
 };
-function Mutation_deleteSingleTableItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler3, $nodeId);
 };
-function Mutation_deleteLogEntry_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLogEntryById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.FirstPartyVulnerability, $nodeId);
 };
-function Mutation_deleteFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFirstPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ThirdPartyVulnerability, $nodeId);
 };
-function Mutation_deleteThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteThirdPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler5, $nodeId);
 };
-function Mutation_deleteAwsApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAwsApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(handler6, $nodeId);
 };
-function Mutation_deleteGcpApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGcpApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CustomDeleteRelationalItemPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CustomDeleteRelationalItemPayload_queryPlan() {
-  return rootValue();
-}
-function CustomDeleteRelationalItemInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function CreateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOrganizationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOrganizationInput_organization_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationInput_relationalItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function CreateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLogEntryInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLogEntryInput_logEntry_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAwsApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAwsApplicationInput_awsApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGcpApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGcpApplicationInput_gcpApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function UpdateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOrganizationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByNameInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByPersonIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByUsernameInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function UpdateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLogEntryInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLogEntryInput_logEntryPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLogEntryByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLogEntryByIdInput_logEntryPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFirstPartyVulnerabilityInput_firstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFirstPartyVulnerabilityByIdInput_firstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateThirdPartyVulnerabilityInput_thirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateThirdPartyVulnerabilityByIdInput_thirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAwsApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationInput_awsApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationByIdInput_awsApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGcpApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationInput_gcpApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationByIdInput_gcpApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function DeleteOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOrganizationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function DeleteLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLogEntryInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLogEntryByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAwsApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAwsApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGcpApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`type SingleTableTopic implements SingleTableItem & Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -16511,23 +13979,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16557,23 +14035,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16603,23 +14091,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16649,23 +14147,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16695,23 +14203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16759,23 +14277,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16805,23 +14333,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16851,23 +14389,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16897,23 +14445,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16943,23 +14501,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17010,23 +14578,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17056,9 +14634,16 @@ export const plans = {
   },
   LogEntriesConnection: {
     __assertStep: ConnectionStep,
-    nodes: LogEntriesConnection_nodesPlan,
-    edges: LogEntriesConnection_edgesPlan,
-    pageInfo: LogEntriesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17141,23 +14726,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17187,23 +14782,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17233,23 +14838,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17539,9 +15154,16 @@ export const plans = {
   },
   AwsApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: AwsApplicationsConnection_nodesPlan,
-    edges: AwsApplicationsConnection_edgesPlan,
-    pageInfo: AwsApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17611,23 +15233,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17684,18 +15316,32 @@ export const plans = {
   },
   VulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: VulnerabilitiesConnection_nodesPlan,
-    edges: VulnerabilitiesConnection_edgesPlan,
-    pageInfo: VulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   ApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ApplicationsConnection_nodesPlan,
-    edges: ApplicationsConnection_edgesPlan,
-    pageInfo: ApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17711,8 +15357,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -17722,9 +15372,16 @@ export const plans = {
   },
   PersonOrOrganizationConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonOrOrganizationConnection_nodesPlan,
-    edges: PersonOrOrganizationConnection_edgesPlan,
-    pageInfo: PersonOrOrganizationConnection_pageInfoPlan
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    }
   },
   PersonOrOrganizationEdge: {
     __assertStep: assertEdgeCapableStep,
@@ -18314,9 +15971,16 @@ export const plans = {
   },
   GcpApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: GcpApplicationsConnection_nodesPlan,
-    edges: GcpApplicationsConnection_edgesPlan,
-    pageInfo: GcpApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18386,23 +16050,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18858,9 +16532,16 @@ export const plans = {
   },
   SingleTableItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemsConnection_nodesPlan,
-    edges: SingleTableItemsConnection_edgesPlan,
-    pageInfo: SingleTableItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19485,18 +17166,32 @@ export const plans = {
   },
   RelationalItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemsConnection_nodesPlan,
-    edges: RelationalItemsConnection_edgesPlan,
-    pageInfo: RelationalItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   RelationalItemRelationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationsConnection_nodesPlan,
-    edges: RelationalItemRelationsConnection_edgesPlan,
-    pageInfo: RelationalItemRelationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19538,9 +17233,16 @@ export const plans = {
   },
   RelationalItemRelationCompositePksConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationCompositePksConnection_nodesPlan,
-    edges: RelationalItemRelationCompositePksConnection_edgesPlan,
-    pageInfo: RelationalItemRelationCompositePksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20375,9 +18077,16 @@ export const plans = {
   },
   SingleTableItemRelationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationsConnection_nodesPlan,
-    edges: SingleTableItemRelationsConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20419,9 +18128,16 @@ export const plans = {
   },
   SingleTableItemRelationCompositePksConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationCompositePksConnection_nodesPlan,
-    edges: SingleTableItemRelationCompositePksConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationCompositePksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20894,23 +18610,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20940,23 +18666,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20986,23 +18722,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21032,23 +18778,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21078,23 +18834,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21142,23 +18908,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21241,23 +19017,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21287,23 +19073,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21333,23 +19129,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21379,23 +19185,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21425,23 +19241,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21526,23 +19352,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21572,23 +19408,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21618,23 +19464,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21664,23 +19520,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21710,23 +19576,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21827,23 +19703,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21873,23 +19759,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21919,23 +19815,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21965,23 +19871,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22011,23 +19927,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22102,23 +20028,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22198,23 +20134,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22322,23 +20268,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22376,23 +20332,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22430,23 +20396,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22484,23 +20460,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22989,23 +20975,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23113,23 +21109,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23167,23 +21173,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23221,23 +21237,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23275,23 +21301,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23414,23 +21450,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23538,23 +21584,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23592,23 +21648,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23646,23 +21712,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23700,23 +21776,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23836,23 +21922,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23960,23 +22056,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24014,23 +22120,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24068,23 +22184,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24122,23 +22248,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24261,23 +22397,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24385,23 +22531,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24439,23 +22595,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24493,23 +22659,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24547,23 +22723,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24588,7 +22774,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler21.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler21.codec.name].encode);
@@ -24820,27 +23008,40 @@ export const plans = {
       }
     },
     allSingleTables: {
-      plan: Query_allSingleTablesPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -25064,23 +23265,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25120,23 +23331,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25176,23 +23397,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25219,23 +23450,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25262,23 +23503,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25305,23 +23556,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -25332,23 +23593,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25375,23 +23646,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25418,23 +23699,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25461,23 +23752,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25504,23 +23805,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25547,23 +23858,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25590,23 +23911,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25633,23 +23964,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25676,23 +24017,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25719,23 +24070,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25762,23 +24123,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25805,23 +24176,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25848,23 +24229,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25891,23 +24282,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25934,23 +24335,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25977,23 +24388,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26063,23 +24484,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26183,23 +24614,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26256,9 +24697,16 @@ export const plans = {
   },
   ZeroImplementationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ZeroImplementationsConnection_nodesPlan,
-    edges: ZeroImplementationsConnection_edgesPlan,
-    pageInfo: ZeroImplementationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -26395,9 +24843,16 @@ export const plans = {
   },
   OrganizationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: OrganizationsConnection_nodesPlan,
-    edges: OrganizationsConnection_edgesPlan,
-    pageInfo: OrganizationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -26566,9 +25021,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -26737,9 +25199,16 @@ export const plans = {
   },
   PrioritiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PrioritiesConnection_nodesPlan,
-    edges: PrioritiesConnection_edgesPlan,
-    pageInfo: PrioritiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -26755,9 +25224,16 @@ export const plans = {
   },
   RelationalChecklistsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistsConnection_nodesPlan,
-    edges: RelationalChecklistsConnection_edgesPlan,
-    pageInfo: RelationalChecklistsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27439,9 +25915,16 @@ export const plans = {
   },
   RelationalTopicsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalTopicsConnection_nodesPlan,
-    edges: RelationalTopicsConnection_edgesPlan,
-    pageInfo: RelationalTopicsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28123,9 +26606,16 @@ export const plans = {
   },
   RelationalChecklistItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistItemsConnection_nodesPlan,
-    edges: RelationalChecklistItemsConnection_edgesPlan,
-    pageInfo: RelationalChecklistItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28864,9 +27354,16 @@ export const plans = {
   },
   RelationalDividersConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalDividersConnection_nodesPlan,
-    edges: RelationalDividersConnection_edgesPlan,
-    pageInfo: RelationalDividersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -29605,9 +28102,16 @@ export const plans = {
   },
   RelationalPostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalPostsConnection_nodesPlan,
-    edges: RelationalPostsConnection_edgesPlan,
-    pageInfo: RelationalPostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -30403,9 +28907,16 @@ export const plans = {
   },
   FirstPartyVulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: FirstPartyVulnerabilitiesConnection_nodesPlan,
-    edges: FirstPartyVulnerabilitiesConnection_edgesPlan,
-    pageInfo: FirstPartyVulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -30688,9 +29199,16 @@ export const plans = {
   },
   ThirdPartyVulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ThirdPartyVulnerabilitiesConnection_nodesPlan,
-    edges: ThirdPartyVulnerabilitiesConnection_edgesPlan,
-    pageInfo: ThirdPartyVulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -30984,7 +29502,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_customDeleteRelationalItem_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -30999,7 +29519,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOrganization_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31014,7 +29536,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31029,7 +29553,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31044,7 +29570,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31059,7 +29587,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31074,7 +29604,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31089,7 +29621,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLogEntry_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31104,7 +29638,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31119,7 +29655,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31134,7 +29672,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAwsApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31149,7 +29689,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGcpApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31163,7 +29705,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganization_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31179,7 +29723,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31195,7 +29741,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31209,7 +29757,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31225,7 +29775,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31241,7 +29793,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31255,7 +29809,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31272,7 +29828,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31286,7 +29844,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31303,7 +29863,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31317,7 +29879,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31333,7 +29897,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31350,7 +29916,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31364,7 +29932,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31380,7 +29950,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31397,7 +29969,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31411,7 +29985,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLogEntry_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31427,7 +30003,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLogEntryById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31441,7 +30019,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31457,7 +30037,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFirstPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31471,7 +30053,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31487,7 +30071,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateThirdPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31501,7 +30087,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31517,7 +30105,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31531,7 +30121,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31547,7 +30139,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31561,7 +30155,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganization_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31577,7 +30173,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31593,7 +30191,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31607,7 +30207,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31623,7 +30225,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31639,7 +30243,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31653,7 +30259,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31670,7 +30278,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31684,7 +30294,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31701,7 +30313,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31715,7 +30329,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31731,7 +30347,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31748,7 +30366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31762,7 +30382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31778,7 +30400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31795,7 +30419,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31809,7 +30435,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLogEntry_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31825,7 +30453,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLogEntryById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31839,7 +30469,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31855,7 +30487,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFirstPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31869,7 +30503,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31885,7 +30521,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteThirdPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31899,7 +30537,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31915,7 +30555,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31929,7 +30571,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -31945,31 +30589,45 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CustomDeleteRelationalItemPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CustomDeleteRelationalItemPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: CustomDeleteRelationalItemPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CustomDeleteRelationalItemInput: {
     clientMutationId: {
-      applyPlan: CustomDeleteRelationalItemInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nodeId: undefined
   },
   CreateOrganizationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOrganizationPayload_clientMutationIdPlan,
-    organization: CreateOrganizationPayload_organizationPlan,
-    query: CreateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32004,11 +30662,16 @@ export const plans = {
   },
   CreateOrganizationInput: {
     clientMutationId: {
-      applyPlan: CreateOrganizationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     organization: {
-      applyPlan: CreateOrganizationInput_organization_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32030,9 +30693,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32067,11 +30736,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32093,9 +30767,15 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: CreateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32140,11 +30820,16 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelationCompositePk: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32166,9 +30851,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: CreateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32213,11 +30904,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelationCompositePk: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32239,9 +30935,15 @@ export const plans = {
   },
   CreateRelationalItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: CreateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: CreateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32286,11 +30988,16 @@ export const plans = {
   },
   CreateRelationalItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelation: {
-      applyPlan: CreateRelationalItemRelationInput_relationalItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32319,9 +31026,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: CreateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: CreateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32366,11 +31079,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelation: {
-      applyPlan: CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32399,9 +31117,15 @@ export const plans = {
   },
   CreateLogEntryPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLogEntryPayload_clientMutationIdPlan,
-    logEntry: CreateLogEntryPayload_logEntryPlan,
-    query: CreateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32446,11 +31170,16 @@ export const plans = {
   },
   CreateLogEntryInput: {
     clientMutationId: {
-      applyPlan: CreateLogEntryInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     logEntry: {
-      applyPlan: CreateLogEntryInput_logEntry_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32486,9 +31215,15 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: CreateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32523,11 +31258,16 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     firstPartyVulnerability: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32563,9 +31303,15 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: CreateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32600,11 +31346,16 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     thirdPartyVulnerability: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32640,9 +31391,15 @@ export const plans = {
   },
   CreateAwsApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: CreateAwsApplicationPayload_awsApplicationPlan,
-    query: CreateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32687,11 +31444,16 @@ export const plans = {
   },
   CreateAwsApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateAwsApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     awsApplication: {
-      applyPlan: CreateAwsApplicationInput_awsApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32741,9 +31503,15 @@ export const plans = {
   },
   CreateGcpApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: CreateGcpApplicationPayload_gcpApplicationPlan,
-    query: CreateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32788,11 +31556,16 @@ export const plans = {
   },
   CreateGcpApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateGcpApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     gcpApplication: {
-      applyPlan: CreateGcpApplicationInput_gcpApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -32842,9 +31615,15 @@ export const plans = {
   },
   UpdateOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOrganizationPayload_clientMutationIdPlan,
-    organization: UpdateOrganizationPayload_organizationPlan,
-    query: UpdateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32879,11 +31658,16 @@ export const plans = {
   },
   UpdateOrganizationInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OrganizationPatch: {
@@ -32904,27 +31688,43 @@ export const plans = {
   },
   UpdateOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByNameInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -32959,11 +31759,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -32984,27 +31789,43 @@ export const plans = {
   },
   UpdatePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByPersonIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByUsernameInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: UpdateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33049,11 +31870,16 @@ export const plans = {
   },
   UpdateRelationalItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     relationalItemRelationCompositePkPatch: {
-      applyPlan: UpdateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationCompositePkPatch: {
@@ -33074,19 +31900,30 @@ export const plans = {
   },
   UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationCompositePkPatch: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: UpdateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33131,11 +31968,16 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     singleTableItemRelationCompositePkPatch: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationCompositePkPatch: {
@@ -33156,19 +31998,30 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationCompositePkPatch: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: UpdateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: UpdateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33213,11 +32066,16 @@ export const plans = {
   },
   UpdateRelationalItemRelationInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationPatch: {
@@ -33245,28 +32103,44 @@ export const plans = {
   },
   UpdateRelationalItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: UpdateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33311,11 +32185,16 @@ export const plans = {
   },
   UpdateSingleTableItemRelationInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationPatch: {
@@ -33343,28 +32222,44 @@ export const plans = {
   },
   UpdateSingleTableItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLogEntryPayload_clientMutationIdPlan,
-    logEntry: UpdateLogEntryPayload_logEntryPlan,
-    query: UpdateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33409,11 +32304,16 @@ export const plans = {
   },
   UpdateLogEntryInput: {
     clientMutationId: {
-      applyPlan: UpdateLogEntryInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     logEntryPatch: {
-      applyPlan: UpdateLogEntryInput_logEntryPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LogEntryPatch: {
@@ -33448,18 +32348,29 @@ export const plans = {
   },
   UpdateLogEntryByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLogEntryByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     logEntryPatch: {
-      applyPlan: UpdateLogEntryByIdInput_logEntryPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: UpdateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33494,11 +32405,16 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: UpdateFirstPartyVulnerabilityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     firstPartyVulnerabilityPatch: {
-      applyPlan: UpdateFirstPartyVulnerabilityInput_firstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FirstPartyVulnerabilityPatch: {
@@ -33533,18 +32449,29 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     firstPartyVulnerabilityPatch: {
-      applyPlan: UpdateFirstPartyVulnerabilityByIdInput_firstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: UpdateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33579,11 +32506,16 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: UpdateThirdPartyVulnerabilityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     thirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateThirdPartyVulnerabilityInput_thirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ThirdPartyVulnerabilityPatch: {
@@ -33618,18 +32550,29 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     thirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateThirdPartyVulnerabilityByIdInput_thirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: UpdateAwsApplicationPayload_awsApplicationPlan,
-    query: UpdateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33674,11 +32617,16 @@ export const plans = {
   },
   UpdateAwsApplicationInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     awsApplicationPatch: {
-      applyPlan: UpdateAwsApplicationInput_awsApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AwsApplicationPatch: {
@@ -33727,18 +32675,29 @@ export const plans = {
   },
   UpdateAwsApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     awsApplicationPatch: {
-      applyPlan: UpdateAwsApplicationByIdInput_awsApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: UpdateGcpApplicationPayload_gcpApplicationPlan,
-    query: UpdateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33783,11 +32742,16 @@ export const plans = {
   },
   UpdateGcpApplicationInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     gcpApplicationPatch: {
-      applyPlan: UpdateGcpApplicationInput_gcpApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GcpApplicationPatch: {
@@ -33836,23 +32800,34 @@ export const plans = {
   },
   UpdateGcpApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     gcpApplicationPatch: {
-      applyPlan: UpdateGcpApplicationByIdInput_gcpApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOrganizationPayload_clientMutationIdPlan,
-    organization: DeleteOrganizationPayload_organizationPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
     deletedOrganizationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler4.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteOrganizationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33887,32 +32862,44 @@ export const plans = {
   },
   DeleteOrganizationInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined
   },
   DeleteOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler2.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33947,32 +32934,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeletePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined
   },
   DeleteRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
     deletedRelationalItemRelationCompositePkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler8.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteRelationalItemRelationCompositePkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34017,27 +33016,37 @@ export const plans = {
   },
   DeleteRelationalItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationCompositePkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
     deletedSingleTableItemRelationCompositePkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler10.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteSingleTableItemRelationCompositePkPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34082,27 +33091,37 @@ export const plans = {
   },
   DeleteSingleTableItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: DeleteRelationalItemRelationPayload_relationalItemRelationPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
     deletedRelationalItemRelationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler7.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteRelationalItemRelationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34147,33 +33166,45 @@ export const plans = {
   },
   DeleteRelationalItemRelationInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteRelationalItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
     deletedSingleTableItemRelationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler9.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteSingleTableItemRelationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34218,33 +33249,45 @@ export const plans = {
   },
   DeleteSingleTableItemRelationInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSingleTableItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLogEntryPayload_clientMutationIdPlan,
-    logEntry: DeleteLogEntryPayload_logEntryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
     deletedLogEntryId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler3.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteLogEntryPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34289,26 +33332,36 @@ export const plans = {
   },
   DeleteLogEntryInput: {
     clientMutationId: {
-      applyPlan: DeleteLogEntryInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLogEntryByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLogEntryByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
     deletedFirstPartyVulnerabilityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.FirstPartyVulnerability.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteFirstPartyVulnerabilityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34343,26 +33396,36 @@ export const plans = {
   },
   DeleteFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: DeleteFirstPartyVulnerabilityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteFirstPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
     deletedThirdPartyVulnerabilityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ThirdPartyVulnerability.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteThirdPartyVulnerabilityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34397,26 +33460,36 @@ export const plans = {
   },
   DeleteThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: DeleteThirdPartyVulnerabilityInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteThirdPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: DeleteAwsApplicationPayload_awsApplicationPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
     deletedAwsApplicationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler5.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteAwsApplicationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34461,26 +33534,36 @@ export const plans = {
   },
   DeleteAwsApplicationInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteAwsApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: DeleteGcpApplicationPayload_gcpApplicationPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
     deletedGcpApplicationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler6.plan($record);
       return lambda(specifier, handler_codec_base64JSON.encode);
     },
-    query: DeleteGcpApplicationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34525,13 +33608,17 @@ export const plans = {
   },
   DeleteGcpApplicationInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteGcpApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -13,6 +13,26 @@ const handler_codec_base64JSON = {
   encode: base64JSONEncode,
   decode: base64JSONDecode
 };
+const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
+  aws_application_id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  first_party_vulnerability_id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -35,35 +55,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_awsApplicationFirstPartyVulnerabilities = {
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
+const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]),
-  attributes: Object.assign(Object.create(null), {
-    aws_application_id: {
-      description: undefined,
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    first_party_vulnerability_id: {
-      description: undefined,
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
-const attributes2 = Object.assign(Object.create(null), {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
+const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -96,17 +98,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_awsApplicationThirdPartyVulnerabilities = {
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
+const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
-const attributes3 = Object.assign(Object.create(null), {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
+const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -139,17 +141,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_gcpApplicationFirstPartyVulnerabilities = {
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
+const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
-const attributes4 = Object.assign(Object.create(null), {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
+const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -182,17 +184,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_gcpApplicationThirdPartyVulnerabilities = {
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
+const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
     codec: TYPES.int,
@@ -224,17 +226,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["polymorphic", "organizations"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_organizations = {
+const organizationsIdentifier = sql.identifier(...parts5);
+const organizationsCodecSpec = {
   name: "organizations",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: organizationsIdentifier,
+  attributes: organizationsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_organizations_organizations = recordCodec(spec_organizations);
-const attributes5 = Object.assign(Object.create(null), {
+const organizationsCodec = recordCodec(organizationsCodecSpec);
+const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -281,17 +283,17 @@ const extensions6 = {
   })
 };
 const parts6 = ["polymorphic", "people"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_people = {
+const peopleIdentifier = sql.identifier(...parts6);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes6 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const prioritiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -324,16 +326,16 @@ const extensions7 = {
   })
 };
 const parts7 = ["polymorphic", "priorities"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_priorities = {
+const prioritiesIdentifier = sql.identifier(...parts7);
+const prioritiesCodecSpec = {
   name: "priorities",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: prioritiesIdentifier,
+  attributes: prioritiesAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_priorities_priorities = recordCodec(spec_priorities);
+const prioritiesCodec = recordCodec(prioritiesCodecSpec);
 const extensions8 = {
   pg: {
     serviceName: "main",
@@ -343,15 +345,14 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["polymorphic", "item_type"];
-const sqlIdent8 = sql.identifier(...parts8);
-const attributes_type_codec_itemType = enumCodec({
+const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sqlIdent8,
+  identifier: sql.identifier(...parts8),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
   extensions: extensions8
 });
-const attributes7 = Object.assign(Object.create(null), {
+const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -382,7 +383,7 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemId",
@@ -492,17 +493,17 @@ const extensions9 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts9 = ["polymorphic", "relational_checklists"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_relationalChecklists = {
+const relationalChecklistsIdentifier = sql.identifier(...parts9);
+const relationalChecklistsCodecSpec = {
   name: "relationalChecklists",
-  identifier: sqlIdent9,
-  attributes: attributes7,
+  identifier: relationalChecklistsIdentifier,
+  attributes: relationalChecklistsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklists_relationalChecklists = recordCodec(spec_relationalChecklists);
-const attributes8 = Object.assign(Object.create(null), {
+const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -532,17 +533,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_relationalItemRelationCompositePks = {
+const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
+const relationalItemRelationCompositePksCodecSpec = {
   name: "relationalItemRelationCompositePks",
-  identifier: sqlIdent10,
-  attributes: attributes8,
+  identifier: relationalItemRelationCompositePksIdentifier,
+  attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks = recordCodec(spec_relationalItemRelationCompositePks);
-const attributes9 = Object.assign(Object.create(null), {
+const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -569,18 +570,18 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyTopicItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -591,7 +592,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -602,7 +603,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -613,7 +614,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -624,7 +625,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -635,7 +636,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -646,7 +647,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -657,7 +658,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -668,7 +669,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -683,17 +684,17 @@ const extensions11 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts11 = ["polymorphic", "relational_topics"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_relationalTopics = {
+const relationalTopicsIdentifier = sql.identifier(...parts11);
+const relationalTopicsCodecSpec = {
   name: "relationalTopics",
-  identifier: sqlIdent11,
-  attributes: attributes9,
+  identifier: relationalTopicsIdentifier,
+  attributes: relationalTopicsAttributes,
   description: undefined,
   extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalTopics_relationalTopics = recordCodec(spec_relationalTopics);
-const attributes10 = Object.assign(Object.create(null), {
+const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -723,17 +724,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_singleTableItemRelationCompositePks = {
+const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
+const singleTableItemRelationCompositePksCodecSpec = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sqlIdent12,
-  attributes: attributes10,
+  identifier: singleTableItemRelationCompositePksIdentifier,
+  attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks = recordCodec(spec_singleTableItemRelationCompositePks);
-const attributes11 = Object.assign(Object.create(null), {
+const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -769,18 +770,18 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -791,7 +792,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -802,7 +803,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -813,7 +814,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -824,7 +825,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -835,7 +836,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -846,7 +847,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -857,7 +858,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -868,7 +869,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -883,17 +884,17 @@ const extensions13 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts13 = ["polymorphic", "relational_checklist_items"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_relationalChecklistItems = {
+const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
+const relationalChecklistItemsCodecSpec = {
   name: "relationalChecklistItems",
-  identifier: sqlIdent13,
-  attributes: attributes11,
+  identifier: relationalChecklistItemsIdentifier,
+  attributes: relationalChecklistItemsAttributes,
   description: undefined,
   extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems = recordCodec(spec_relationalChecklistItems);
-const attributes12 = Object.assign(Object.create(null), {
+const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -929,18 +930,18 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyDividerItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -951,7 +952,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -962,7 +963,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -973,7 +974,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -984,7 +985,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -995,7 +996,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -1006,7 +1007,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1017,7 +1018,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1028,7 +1029,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1043,17 +1044,17 @@ const extensions14 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts14 = ["polymorphic", "relational_dividers"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_relationalDividers = {
+const relationalDividersIdentifier = sql.identifier(...parts14);
+const relationalDividersCodecSpec = {
   name: "relationalDividers",
-  identifier: sqlIdent14,
-  attributes: attributes12,
+  identifier: relationalDividersIdentifier,
+  attributes: relationalDividersAttributes,
   description: undefined,
   extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalDividers_relationalDividers = recordCodec(spec_relationalDividers);
-const attributes13 = Object.assign(Object.create(null), {
+const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1092,17 +1093,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts15 = ["polymorphic", "relational_item_relations"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_relationalItemRelations = {
+const relationalItemRelationsIdentifier = sql.identifier(...parts15);
+const relationalItemRelationsCodecSpec = {
   name: "relationalItemRelations",
-  identifier: sqlIdent15,
-  attributes: attributes13,
+  identifier: relationalItemRelationsIdentifier,
+  attributes: relationalItemRelationsAttributes,
   description: undefined,
   extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations = recordCodec(spec_relationalItemRelations);
-const attributes14 = Object.assign(Object.create(null), {
+const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1141,17 +1142,17 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts16 = ["polymorphic", "single_table_item_relations"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_singleTableItemRelations = {
+const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
+const singleTableItemRelationsCodecSpec = {
   name: "singleTableItemRelations",
-  identifier: sqlIdent16,
-  attributes: attributes14,
+  identifier: singleTableItemRelationsIdentifier,
+  attributes: singleTableItemRelationsAttributes,
   description: undefined,
   extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations = recordCodec(spec_singleTableItemRelations);
-const attributes15 = Object.assign(Object.create(null), {
+const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1215,17 +1216,17 @@ const extensions17 = {
   })
 };
 const parts17 = ["polymorphic", "log_entries"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_logEntries = {
+const logEntriesIdentifier = sql.identifier(...parts17);
+const logEntriesCodecSpec = {
   name: "logEntries",
-  identifier: sqlIdent17,
-  attributes: attributes15,
+  identifier: logEntriesIdentifier,
+  attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_logEntries_logEntries = recordCodec(spec_logEntries);
-const attributes16 = Object.assign(Object.create(null), {
+const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -1270,18 +1271,18 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyPostItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1292,7 +1293,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1303,7 +1304,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -1314,7 +1315,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -1325,7 +1326,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -1336,7 +1337,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -1347,7 +1348,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1358,7 +1359,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1369,7 +1370,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1384,17 +1385,17 @@ const extensions18 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts18 = ["polymorphic", "relational_posts"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_relationalPosts = {
+const relationalPostsIdentifier = sql.identifier(...parts18);
+const relationalPostsCodecSpec = {
   name: "relationalPosts",
-  identifier: sqlIdent18,
-  attributes: attributes16,
+  identifier: relationalPostsIdentifier,
+  attributes: relationalPostsAttributes,
   description: undefined,
   extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalPosts_relationalPosts = recordCodec(spec_relationalPosts);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1470,17 +1471,17 @@ const extensions19 = {
   })
 };
 const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_firstPartyVulnerabilities = {
+const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
+const firstPartyVulnerabilitiesCodecSpec = {
   name: "firstPartyVulnerabilities",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_2,
+  identifier: firstPartyVulnerabilitiesIdentifier,
+  attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities = recordCodec(spec_firstPartyVulnerabilities);
-const attributes_object_Object_3 = Object.assign(Object.create(null), {
+const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1556,17 +1557,17 @@ const extensions20 = {
   })
 };
 const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_thirdPartyVulnerabilities = {
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
+const thirdPartyVulnerabilitiesCodecSpec = {
   name: "thirdPartyVulnerabilities",
-  identifier: sqlIdent20,
-  attributes: attributes_object_Object_3,
+  identifier: thirdPartyVulnerabilitiesIdentifier,
+  attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities = recordCodec(spec_thirdPartyVulnerabilities);
-const attributes_object_Object_4 = Object.assign(Object.create(null), {
+const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1660,17 +1661,17 @@ const extensions21 = {
   })
 };
 const parts21 = ["polymorphic", "aws_applications"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_awsApplications = {
+const awsApplicationsIdentifier = sql.identifier(...parts21);
+const awsApplicationsCodecSpec = {
   name: "awsApplications",
-  identifier: sqlIdent21,
-  attributes: attributes_object_Object_4,
+  identifier: awsApplicationsIdentifier,
+  attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplications_awsApplications = recordCodec(spec_awsApplications);
-const attributes_object_Object_5 = Object.assign(Object.create(null), {
+const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1764,17 +1765,17 @@ const extensions22 = {
   })
 };
 const parts22 = ["polymorphic", "gcp_applications"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_gcpApplications = {
+const gcpApplicationsIdentifier = sql.identifier(...parts22);
+const gcpApplicationsCodecSpec = {
   name: "gcpApplications",
-  identifier: sqlIdent22,
-  attributes: attributes_object_Object_5,
+  identifier: gcpApplicationsIdentifier,
+  attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplications_gcpApplications = recordCodec(spec_gcpApplications);
-const attributes17 = Object.assign(Object.create(null), {
+const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1786,7 +1787,7 @@ const attributes17 = Object.assign(Object.create(null), {
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1949,33 +1950,33 @@ const extensions23 = {
   })
 };
 const parts23 = ["polymorphic", "single_table_items"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_singleTableItems = {
+const singleTableItemsIdentifier = sql.identifier(...parts23);
+const singleTableItemsCodecSpec = {
   name: "singleTableItems",
-  identifier: sqlIdent23,
-  attributes: attributes17,
+  identifier: singleTableItemsIdentifier,
+  attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItems_singleTableItems = recordCodec(spec_singleTableItems);
-const attributes18 = Object.assign(Object.create(null), {
+const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1984,7 +1985,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1993,7 +1994,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -2002,7 +2003,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: false,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -2011,7 +2012,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -2020,7 +2021,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -2029,7 +2030,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -2038,7 +2039,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -2047,7 +2048,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -2064,17 +2065,17 @@ const extensions24 = {
   })
 };
 const parts24 = ["polymorphic", "relational_items"];
-const sqlIdent24 = sql.identifier(...parts24);
-const spec_relationalItems = {
+const relationalItemsIdentifier = sql.identifier(...parts24);
+const relationalItemsCodecSpec = {
   name: "relationalItems",
-  identifier: sqlIdent24,
-  attributes: attributes18,
+  identifier: relationalItemsIdentifier,
+  attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItems_relationalItems = recordCodec(spec_relationalItems);
-const attributes_object_Object_6 = Object.assign(Object.create(null), {
+const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2146,16 +2147,16 @@ const extensions25 = {
   })
 };
 const parts25 = ["polymorphic", "applications"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_Application = {
+const ApplicationIdentifier = sql.identifier(...parts25);
+const ApplicationCodecSpec = {
   name: "Application",
-  identifier: sqlIdent25,
-  attributes: attributes_object_Object_6,
+  identifier: ApplicationIdentifier,
+  attributes: ApplicationAttributes,
   description: undefined,
   extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_7 = Object.assign(Object.create(null), {
+const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2229,16 +2230,16 @@ const extensions26 = {
   })
 };
 const parts26 = ["polymorphic", "vulnerabilities"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_Vulnerability = {
+const VulnerabilityIdentifier = sql.identifier(...parts26);
+const VulnerabilityCodecSpec = {
   name: "Vulnerability",
-  identifier: sqlIdent26,
-  attributes: attributes_object_Object_7,
+  identifier: VulnerabilityIdentifier,
+  attributes: VulnerabilityAttributes,
   description: undefined,
   extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_8 = Object.assign(Object.create(null), {
+const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2272,11 +2273,11 @@ const extensions27 = {
   })
 };
 const parts27 = ["polymorphic", "zero_implementation"];
-const sqlIdent27 = sql.identifier(...parts27);
-const spec_ZeroImplementation = {
+const ZeroImplementationIdentifier = sql.identifier(...parts27);
+const ZeroImplementationCodecSpec = {
   name: "ZeroImplementation",
-  identifier: sqlIdent27,
-  attributes: attributes_object_Object_8,
+  identifier: ZeroImplementationIdentifier,
+  attributes: ZeroImplementationAttributes,
   description: undefined,
   extensions: extensions27,
   executor: executor_mainPgExecutor
@@ -2297,8 +2298,8 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["aws_application_id", "first_party_vulnerability_id"],
@@ -2335,8 +2336,8 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -2366,8 +2367,8 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -2397,8 +2398,8 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -2434,8 +2435,8 @@ const registryConfig_pgResources_organizations_organizations = {
   executor: executor_mainPgExecutor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: registryConfig_pgCodecs_organizations_organizations.sqlType,
-  codec: registryConfig_pgCodecs_organizations_organizations,
+  from: organizationsCodec.sqlType,
+  codec: organizationsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -2473,8 +2474,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -2504,8 +2505,8 @@ const registryConfig_pgResources_priorities_priorities = {
   executor: executor_mainPgExecutor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: registryConfig_pgCodecs_priorities_priorities.sqlType,
-  codec: registryConfig_pgCodecs_priorities_priorities,
+  from: prioritiesCodec.sqlType,
+  codec: prioritiesCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -2532,8 +2533,8 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   executor: executor_mainPgExecutor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: registryConfig_pgCodecs_relationalChecklists_relationalChecklists.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+  from: relationalChecklistsCodec.sqlType,
+  codec: relationalChecklistsCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -2560,8 +2561,8 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   executor: executor_mainPgExecutor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+  from: relationalItemRelationCompositePksCodec.sqlType,
+  codec: relationalItemRelationCompositePksCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -2588,8 +2589,8 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   executor: executor_mainPgExecutor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: registryConfig_pgCodecs_relationalTopics_relationalTopics.sqlType,
-  codec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+  from: relationalTopicsCodec.sqlType,
+  codec: relationalTopicsCodec,
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
@@ -2616,8 +2617,8 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   executor: executor_mainPgExecutor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+  from: singleTableItemRelationCompositePksCodec.sqlType,
+  codec: singleTableItemRelationCompositePksCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
@@ -2644,8 +2645,8 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   executor: executor_mainPgExecutor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+  from: relationalChecklistItemsCodec.sqlType,
+  codec: relationalChecklistItemsCodec,
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
@@ -2672,8 +2673,8 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   executor: executor_mainPgExecutor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: registryConfig_pgCodecs_relationalDividers_relationalDividers.sqlType,
-  codec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+  from: relationalDividersCodec.sqlType,
+  codec: relationalDividersCodec,
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
@@ -2707,8 +2708,8 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   executor: executor_mainPgExecutor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+  from: relationalItemRelationsCodec.sqlType,
+  codec: relationalItemRelationsCodec,
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
@@ -2742,8 +2743,8 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   executor: executor_mainPgExecutor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+  from: singleTableItemRelationsCodec.sqlType,
+  codec: singleTableItemRelationsCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
@@ -2773,8 +2774,8 @@ const registryConfig_pgResources_log_entries_log_entries = {
   executor: executor_mainPgExecutor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: registryConfig_pgCodecs_logEntries_logEntries.sqlType,
-  codec: registryConfig_pgCodecs_logEntries_logEntries,
+  from: logEntriesCodec.sqlType,
+  codec: logEntriesCodec,
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
@@ -2801,8 +2802,8 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   executor: executor_mainPgExecutor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: registryConfig_pgCodecs_relationalPosts_relationalPosts.sqlType,
-  codec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+  from: relationalPostsCodec.sqlType,
+  codec: relationalPostsCodec,
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
@@ -2833,8 +2834,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   executor: executor_mainPgExecutor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+  from: firstPartyVulnerabilitiesCodec.sqlType,
+  codec: firstPartyVulnerabilitiesCodec,
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
@@ -2865,8 +2866,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   executor: executor_mainPgExecutor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  codec: thirdPartyVulnerabilitiesCodec,
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
@@ -2897,8 +2898,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   executor: executor_mainPgExecutor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: registryConfig_pgCodecs_awsApplications_awsApplications.sqlType,
-  codec: registryConfig_pgCodecs_awsApplications_awsApplications,
+  from: awsApplicationsCodec.sqlType,
+  codec: awsApplicationsCodec,
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
@@ -2929,8 +2930,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   executor: executor_mainPgExecutor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: registryConfig_pgCodecs_gcpApplications_gcpApplications.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+  from: gcpApplicationsCodec.sqlType,
+  codec: gcpApplicationsCodec,
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
@@ -2948,7 +2949,7 @@ const extensions49 = {
   }
 };
 const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent28 = sql.identifier(...parts28);
+const sqlIdent2 = sql.identifier(...parts28);
 const extensions50 = {
   description: undefined,
   pg: {
@@ -2974,20 +2975,20 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   executor: executor_mainPgExecutor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: registryConfig_pgCodecs_singleTableItems_singleTableItems.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+  from: singleTableItemsCodec.sqlType,
+  codec: singleTableItemsCodec,
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
   extensions: extensions50
 };
 const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent29 = sql.identifier(...parts29);
+const sqlIdent3 = sql.identifier(...parts29);
 const options_all_single_tables = {
   name: "all_single_tables",
   identifier: "main.polymorphic.all_single_tables()",
   from(...args) {
-    return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3006,12 +3007,12 @@ const options_all_single_tables = {
   description: undefined
 };
 const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent30 = sql.identifier(...parts30);
+const sqlIdent4 = sql.identifier(...parts30);
 const options_get_single_table_topic_by_id = {
   name: "get_single_table_topic_by_id",
   identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
   from(...args) {
-    return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3059,8 +3060,8 @@ const registryConfig_pgResources_relational_items_relational_items = {
   executor: executor_mainPgExecutor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: registryConfig_pgCodecs_relationalItems_relationalItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+  from: relationalItemsCodec.sqlType,
+  codec: relationalItemsCodec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
@@ -3068,41 +3069,41 @@ const registryConfig_pgResources_relational_items_relational_items = {
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
-    awsApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+    awsApplicationFirstPartyVulnerabilities: awsApplicationFirstPartyVulnerabilitiesCodec,
     int4: TYPES.int,
-    awsApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
-    gcpApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
-    gcpApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
-    organizations: registryConfig_pgCodecs_organizations_organizations,
+    awsApplicationThirdPartyVulnerabilities: awsApplicationThirdPartyVulnerabilitiesCodec,
+    gcpApplicationFirstPartyVulnerabilities: gcpApplicationFirstPartyVulnerabilitiesCodec,
+    gcpApplicationThirdPartyVulnerabilities: gcpApplicationThirdPartyVulnerabilitiesCodec,
+    organizations: organizationsCodec,
     text: TYPES.text,
-    people: registryConfig_pgCodecs_people_people,
-    priorities: registryConfig_pgCodecs_priorities_priorities,
-    relationalChecklists: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
-    relationalItemRelationCompositePks: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
-    relationalTopics: registryConfig_pgCodecs_relationalTopics_relationalTopics,
-    singleTableItemRelationCompositePks: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
-    relationalChecklistItems: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
-    relationalDividers: registryConfig_pgCodecs_relationalDividers_relationalDividers,
-    relationalItemRelations: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
-    singleTableItemRelations: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
-    logEntries: registryConfig_pgCodecs_logEntries_logEntries,
-    relationalPosts: registryConfig_pgCodecs_relationalPosts_relationalPosts,
-    firstPartyVulnerabilities: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+    people: peopleCodec,
+    priorities: prioritiesCodec,
+    relationalChecklists: relationalChecklistsCodec,
+    relationalItemRelationCompositePks: relationalItemRelationCompositePksCodec,
+    relationalTopics: relationalTopicsCodec,
+    singleTableItemRelationCompositePks: singleTableItemRelationCompositePksCodec,
+    relationalChecklistItems: relationalChecklistItemsCodec,
+    relationalDividers: relationalDividersCodec,
+    relationalItemRelations: relationalItemRelationsCodec,
+    singleTableItemRelations: singleTableItemRelationsCodec,
+    logEntries: logEntriesCodec,
+    relationalPosts: relationalPostsCodec,
+    firstPartyVulnerabilities: firstPartyVulnerabilitiesCodec,
     float8: TYPES.float,
-    thirdPartyVulnerabilities: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
-    awsApplications: registryConfig_pgCodecs_awsApplications_awsApplications,
+    thirdPartyVulnerabilities: thirdPartyVulnerabilitiesCodec,
+    awsApplications: awsApplicationsCodec,
     timestamptz: TYPES.timestamptz,
-    gcpApplications: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+    gcpApplications: gcpApplicationsCodec,
     bool: TYPES.boolean,
-    singleTableItems: registryConfig_pgCodecs_singleTableItems_singleTableItems,
-    itemType: attributes_type_codec_itemType,
+    singleTableItems: singleTableItemsCodec,
+    itemType: itemTypeCodec,
     int8: TYPES.bigint,
-    relationalItems: registryConfig_pgCodecs_relationalItems_relationalItems,
+    relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(spec_Application),
-    Vulnerability: recordCodec(spec_Vulnerability),
-    ZeroImplementation: recordCodec(spec_ZeroImplementation)
+    Application: recordCodec(ApplicationCodecSpec),
+    Vulnerability: recordCodec(VulnerabilityCodecSpec),
+    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3131,13 +3132,13 @@ const registryConfig = {
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
         required: true,
         notNull: false,
-        codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        codec: relationalItemsCodec,
         extensions: {
           variant: "nodeId"
         }
@@ -3157,7 +3158,7 @@ const registryConfig = {
   pgRelations: Object.assign(Object.create(null), {
     awsApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3172,7 +3173,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3189,7 +3190,7 @@ const registryConfig = {
     }),
     awsApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3204,7 +3205,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3221,7 +3222,7 @@ const registryConfig = {
     }),
     awsApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3236,7 +3237,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3251,7 +3252,7 @@ const registryConfig = {
         }
       },
       awsApplicationFirstPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3266,7 +3267,7 @@ const registryConfig = {
         }
       },
       awsApplicationThirdPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3283,7 +3284,7 @@ const registryConfig = {
     }),
     firstPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3298,7 +3299,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3315,7 +3316,7 @@ const registryConfig = {
     }),
     gcpApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3330,7 +3331,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3347,7 +3348,7 @@ const registryConfig = {
     }),
     gcpApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3362,7 +3363,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3379,7 +3380,7 @@ const registryConfig = {
     }),
     gcpApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3394,7 +3395,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3409,7 +3410,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3424,7 +3425,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3441,7 +3442,7 @@ const registryConfig = {
     }),
     logEntries: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3456,7 +3457,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3473,7 +3474,7 @@ const registryConfig = {
     }),
     organizations: Object.assign(Object.create(null), {
       logEntriesByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3488,7 +3489,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3503,7 +3504,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3520,7 +3521,7 @@ const registryConfig = {
     }),
     people: Object.assign(Object.create(null), {
       logEntriesByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3535,7 +3536,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3550,7 +3551,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3565,7 +3566,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3580,7 +3581,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3597,7 +3598,7 @@ const registryConfig = {
     }),
     priorities: Object.assign(Object.create(null), {
       singleTableItemsByTheirPriorityId: {
-        localCodec: registryConfig_pgCodecs_priorities_priorities,
+        localCodec: prioritiesCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3614,7 +3615,7 @@ const registryConfig = {
     }),
     relationalChecklistItems: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+        localCodec: relationalChecklistItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_item_id"],
@@ -3631,7 +3632,7 @@ const registryConfig = {
     }),
     relationalChecklists: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+        localCodec: relationalChecklistsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_id"],
@@ -3648,7 +3649,7 @@ const registryConfig = {
     }),
     relationalDividers: Object.assign(Object.create(null), {
       relationalItemsByMyDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+        localCodec: relationalDividersCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["divider_item_id"],
@@ -3665,7 +3666,7 @@ const registryConfig = {
     }),
     relationalItemRelationCompositePks: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3680,7 +3681,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3697,7 +3698,7 @@ const registryConfig = {
     }),
     relationalItemRelations: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3712,7 +3713,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3729,7 +3730,7 @@ const registryConfig = {
     }),
     relationalItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -3744,7 +3745,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3759,7 +3760,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -3774,7 +3775,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3789,7 +3790,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByTheirTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3804,7 +3805,7 @@ const registryConfig = {
         }
       },
       relationalPostsByTheirPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_posts_relational_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3819,7 +3820,7 @@ const registryConfig = {
         }
       },
       relationalDividersByTheirDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_dividers_relational_dividers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3834,7 +3835,7 @@ const registryConfig = {
         }
       },
       relationalChecklistsByTheirChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklists_relational_checklists,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3849,7 +3850,7 @@ const registryConfig = {
         }
       },
       relationalChecklistItemsByTheirChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklist_items_relational_checklist_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3864,7 +3865,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3879,7 +3880,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3894,7 +3895,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3909,7 +3910,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3926,7 +3927,7 @@ const registryConfig = {
     }),
     relationalPosts: Object.assign(Object.create(null), {
       relationalItemsByMyPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+        localCodec: relationalPostsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_item_id"],
@@ -3943,7 +3944,7 @@ const registryConfig = {
     }),
     relationalTopics: Object.assign(Object.create(null), {
       relationalItemsByMyTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3958,7 +3959,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3975,7 +3976,7 @@ const registryConfig = {
     }),
     singleTableItemRelationCompositePks: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3990,7 +3991,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4007,7 +4008,7 @@ const registryConfig = {
     }),
     singleTableItemRelations: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -4022,7 +4023,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4039,7 +4040,7 @@ const registryConfig = {
     }),
     singleTableItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -4054,7 +4055,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4069,7 +4070,7 @@ const registryConfig = {
         }
       },
       prioritiesByMyPriorityId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_priorities_priorities,
         localCodecPolymorphicTypes: ["POST", "CHECKLIST_ITEM"],
         localAttributes: ["priority_id"],
@@ -4084,7 +4085,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -4099,7 +4100,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4114,7 +4115,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4129,7 +4130,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4144,7 +4145,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4159,7 +4160,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4174,7 +4175,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4191,7 +4192,7 @@ const registryConfig = {
     }),
     thirdPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4206,7 +4207,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4542,7 +4543,7 @@ const handler3 = {
   }
 };
 const otherSource_organizationsPgResource = registry.pgResources["organizations"];
-const attributes19 = {};
+const attributes = {};
 const members2 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4743,7 +4744,7 @@ function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes20 = {};
+const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4914,7 +4915,7 @@ function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes21 = {};
+const attributes3 = {};
 const members6 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -6808,7 +6809,7 @@ function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes22 = {};
+const attributes4 = {};
 const members11 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -7006,7 +7007,7 @@ function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes23 = {};
+const attributes5 = {};
 const members13 = [{
   resource: members_1_resource_aws_application_third_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -7291,7 +7292,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple3 = [{
   graphqlArgName: "nodeId",
   postgresArgName: "nodeId",
-  pgCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+  pgCodec: relationalItemsCodec,
   required: true,
   fetcher($nodeId) {
     return otherSource_relational_itemsPgResource.get(getSpec($nodeId));
@@ -16993,7 +16994,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -17104,7 +17105,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes19,
+        attributes,
         resourceByTypeName: resourceByTypeName2,
         members: members2,
         name: "author"
@@ -17276,7 +17277,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17292,7 +17293,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17458,7 +17459,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
             }
           });
         }
@@ -17481,7 +17482,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
             }
           });
         }
@@ -17504,7 +17505,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -17527,7 +17528,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
             }
           });
         }
@@ -17594,7 +17595,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -17667,7 +17668,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes20,
+        attributes: attributes2,
         resourceByTypeName: resourceByTypeName4,
         members: members4,
         name: "owner"
@@ -17866,7 +17867,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
             }
           });
         }
@@ -17889,7 +17890,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
             }
           });
         }
@@ -17912,7 +17913,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -17937,7 +17938,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17953,7 +17954,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18187,7 +18188,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -18210,7 +18211,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -18233,7 +18234,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -18256,7 +18257,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -18279,7 +18280,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -18302,7 +18303,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
             }
           });
         }
@@ -18369,7 +18370,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "vulnerabilities"
@@ -18442,7 +18443,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes21,
+        attributes: attributes3,
         resourceByTypeName: resourceByTypeName6,
         members: members6,
         name: "owner"
@@ -18472,7 +18473,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18488,7 +18489,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18722,7 +18723,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -18745,7 +18746,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -18768,7 +18769,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -18791,7 +18792,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -18814,7 +18815,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -18837,7 +18838,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
             }
           });
         }
@@ -18880,7 +18881,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18896,7 +18897,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19266,7 +19267,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -19289,7 +19290,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -19312,7 +19313,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -19335,7 +19336,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -19358,7 +19359,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -19381,7 +19382,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -19404,7 +19405,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -19427,7 +19428,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -19450,7 +19451,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -19473,7 +19474,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -19592,7 +19593,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19608,7 +19609,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19978,7 +19979,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -20001,7 +20002,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -20024,7 +20025,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20047,7 +20048,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -20070,7 +20071,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -20093,7 +20094,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -20116,7 +20117,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -20139,7 +20140,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -20162,7 +20163,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -20185,7 +20186,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -20317,7 +20318,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
             }
           });
         }
@@ -20340,7 +20341,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
             }
           });
         }
@@ -20363,7 +20364,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -20464,7 +20465,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20480,7 +20481,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20612,7 +20613,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -20635,7 +20636,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20658,7 +20659,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -20674,7 +20675,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20690,7 +20691,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20788,7 +20789,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20811,7 +20812,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -22527,7 +22528,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -22543,7 +22544,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -22675,7 +22676,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -22698,7 +22699,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -22721,7 +22722,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -22737,7 +22738,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -22753,7 +22754,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -22851,7 +22852,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -22874,7 +22875,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -25053,7 +25054,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "Vulnerability"
@@ -25109,7 +25110,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName8,
           members: members8,
           name: "Application"
@@ -25165,7 +25166,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_8,
+          attributes: ZeroImplementationAttributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "ZeroImplementation"
@@ -26046,7 +26047,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName10,
           members: members10,
           name: "applications"
@@ -26119,7 +26120,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes22,
+        attributes: attributes4,
         resourceByTypeName: resourceByTypeName11,
         members: members11,
         name: "owners"
@@ -26166,7 +26167,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "applications"
@@ -26239,7 +26240,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes23,
+        attributes: attributes5,
         resourceByTypeName: resourceByTypeName13,
         members: members13,
         name: "owners"
@@ -26360,7 +26361,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
             }
           });
         }
@@ -26383,7 +26384,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
             }
           });
         }
@@ -26417,7 +26418,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26433,7 +26434,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26531,7 +26532,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -26554,7 +26555,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
             }
           });
         }
@@ -26588,7 +26589,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26604,7 +26605,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26702,7 +26703,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
             }
           });
         }
@@ -26725,7 +26726,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
             }
           });
         }
@@ -26777,7 +26778,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26793,7 +26794,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27197,7 +27198,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
             }
           });
         }
@@ -27220,7 +27221,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
             }
           });
         }
@@ -27243,7 +27244,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
             }
           });
         }
@@ -27266,7 +27267,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -27289,7 +27290,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27312,7 +27313,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -27335,7 +27336,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
             }
           });
         }
@@ -27358,7 +27359,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -27381,7 +27382,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -27404,7 +27405,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -27427,7 +27428,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -27461,7 +27462,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27477,7 +27478,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27881,7 +27882,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
             }
           });
         }
@@ -27904,7 +27905,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
             }
           });
         }
@@ -27927,7 +27928,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
             }
           });
         }
@@ -27950,7 +27951,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -27973,7 +27974,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27996,7 +27997,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -28019,7 +28020,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
             }
           });
         }
@@ -28042,7 +28043,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -28065,7 +28066,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -28088,7 +28089,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28111,7 +28112,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -28145,7 +28146,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28161,7 +28162,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28599,7 +28600,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
             }
           });
         }
@@ -28622,7 +28623,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
             }
           });
         }
@@ -28645,7 +28646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -28668,7 +28669,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -28691,7 +28692,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -28714,7 +28715,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -28737,7 +28738,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -28760,7 +28761,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -28783,7 +28784,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -28806,7 +28807,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -28829,7 +28830,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28852,7 +28853,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -28886,7 +28887,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28902,7 +28903,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -29340,7 +29341,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
             }
           });
         }
@@ -29363,7 +29364,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
             }
           });
         }
@@ -29386,7 +29387,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
             }
           });
         }
@@ -29409,7 +29410,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
             }
           });
         }
@@ -29432,7 +29433,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -29455,7 +29456,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -29478,7 +29479,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
             }
           });
         }
@@ -29501,7 +29502,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
             }
           });
         }
@@ -29524,7 +29525,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
             }
           });
         }
@@ -29547,7 +29548,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -29570,7 +29571,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -29593,7 +29594,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -29627,7 +29628,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -29643,7 +29644,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30115,7 +30116,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
             }
           });
         }
@@ -30138,7 +30139,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
             }
           });
         }
@@ -30161,7 +30162,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
             }
           });
         }
@@ -30184,7 +30185,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
             }
           });
         }
@@ -30207,7 +30208,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
             }
           });
         }
@@ -30230,7 +30231,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -30253,7 +30254,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -30276,7 +30277,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -30299,7 +30300,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
             }
           });
         }
@@ -30322,7 +30323,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -30345,7 +30346,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -30368,7 +30369,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -30391,7 +30392,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -30425,7 +30426,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30441,7 +30442,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30607,7 +30608,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -30630,7 +30631,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -30653,7 +30654,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -30676,7 +30677,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
             }
           });
         }
@@ -30710,7 +30711,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30726,7 +30727,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30892,7 +30893,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -30915,7 +30916,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -30938,7 +30939,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -30961,7 +30962,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -11,7 +11,7 @@ const handler_codec_base64JSON = {
     return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
   }
 };
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -58,7 +58,7 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions2 = {
   isTableLike: true,
@@ -97,7 +97,7 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions2,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -136,7 +136,7 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions4 = {
   isTableLike: true,
@@ -175,7 +175,7 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions4,
-  executor: executor_mainPgExecutor
+  executor
 });
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
@@ -213,7 +213,7 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -267,7 +267,7 @@ const peopleCodec = recordCodec({
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions7 = {
   isTableLike: true,
@@ -306,7 +306,7 @@ const prioritiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions7,
-  executor: executor_mainPgExecutor
+  executor
 });
 const itemTypeCodec = enumCodec({
   name: "itemType",
@@ -467,7 +467,7 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -503,7 +503,7 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
@@ -650,7 +650,7 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -686,7 +686,7 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
@@ -842,7 +842,7 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
@@ -998,7 +998,7 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1043,7 +1043,7 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1088,7 +1088,7 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1159,7 +1159,7 @@ const logEntriesCodec = recordCodec({
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
@@ -1324,7 +1324,7 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1407,7 +1407,7 @@ const firstPartyVulnerabilitiesCodec = recordCodec({
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
-  executor: executor_mainPgExecutor
+  executor
 });
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1490,7 +1490,7 @@ const thirdPartyVulnerabilitiesCodec = recordCodec({
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
-  executor: executor_mainPgExecutor
+  executor
 });
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1591,7 +1591,7 @@ const awsApplicationsCodec = recordCodec({
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
-  executor: executor_mainPgExecutor
+  executor
 });
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1692,7 +1692,7 @@ const gcpApplicationsCodec = recordCodec({
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1874,7 +1874,7 @@ const singleTableItemsCodec = recordCodec({
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1986,7 +1986,7 @@ const relationalItemsCodec = recordCodec({
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
-  executor: executor_mainPgExecutor
+  executor
 });
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2077,7 +2077,7 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   }
 });
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
   from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
@@ -2106,7 +2106,7 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
   from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
@@ -2135,7 +2135,7 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
   from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
@@ -2164,7 +2164,7 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   }
 };
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
   from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
@@ -2192,7 +2192,7 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
     }
   }
 };
-const uniques5 = [{
+const organizationsUniques = [{
   isPrimary: true,
   attributes: ["organization_id"],
   description: undefined,
@@ -2208,12 +2208,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
   from: organizationsCodec.sqlType,
   codec: organizationsCodec,
-  uniques: uniques5,
+  uniques: organizationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2228,7 +2228,7 @@ const registryConfig_pgResources_organizations_organizations = {
     }
   }
 };
-const uniques6 = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2244,12 +2244,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.polymorphic.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques: uniques6,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2267,7 +2267,7 @@ const registryConfig_pgResources_people_people = {
   }
 };
 const registryConfig_pgResources_priorities_priorities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
   from: prioritiesCodec.sqlType,
@@ -2295,7 +2295,7 @@ const registryConfig_pgResources_priorities_priorities = {
     }
   }
 };
-const uniques8 = [{
+const relational_checklistsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_id"],
   description: undefined,
@@ -2304,12 +2304,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
   from: relationalChecklistsCodec.sqlType,
   codec: relationalChecklistsCodec,
-  uniques: uniques8,
+  uniques: relational_checklistsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2322,7 +2322,7 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
     tags: {}
   }
 };
-const uniques9 = [{
+const relational_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2331,12 +2331,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
   from: relationalItemRelationCompositePksCodec.sqlType,
   codec: relationalItemRelationCompositePksCodec,
-  uniques: uniques9,
+  uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2349,7 +2349,7 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
     tags: {}
   }
 };
-const uniques10 = [{
+const relational_topicsUniques = [{
   isPrimary: true,
   attributes: ["topic_item_id"],
   description: undefined,
@@ -2358,12 +2358,12 @@ const uniques10 = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
   from: relationalTopicsCodec.sqlType,
   codec: relationalTopicsCodec,
-  uniques: uniques10,
+  uniques: relational_topicsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2376,7 +2376,7 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
     tags: {}
   }
 };
-const uniques11 = [{
+const single_table_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2385,12 +2385,12 @@ const uniques11 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
   from: singleTableItemRelationCompositePksCodec.sqlType,
   codec: singleTableItemRelationCompositePksCodec,
-  uniques: uniques11,
+  uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2403,7 +2403,7 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
     tags: {}
   }
 };
-const uniques12 = [{
+const relational_checklist_itemsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_item_id"],
   description: undefined,
@@ -2412,12 +2412,12 @@ const uniques12 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
   from: relationalChecklistItemsCodec.sqlType,
   codec: relationalChecklistItemsCodec,
-  uniques: uniques12,
+  uniques: relational_checklist_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2430,7 +2430,7 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
     tags: {}
   }
 };
-const uniques13 = [{
+const relational_dividersUniques = [{
   isPrimary: true,
   attributes: ["divider_item_id"],
   description: undefined,
@@ -2439,12 +2439,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
   from: relationalDividersCodec.sqlType,
   codec: relationalDividersCodec,
-  uniques: uniques13,
+  uniques: relational_dividersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2457,7 +2457,7 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
     tags: {}
   }
 };
-const uniques14 = [{
+const relational_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2473,12 +2473,12 @@ const uniques14 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
   from: relationalItemRelationsCodec.sqlType,
   codec: relationalItemRelationsCodec,
-  uniques: uniques14,
+  uniques: relational_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2491,7 +2491,7 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
     tags: {}
   }
 };
-const uniques15 = [{
+const single_table_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2507,12 +2507,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
   from: singleTableItemRelationsCodec.sqlType,
   codec: singleTableItemRelationsCodec,
-  uniques: uniques15,
+  uniques: single_table_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2525,7 +2525,7 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
     tags: {}
   }
 };
-const uniques16 = [{
+const log_entriesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2534,12 +2534,12 @@ const uniques16 = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
   from: logEntriesCodec.sqlType,
   codec: logEntriesCodec,
-  uniques: uniques16,
+  uniques: log_entriesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2555,7 +2555,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     }
   }
 };
-const uniques17 = [{
+const relational_postsUniques = [{
   isPrimary: true,
   attributes: ["post_item_id"],
   description: undefined,
@@ -2564,12 +2564,12 @@ const uniques17 = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
   from: relationalPostsCodec.sqlType,
   codec: relationalPostsCodec,
-  uniques: uniques17,
+  uniques: relational_postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2582,7 +2582,7 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
     tags: {}
   }
 };
-const uniques18 = [{
+const first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2591,12 +2591,12 @@ const uniques18 = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
   from: firstPartyVulnerabilitiesCodec.sqlType,
   codec: firstPartyVulnerabilitiesCodec,
-  uniques: uniques18,
+  uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2613,7 +2613,7 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     }
   }
 };
-const uniques19 = [{
+const third_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2622,12 +2622,12 @@ const uniques19 = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
   from: thirdPartyVulnerabilitiesCodec.sqlType,
   codec: thirdPartyVulnerabilitiesCodec,
-  uniques: uniques19,
+  uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2644,7 +2644,7 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     }
   }
 };
-const uniques20 = [{
+const aws_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2653,12 +2653,12 @@ const uniques20 = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
   from: awsApplicationsCodec.sqlType,
   codec: awsApplicationsCodec,
-  uniques: uniques20,
+  uniques: aws_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2675,7 +2675,7 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     }
   }
 };
-const uniques21 = [{
+const gcp_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2684,12 +2684,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
   from: gcpApplicationsCodec.sqlType,
   codec: gcpApplicationsCodec,
-  uniques: uniques21,
+  uniques: gcp_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2706,8 +2706,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     }
   }
 };
-const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
-const uniques22 = [{
+const custom_delete_relational_itemFunctionIdentifer = sql.identifier("polymorphic", "custom_delete_relational_item");
+const single_table_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2716,12 +2716,12 @@ const uniques22 = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
   from: singleTableItemsCodec.sqlType,
   codec: singleTableItemsCodec,
-  uniques: uniques22,
+  uniques: single_table_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2738,9 +2738,9 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     }
   }
 };
-const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
-const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
-const uniques23 = [{
+const all_single_tablesFunctionIdentifer = sql.identifier("polymorphic", "all_single_tables");
+const get_single_table_topic_by_idFunctionIdentifer = sql.identifier("polymorphic", "get_single_table_topic_by_id");
+const relational_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2749,12 +2749,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
   from: relationalItemsCodec.sqlType,
   codec: relationalItemsCodec,
-  uniques: uniques23,
+  uniques: relational_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2847,7 +2847,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     Vulnerability: recordCodec({
       name: "Vulnerability",
@@ -2892,7 +2892,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     ZeroImplementation: recordCodec({
       name: "ZeroImplementation",
@@ -2912,7 +2912,7 @@ const registryConfig = {
           behavior: "node"
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -2938,11 +2938,11 @@ const registryConfig = {
     aws_applications: registryConfig_pgResources_aws_applications_aws_applications,
     gcp_applications: registryConfig_pgResources_gcp_applications_gcp_applications,
     custom_delete_relational_item: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${custom_delete_relational_itemFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
@@ -2975,7 +2975,7 @@ const registryConfig = {
       name: "all_single_tables",
       identifier: "main.polymorphic.all_single_tables()",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${all_single_tablesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -2997,7 +2997,7 @@ const registryConfig = {
       name: "get_single_table_topic_by_id",
       identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${get_single_table_topic_by_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -5553,19 +5553,19 @@ const resourceByTypeName13 = Object.assign(Object.create(null), {
 });
 const decodeNodeId = makeDecodeNodeId([handler16, handler17, handler18, handler19, handler20]);
 const details = [{
-  pkAttributes: uniques10[0].attributes,
+  pkAttributes: relational_topicsUniques[0].attributes,
   handler: handler16
 }, {
-  pkAttributes: uniques17[0].attributes,
+  pkAttributes: relational_postsUniques[0].attributes,
   handler: handler17
 }, {
-  pkAttributes: uniques13[0].attributes,
+  pkAttributes: relational_dividersUniques[0].attributes,
   handler: handler18
 }, {
-  pkAttributes: uniques8[0].attributes,
+  pkAttributes: relational_checklistsUniques[0].attributes,
   handler: handler19
 }, {
-  pkAttributes: uniques12[0].attributes,
+  pkAttributes: relational_checklist_itemsUniques[0].attributes,
   handler: handler20
 }];
 const getSpec = $nodeId => {
@@ -5587,7 +5587,7 @@ const getSpec = $nodeId => {
     const match = handlerMatches.find(pk => pk.match);
     return match?.pks;
   }, true);
-  return uniques23[0].attributes.reduce((memo, pkAttribute, i) => {
+  return relational_itemsUniques[0].attributes.reduce((memo, pkAttribute, i) => {
     memo[pkAttribute] = access($pkValues, i);
     return memo;
   }, Object.create(null));
@@ -14891,7 +14891,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14907,7 +14907,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15594,7 +15594,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15610,7 +15610,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16146,7 +16146,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16162,7 +16162,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16561,7 +16561,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16577,7 +16577,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17294,7 +17294,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17310,7 +17310,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18180,7 +18180,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18196,7 +18196,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18390,7 +18390,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18406,7 +18406,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20513,7 +20513,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20529,7 +20529,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20723,7 +20723,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20739,7 +20739,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -24872,7 +24872,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -24888,7 +24888,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25050,7 +25050,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25066,7 +25066,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25253,7 +25253,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25269,7 +25269,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25944,7 +25944,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25960,7 +25960,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26635,7 +26635,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26651,7 +26651,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27383,7 +27383,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27399,7 +27399,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28131,7 +28131,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28147,7 +28147,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28936,7 +28936,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28952,7 +28952,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29228,7 +29228,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29244,7 +29244,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30638,7 +30638,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30712,7 +30712,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30786,7 +30786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30870,7 +30870,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30954,7 +30954,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31045,7 +31045,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31136,7 +31136,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31234,7 +31234,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31322,7 +31322,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31410,7 +31410,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31522,7 +31522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31634,7 +31634,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31735,7 +31735,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31836,7 +31836,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31934,7 +31934,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32032,7 +32032,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32151,7 +32151,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32270,7 +32270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32381,7 +32381,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32482,7 +32482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32583,7 +32583,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32708,7 +32708,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32838,7 +32838,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32910,7 +32910,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32982,7 +32982,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33057,7 +33057,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33132,7 +33132,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33215,7 +33215,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33298,7 +33298,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33372,7 +33372,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33436,7 +33436,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33500,7 +33500,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33574,7 +33574,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,411 +416,359 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
-  attributes: nonUpdatableViewAttributes,
-  description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
+  identifier: sql.identifier("a", "non_updatable_view"),
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
       }
     }
-  }
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+  executor: executor_mainPgExecutor
+});
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
-  attributes: inputsAttributes,
+  identifier: sql.identifier("a", "inputs"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: "Should output as Input",
-  extensions: extensions3,
-  executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+  executor: executor_mainPgExecutor
+});
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
-  attributes: patchsAttributes,
+  identifier: sql.identifier("a", "patchs"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: "Should output as Patch",
-  extensions: extensions4,
-  executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+  executor: executor_mainPgExecutor
+});
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
-  attributes: reservedAttributes,
-  description: undefined,
-  extensions: extensions5,
-  executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
+  identifier: sql.identifier("a", "reserved"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
       }
     }
-  }
-});
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+  executor: executor_mainPgExecutor
+});
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
-  attributes: reservedPatchsAttributes,
+  identifier: sql.identifier("a", "reservedPatchs"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+  executor: executor_mainPgExecutor
+});
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
-  attributes: reservedInputAttributes,
+  identifier: sql.identifier("a", "reserved_input"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
-  attributes: defaultValueAttributes,
+  identifier: sql.identifier("a", "default_value"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts9);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
-  attributes: noPrimaryKeyAttributes,
+  identifier: sql.identifier("a", "no_primary_key"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
-};
-const parts10 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts10);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions10,
-  executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
+  executor: executor_mainPgExecutor
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts11);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
-  attributes: myTableAttributes,
+  identifier: sql.identifier("c", "my_table"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -864,710 +794,647 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts12 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts12);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts13);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
-  attributes: foreignKeyAttributes,
+  identifier: sql.identifier("a", "foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts14);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
-  attributes: testviewAttributes,
+  identifier: sql.identifier("a", "testview"),
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
-  attributes: viewTableAttributes,
+  identifier: sql.identifier("a", "view_table"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
-  attributes: compoundKeyAttributes,
+  identifier: sql.identifier("c", "compound_key"),
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions16,
-  executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
-  attributes: similarTable1Attributes,
+  identifier: sql.identifier("a", "similar_table_1"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
-  attributes: similarTable2Attributes,
+  identifier: sql.identifier("a", "similar_table_2"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
-  attributes: updatableViewAttributes,
+  identifier: sql.identifier("b", "updatable_view"),
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
-  attributes: nullTestRecordAttributes,
+  identifier: sql.identifier("c", "null_test_record"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
-  attributes: edgeCaseAttributes,
+  identifier: sql.identifier("c", "edge_case"),
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions22 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts22);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions22,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts23 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts23);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions23,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions24 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts24);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
-  attributes: issue756Attributes,
+  identifier: sql.identifier("c", "issue756"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1614,245 +1481,220 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts25);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1861,29 +1703,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1893,88 +1734,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -2047,56 +1877,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2105,29 +1930,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2136,29 +1960,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2168,67 +1991,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2346,48 +2158,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2396,37 +2203,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2435,37 +2241,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2474,37 +2279,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2513,37 +2317,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2552,37 +2355,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2592,195 +2394,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -2798,547 +2571,6 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
 const extensions46 = {
   isTableLike: true,
   pg: {
@@ -3350,1680 +2582,681 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-insert -update"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete", "-select -single -list -connection -insert -update -delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques2 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques4 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques5 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques6 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques7 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques8 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy", "-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques9,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions122
-};
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques10 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions124 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret).",
-    behavior: ["-update"]
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy", "-select -single -list -connection -insert -update -delete"]
+    }
   }
 };
 const uniques11 = [{
@@ -5043,380 +3276,121 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques11,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret).",
+      behavior: ["-update"]
+    }
   }
 };
-const uniques12 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques12,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions125
-};
-const extensions126 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques13 = [];
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques14 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {
+      behavior: ["-select -single -list -connection -insert -update -delete"]
+    }
   }
 };
-const uniques15 = [{
-  isPrimary: true,
-  attributes: ["person_id_1", "person_id_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["person_id_1", "person_id_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts114 = ["b", "list_bde_mutation"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques16 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions131 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques17 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions132 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts115 = ["c", "edge_case_computed"];
-const sqlIdent73 = sql.identifier(...parts115);
-const fromCallback65 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const extensions133 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete",
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions134 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
-  }
-};
-const uniques19 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const parts116 = ["c", "return_table_without_grants"];
-const sqlIdent74 = sql.identifier(...parts116);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "return_table_without_grants"
+      name: "compound_key"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      behavior: ["-select -single -list -connection -insert -update -delete"]
     }
-  },
-  description: undefined
-};
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
   }
 };
-const uniques20 = [];
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions136 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques21 = [];
+const sqlIdent72 = sql.identifier("b", "list_bde_mutation");
+const sqlIdent73 = sql.identifier("c", "edge_case_computed");
+const sqlIdent74 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques21,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions136
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {
-    behavior: ["-select -single -list -connection -insert -update -delete"]
   }
 };
-const uniques22 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques22,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
-};
-const extensions138 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: {
+      behavior: ["-select -single -list -connection -insert -update -delete"]
+    }
+  }
 };
 const uniques23 = [{
   isPrimary: true,
@@ -5442,823 +3416,64 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques23,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions138
-};
-const parts119 = ["b", "authenticate_many"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["c", "left_arm_identity"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "left_arm_identity"
-    },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts127 = ["c", "func_out_out_compound_type"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts128 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts129 = ["a", "post_computed_interval_set"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts130 = ["a", "post_computed_interval_array"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts131 = ["a", "post_computed_text_array"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts132 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts133 = ["a", "post_computed_with_required_arg"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const parts137 = ["c", "compound_type_set_query"];
-const sqlIdent95 = sql.identifier(...parts137);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions153 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques25 = [];
+const sqlIdent77 = sql.identifier("b", "authenticate_many");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("c", "left_arm_identity");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent86 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent87 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent88 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent89 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent90 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent91 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques25,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions153
-};
-const parts138 = ["b", "compound_type_mutation"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
+      schemaName: "c",
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts139 = ["b", "compound_type_query"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_set_mutation"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions154 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
   }
 };
-const parts141 = ["c", "query_output_two_rows"];
-const sqlIdent99 = sql.identifier(...parts141);
-const fromCallback79 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts142 = ["a", "mutation_compound_type_array"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts143 = ["a", "query_compound_type_array"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["b", "compound_type_array_mutation"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["b", "compound_type_array_query"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {
-    behavior: ["-insert -update -delete"]
-  }
-};
+const sqlIdent96 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent97 = sql.identifier("b", "compound_type_query");
+const sqlIdent98 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent99 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent100 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent101 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent102 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent103 = sql.identifier("b", "compound_type_array_query");
 const uniques26 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6276,453 +3491,35 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques26,
   isVirtual: false,
   description: undefined,
-  extensions: extensions155
-};
-const parts146 = ["a", "post_computed_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "a",
-      name: "post_computed_compound_type_array"
+      name: "post"
     },
     tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+      behavior: ["-insert -update -delete"]
     }
-  },
-  description: undefined
-};
-const parts147 = ["c", "table_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["c", "table_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_with_suffix"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent104 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent105 = sql.identifier("c", "table_mutation");
+const sqlIdent106 = sql.identifier("c", "table_query");
+const sqlIdent107 = sql.identifier("a", "post_with_suffix");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6747,569 +3544,65 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: "The first post by the person."
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey,
-    behavior: ["-select -single -list -connection -insert -update -delete"]
+    tags: {}
   }
 };
-const uniques28 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
+const sqlIdent121 = sql.identifier("c", "person_first_post");
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+      foreignKey: extensions46.tags.foreignKey,
+      behavior: ["-select -single -list -connection -insert -update -delete"]
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7424,19 +3717,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7445,9 +3759,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7462,813 +3932,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8280,7 +5783,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete", "-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8288,10 +5801,27 @@ const registry = makeRegistry({
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8299,10 +5829,27 @@ const registry = makeRegistry({
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8310,10 +5857,27 @@ const registry = makeRegistry({
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8321,10 +5885,27 @@ const registry = makeRegistry({
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8332,10 +5913,27 @@ const registry = makeRegistry({
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8343,10 +5941,27 @@ const registry = makeRegistry({
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     no_primary_key: {
       executor: executor_mainPgExecutor,
@@ -8354,10 +5969,27 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques8,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions121
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8366,10 +5998,27 @@ const registry = makeRegistry({
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques10,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
@@ -8379,10 +6028,20 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques13,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions126
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     view_table: {
       executor: executor_mainPgExecutor,
@@ -8390,23 +6049,66 @@ const registry = makeRegistry({
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions129,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     similar_table_1: {
@@ -8415,10 +6117,27 @@ const registry = makeRegistry({
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8426,22 +6145,55 @@ const registry = makeRegistry({
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions131
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions132,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     updatable_view: {
@@ -8450,10 +6202,31 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions133
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete",
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8461,406 +6234,2063 @@ const registry = makeRegistry({
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: [{
+        isPrimary: true,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions134
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {
+          behavior: ["-select -single -list -connection -insert -update -delete"]
+        }
+      }
     },
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     post: registryConfig_pgResources_post_post,
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "-queryField -mutationField -typeField -orderBy -filterBy"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9427,21 +8857,6 @@ const fetcher4 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -9460,113 +8875,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple3 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9619,248 +8928,26 @@ const makeArgs3 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -11135,7 +10222,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -11259,23 +10348,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -11302,23 +10401,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -11345,23 +10454,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -11388,23 +10507,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -11498,23 +10627,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -11553,9 +10692,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -11595,8 +10741,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -11919,9 +11069,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12090,9 +11247,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -12375,9 +11539,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -13045,7 +12216,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13060,7 +12233,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13075,7 +12250,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13090,7 +12267,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13104,7 +12283,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13120,7 +12301,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13136,7 +12319,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13150,7 +12335,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13166,7 +12353,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13182,7 +12371,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13196,7 +12387,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13212,7 +12405,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13226,7 +12421,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13242,7 +12439,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13258,7 +12457,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13272,7 +12473,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13288,7 +12491,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -13304,18 +12509,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13355,7 +12566,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -13392,9 +12605,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13434,11 +12653,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -13453,9 +12677,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13495,11 +12725,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -13514,9 +12749,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13551,11 +12792,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -13598,9 +12844,15 @@ export const plans = {
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13640,11 +12892,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -13658,27 +12915,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13713,11 +12986,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -13759,32 +13037,48 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13824,26 +13118,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13883,32 +13187,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -13943,19 +13259,25 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -468,7 +468,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsCodec = recordCodec({
   name: "inputs",
@@ -496,7 +496,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsCodec = recordCodec({
   name: "patchs",
@@ -524,7 +524,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedCodec = recordCodec({
   name: "reserved",
@@ -552,7 +552,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
@@ -580,7 +580,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputCodec = recordCodec({
   name: "reservedInput",
@@ -608,7 +608,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueCodec = recordCodec({
   name: "defaultValue",
@@ -647,7 +647,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
@@ -686,7 +686,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
@@ -728,7 +728,7 @@ const uniqueForeignKeyCodec = recordCodec({
       behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableCodec = recordCodec({
   name: "myTable",
@@ -767,7 +767,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -810,7 +810,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyCodec = recordCodec({
   name: "foreignKey",
@@ -860,7 +860,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewCodec = recordCodec({
   name: "testview",
@@ -910,7 +910,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableCodec = recordCodec({
   name: "viewTable",
@@ -960,7 +960,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyCodec = recordCodec({
   name: "compoundKey",
@@ -1010,7 +1010,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1084,7 +1084,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Codec = recordCodec({
   name: "similarTable2",
@@ -1145,7 +1145,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewCodec = recordCodec({
   name: "updatableView",
@@ -1209,7 +1209,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
@@ -1270,7 +1270,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseCodec = recordCodec({
   name: "edgeCase",
@@ -1320,7 +1320,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1382,7 +1382,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1433,7 +1433,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1495,7 +1495,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1541,7 +1541,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1672,7 +1672,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1701,7 +1701,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1731,7 +1731,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1794,7 +1794,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1891,7 +1891,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1928,7 +1928,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1958,7 +1958,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1988,7 +1988,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -2039,7 +2039,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2172,7 +2172,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2201,7 +2201,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2239,7 +2239,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2277,7 +2277,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2315,7 +2315,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2353,7 +2353,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2391,7 +2391,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2506,7 +2506,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -3128,7 +3128,7 @@ const typesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -3167,71 +3167,71 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3259,7 +3259,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques11 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3268,12 +3268,12 @@ const uniques11 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques11,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3290,7 +3290,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
   }
 };
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3311,7 +3311,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
@@ -3338,12 +3338,12 @@ const registryConfig_pgResources_compound_key_compound_key = {
     }
   }
 };
-const sqlIdent72 = sql.identifier("b", "list_bde_mutation");
-const sqlIdent73 = sql.identifier("c", "edge_case_computed");
-const sqlIdent74 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3363,9 +3363,9 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
@@ -3392,7 +3392,7 @@ const registryConfig_pgResources_issue756_issue756 = {
     }
   }
 };
-const uniques23 = [{
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3408,12 +3408,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques23,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3426,27 +3426,27 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("b", "authenticate_many");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("c", "left_arm_identity");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent86 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent87 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent88 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent89 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent90 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent91 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "compound_type_set_query");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3466,15 +3466,15 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent96 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent97 = sql.identifier("b", "compound_type_query");
-const sqlIdent98 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent99 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent100 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent101 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent102 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent103 = sql.identifier("b", "compound_type_array_query");
-const uniques26 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3483,12 +3483,12 @@ const uniques26 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques26,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3503,24 +3503,24 @@ const registryConfig_pgResources_post_post = {
     }
   }
 };
-const sqlIdent104 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent105 = sql.identifier("c", "table_mutation");
-const sqlIdent106 = sql.identifier("c", "table_query");
-const sqlIdent107 = sql.identifier("a", "post_with_suffix");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const uniques27 = [{
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3536,12 +3536,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3554,19 +3554,19 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
@@ -3594,15 +3594,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3801,7 +3801,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3854,7 +3854,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3916,16 +3916,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3945,11 +3945,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3970,11 +3970,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3995,11 +3995,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4019,11 +4019,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4044,11 +4044,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4069,11 +4069,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4093,11 +4093,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4117,11 +4117,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4141,11 +4141,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4165,11 +4165,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4189,11 +4189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4213,11 +4213,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4237,11 +4237,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4267,11 +4267,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4297,11 +4297,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4327,11 +4327,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4357,11 +4357,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4386,11 +4386,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4416,11 +4416,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4445,11 +4445,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4474,11 +4474,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4503,11 +4503,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4532,11 +4532,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4561,11 +4561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4590,11 +4590,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4624,11 +4624,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4658,11 +4658,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4692,11 +4692,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4726,11 +4726,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4760,11 +4760,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4794,11 +4794,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4828,11 +4828,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4862,11 +4862,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4896,11 +4896,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4930,11 +4930,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4964,11 +4964,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4998,11 +4998,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -5032,11 +5032,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5067,11 +5067,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5091,11 +5091,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5115,11 +5115,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5139,11 +5139,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5174,11 +5174,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5198,11 +5198,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5222,11 +5222,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5246,11 +5246,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5271,11 +5271,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5310,11 +5310,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5349,11 +5349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5388,11 +5388,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5427,11 +5427,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5466,11 +5466,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5490,11 +5490,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5519,11 +5519,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5558,11 +5558,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5597,11 +5597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5621,11 +5621,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5650,11 +5650,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5679,11 +5679,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5703,11 +5703,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5727,11 +5727,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5751,11 +5751,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5775,7 +5775,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5796,7 +5796,7 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
@@ -5824,7 +5824,7 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
@@ -5852,7 +5852,7 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
@@ -5880,7 +5880,7 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
@@ -5908,7 +5908,7 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
@@ -5936,7 +5936,7 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
@@ -5964,7 +5964,7 @@ const registry = makeRegistry({
       }
     },
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5993,7 +5993,7 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
@@ -6023,7 +6023,7 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -6044,7 +6044,7 @@ const registry = makeRegistry({
       }
     },
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
@@ -6073,11 +6073,11 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6112,7 +6112,7 @@ const registry = makeRegistry({
       description: undefined
     },
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
@@ -6140,7 +6140,7 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
@@ -6168,11 +6168,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -6197,7 +6197,7 @@ const registry = makeRegistry({
       description: undefined
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -6229,7 +6229,7 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
@@ -6260,7 +6260,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6279,7 +6279,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6303,7 +6303,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6325,7 +6325,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6364,7 +6364,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6401,7 +6401,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6423,7 +6423,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6445,7 +6445,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6474,7 +6474,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6498,7 +6498,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6532,11 +6532,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6586,11 +6586,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6640,11 +6640,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6669,11 +6669,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6698,11 +6698,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6727,11 +6727,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6756,11 +6756,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6785,11 +6785,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6814,11 +6814,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6850,11 +6850,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6886,11 +6886,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6925,11 +6925,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6964,11 +6964,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7006,7 +7006,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7028,7 +7028,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7055,7 +7055,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7082,7 +7082,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7106,11 +7106,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -7148,7 +7148,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7175,7 +7175,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7202,7 +7202,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7229,7 +7229,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7257,7 +7257,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7289,7 +7289,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7316,7 +7316,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7343,7 +7343,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7376,7 +7376,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7400,11 +7400,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7433,11 +7433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7463,11 +7463,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7492,11 +7492,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7527,11 +7527,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7561,11 +7561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7596,11 +7596,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7625,11 +7625,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7659,11 +7659,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7693,11 +7693,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7727,11 +7727,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7761,11 +7761,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7804,7 +7804,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7831,7 +7831,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7854,7 +7854,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7876,7 +7876,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7898,7 +7898,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7920,7 +7920,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7942,7 +7942,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7964,7 +7964,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7988,7 +7988,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8010,7 +8010,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -8038,7 +8038,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -8067,7 +8067,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8089,7 +8089,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -8111,7 +8111,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -8138,7 +8138,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -8165,7 +8165,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8192,7 +8192,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -8224,7 +8224,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8246,7 +8246,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8268,7 +8268,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -10760,7 +10760,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques26[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -10776,7 +10776,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques26[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11098,7 +11098,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11114,7 +11114,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11276,7 +11276,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11292,7 +11292,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11568,7 +11568,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -11584,7 +11584,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -12537,7 +12537,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -12624,7 +12624,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -12696,7 +12696,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -12768,7 +12768,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -12863,7 +12863,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -12962,7 +12962,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13089,7 +13089,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13158,7 +13158,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -13235,7 +13235,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -475,7 +475,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -485,17 +485,83 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {
+        behavior: ["-insert -update"]
+      }
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {
+        behavior: ["-insert -update"]
+      }
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -513,22 +579,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -546,22 +612,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -579,88 +645,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-insert -update"]
-      }
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -684,7 +684,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -694,17 +694,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -728,7 +728,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -738,17 +738,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "no_primary_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts9);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes20 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -772,7 +772,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -785,17 +785,17 @@ const extensions12 = {
   })
 };
 const parts10 = ["a", "unique_foreign_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts10);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes21 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -819,7 +819,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -829,17 +829,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["c", "my_table"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts11);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes22 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -864,7 +864,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -876,17 +876,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["c", "person_secret"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts12);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes23 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -921,7 +921,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -931,17 +931,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "foreign_key"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts13);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes24 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -976,7 +976,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -986,17 +986,17 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "testview"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts14);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes25 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1086,7 +1086,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1096,17 +1096,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const extensions19 = {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1114,13 +1114,13 @@ const extensions19 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions19,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes27 = Object.assign(Object.create(null), {
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1166,7 +1166,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1176,17 +1176,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1232,7 +1232,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1242,17 +1242,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1298,7 +1298,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1311,17 +1311,17 @@ const extensions22 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1367,7 +1367,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions23 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1377,17 +1377,17 @@ const extensions23 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions23,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes30 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1422,7 +1422,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1432,17 +1432,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1489,7 +1489,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1499,17 +1499,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["b", "jwt_token"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts22);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions26 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1518,13 +1518,13 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["c", "not_null_timestamp"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent23, {
+const notNullTimestampIdentifier = sql.identifier(...parts23);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   notNull: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1538,7 +1538,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1548,7 +1548,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions27 = {
+const extensions24 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1558,17 +1558,17 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "issue756"];
-const sqlIdent24 = sql.identifier(...parts24);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts24);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent24,
-  attributes: attributes32,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1614,7 +1614,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1624,20 +1624,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "left_arm"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts25);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes34 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1663,7 +1663,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1675,17 +1675,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1694,16 +1694,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1712,16 +1711,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1730,15 +1729,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1759,7 +1758,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1777,7 +1776,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1786,7 +1785,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1812,7 +1811,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1822,17 +1821,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1843,7 +1842,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1853,7 +1852,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1863,7 +1862,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1874,7 +1873,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1884,7 +1883,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1894,7 +1893,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1903,7 +1902,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1912,21 +1911,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1934,7 +1933,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1954,7 +1953,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1964,23 +1963,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2027,7 +2026,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2038,7 +2037,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2048,7 +2047,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2058,17 +2057,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -2079,7 +2078,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -2087,7 +2086,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -2097,7 +2096,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2107,7 +2106,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2128,7 +2127,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2138,7 +2137,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2159,7 +2158,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2169,7 +2168,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2178,13 +2177,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2193,16 +2192,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2210,7 +2209,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2220,17 +2219,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2255,7 +2254,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2273,7 +2272,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2282,7 +2281,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2347,7 +2346,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2357,20 +2356,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2388,7 +2387,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2398,7 +2397,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2409,7 +2408,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2417,7 +2416,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2427,7 +2426,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2437,7 +2436,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2448,7 +2447,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2456,7 +2455,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2466,7 +2465,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2476,7 +2475,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2487,7 +2486,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2495,7 +2494,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2505,7 +2504,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2515,7 +2514,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2526,7 +2525,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2534,7 +2533,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2544,7 +2543,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2554,7 +2553,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2565,7 +2564,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2573,7 +2572,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2583,7 +2582,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2593,7 +2592,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2601,13 +2600,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2616,13 +2615,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2631,13 +2630,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2646,12 +2645,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2660,12 +2659,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2674,15 +2673,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2691,7 +2690,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2708,7 +2707,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2718,17 +2717,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2737,13 +2736,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2751,7 +2750,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2759,20 +2758,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2780,13 +2779,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2798,8 +2797,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2879,7 +2878,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2890,7 +2889,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2901,7 +2900,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2912,7 +2911,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2923,7 +2922,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2956,7 +2955,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2967,7 +2966,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2978,7 +2977,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2989,7 +2988,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3066,7 +3065,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3088,7 +3087,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3099,7 +3098,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -3110,7 +3109,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3121,7 +3120,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3275,7 +3274,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3286,7 +3285,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3308,7 +3307,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3319,7 +3318,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3330,7 +3329,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3340,7 +3339,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3352,17 +3351,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3370,7 +3369,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3378,7 +3377,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3386,7 +3385,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3394,13 +3393,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3409,12 +3408,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3422,13 +3421,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3457,7 +3456,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3467,16 +3466,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3514,7 +3513,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3524,16 +3523,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3580,7 +3579,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3590,16 +3589,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3610,8 +3609,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3623,10 +3622,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3638,10 +3637,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3652,10 +3651,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3667,10 +3666,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3682,10 +3681,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3696,10 +3695,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3710,10 +3709,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,10 +3723,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3738,10 +3737,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3752,10 +3751,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3766,10 +3765,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3780,10 +3779,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3795,15 +3794,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3815,15 +3814,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3835,15 +3834,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3855,15 +3854,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3874,15 +3873,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3894,15 +3893,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3913,15 +3912,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3932,15 +3931,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3951,15 +3950,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3970,15 +3969,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3989,15 +3988,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4008,15 +4007,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4027,8 +4026,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -4040,7 +4039,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4051,8 +4050,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -4064,7 +4063,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4075,8 +4074,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -4088,7 +4087,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4099,8 +4098,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -4112,7 +4111,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4123,8 +4122,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -4136,7 +4135,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4147,8 +4146,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -4160,7 +4159,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4171,8 +4170,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -4184,7 +4183,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4195,8 +4194,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -4208,7 +4207,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4219,8 +4218,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4232,7 +4231,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4243,8 +4242,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4256,7 +4255,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4267,8 +4266,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4280,7 +4279,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4291,8 +4290,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4304,7 +4303,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4315,8 +4314,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4328,7 +4327,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4340,8 +4339,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4353,7 +4352,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4364,10 +4363,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4378,10 +4377,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4392,10 +4391,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4407,8 +4406,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4420,7 +4419,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4431,10 +4430,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4445,10 +4444,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4459,10 +4458,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4474,10 +4473,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4488,8 +4487,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4506,7 +4505,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4517,8 +4516,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4535,7 +4534,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4546,8 +4545,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4564,7 +4563,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4575,8 +4574,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4593,7 +4592,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4604,8 +4603,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4622,7 +4621,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4633,10 +4632,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4647,15 +4646,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4666,8 +4665,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4684,7 +4683,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4695,8 +4694,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4713,7 +4712,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4724,10 +4723,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4738,15 +4737,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4757,15 +4756,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4776,10 +4775,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4790,10 +4789,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4804,10 +4803,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4818,10 +4817,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4832,7 +4831,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete", "-select -single -list -connection -insert -update -delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4851,7 +4850,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4870,7 +4869,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4889,7 +4888,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4908,7 +4907,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4927,7 +4926,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4946,7 +4945,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4965,7 +4964,7 @@ const uniques8 = [{
     tags: Object.create(null)
   }
 }];
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4989,14 +4988,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions135
+  extensions: extensions122
 };
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5015,7 +5014,7 @@ const uniques10 = [{
     tags: Object.create(null)
   }
 }];
-const extensions137 = {
+const extensions124 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -5039,14 +5038,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques11,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5062,14 +5061,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
+  extensions: extensions125
 };
-const extensions139 = {
+const extensions126 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5081,7 +5080,7 @@ const extensions139 = {
   }
 };
 const uniques13 = [];
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5100,7 +5099,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5123,14 +5122,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5141,13 +5140,13 @@ const extensions142 = {
   }
 };
 const parts114 = ["b", "list_bde_mutation"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5159,7 +5158,7 @@ const parameters64 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5178,7 +5177,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5197,7 +5196,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions145 = {
+const extensions132 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5208,15 +5207,15 @@ const extensions145 = {
   }
 };
 const parts115 = ["c", "edge_case_computed"];
-const sqlIdent115 = sql.identifier(...parts115);
-const fromCallback65 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+const sqlIdent73 = sql.identifier(...parts115);
+const fromCallback65 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
-const extensions146 = {
+const extensions133 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -5239,7 +5238,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions147 = {
+const extensions134 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5259,12 +5258,12 @@ const uniques19 = [{
   }
 }];
 const parts116 = ["c", "return_table_without_grants"];
-const sqlIdent116 = sql.identifier(...parts116);
+const sqlIdent74 = sql.identifier(...parts116);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5282,7 +5281,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5295,12 +5294,12 @@ const extensions148 = {
 };
 const uniques20 = [];
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5318,7 +5317,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions149 = {
+const extensions136 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5334,20 +5333,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques21,
   isVirtual: true,
   description: undefined,
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5380,7 +5379,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5403,14 +5402,14 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
-const extensions151 = {
+const extensions138 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5438,20 +5437,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques23,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["b", "authenticate_many"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5485,12 +5484,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5509,12 +5508,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5533,18 +5532,18 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["c", "left_arm_identity"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5567,12 +5566,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5605,7 +5604,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5622,14 +5621,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5640,8 +5639,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5661,7 +5660,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5671,9 +5670,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5684,8 +5683,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5705,7 +5704,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5715,9 +5714,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5728,15 +5727,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5747,15 +5746,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["c", "func_out_out_compound_type"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5766,15 +5765,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5785,15 +5784,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_interval_set"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5804,15 +5803,15 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_interval_array"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5823,15 +5822,15 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_text_array"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5844,20 +5843,20 @@ const extensions161 = {
   }
 };
 const parts132 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5870,20 +5869,20 @@ const extensions162 = {
   }
 };
 const parts133 = ["a", "post_computed_with_required_arg"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5894,13 +5893,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5912,7 +5911,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5923,13 +5922,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5941,7 +5940,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5952,13 +5951,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5971,12 +5970,12 @@ const parameters78 = [{
   codec: TYPES.text
 }];
 const parts137 = ["c", "compound_type_set_query"];
-const sqlIdent137 = sql.identifier(...parts137);
+const sqlIdent95 = sql.identifier(...parts137);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5994,7 +5993,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions166 = {
+const extensions153 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -6010,26 +6009,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques25,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions166
+  extensions: extensions153
 };
 const parts138 = ["b", "compound_type_mutation"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6047,18 +6046,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts139 = ["b", "compound_type_query"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6076,18 +6075,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_set_mutation"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6104,7 +6103,7 @@ const options_compound_type_set_mutation = {
   },
   description: undefined
 };
-const extensions167 = {
+const extensions154 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6115,8 +6114,8 @@ const extensions167 = {
   }
 };
 const parts141 = ["c", "query_output_two_rows"];
-const sqlIdent141 = sql.identifier(...parts141);
-const fromCallback79 = (...args) => sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+const sqlIdent99 = sql.identifier(...parts141);
+const fromCallback79 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -6134,18 +6133,18 @@ const parameters79 = [{
   codec: TYPES.text
 }];
 const parts142 = ["a", "mutation_compound_type_array"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6163,18 +6162,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts143 = ["a", "query_compound_type_array"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6192,18 +6191,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts144 = ["b", "compound_type_array_mutation"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6221,18 +6220,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts145 = ["b", "compound_type_array_query"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6249,7 +6248,7 @@ const options_compound_type_array_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6272,31 +6271,31 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques26,
   isVirtual: false,
   description: undefined,
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts146 = ["a", "post_computed_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6314,12 +6313,12 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts147 = ["c", "table_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6343,12 +6342,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts148 = ["c", "table_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6372,18 +6371,18 @@ const options_table_query = {
   description: undefined
 };
 const parts149 = ["a", "post_with_suffix"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -6407,18 +6406,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6435,7 +6434,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6450,15 +6449,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6470,15 +6469,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6489,15 +6488,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6509,20 +6508,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6533,20 +6532,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6558,20 +6557,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6582,15 +6581,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6601,8 +6600,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6614,7 +6613,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6625,8 +6624,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6638,7 +6637,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6649,8 +6648,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6662,7 +6661,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6673,8 +6672,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6686,7 +6685,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6697,13 +6696,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6715,7 +6714,7 @@ const parameters91 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6743,26 +6742,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6780,12 +6779,12 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6805,12 +6804,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6829,12 +6828,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6853,12 +6852,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6877,12 +6876,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6901,12 +6900,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6925,12 +6924,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6951,12 +6950,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6975,18 +6974,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -7005,18 +7004,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -7034,7 +7033,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -7042,7 +7041,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey,
+    foreignKey: extensions46.tags.foreignKey,
     behavior: ["-select -single -list -connection -insert -update -delete"]
   }
 };
@@ -7058,20 +7057,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -7090,12 +7089,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -7114,12 +7113,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -7143,12 +7142,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -7172,18 +7171,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -7201,18 +7200,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -7235,12 +7234,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7259,12 +7258,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7283,18 +7282,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7331,61 +7330,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    foreignKey: foreignKeyCodec,
+    testview: testviewCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7396,18 +7395,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7417,38 +7416,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7456,14 +7455,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7476,7 +7475,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7489,7 +7488,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7502,7 +7501,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7515,7 +7514,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7528,7 +7527,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7541,7 +7540,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7554,7 +7553,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7567,7 +7566,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7580,7 +7579,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7593,7 +7592,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7606,7 +7605,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7619,7 +7618,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7632,7 +7631,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7645,7 +7644,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7658,7 +7657,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7671,7 +7670,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7684,7 +7683,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7697,7 +7696,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7710,7 +7709,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7723,7 +7722,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7736,7 +7735,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7749,7 +7748,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7762,7 +7761,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7775,7 +7774,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7788,7 +7787,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7801,7 +7800,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7814,7 +7813,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7827,7 +7826,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7840,7 +7839,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7853,7 +7852,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7866,7 +7865,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7879,7 +7878,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7892,7 +7891,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7905,7 +7904,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7918,7 +7917,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7931,7 +7930,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7944,7 +7943,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7957,7 +7956,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7970,7 +7969,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7983,7 +7982,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7996,7 +7995,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -8009,7 +8008,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -8022,7 +8021,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -8035,7 +8034,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -8048,7 +8047,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -8061,7 +8060,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -8074,7 +8073,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -8087,7 +8086,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -8100,7 +8099,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -8113,7 +8112,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -8126,7 +8125,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -8139,7 +8138,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -8152,7 +8151,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -8165,7 +8164,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -8178,7 +8177,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -8191,7 +8190,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -8204,7 +8203,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -8214,10 +8213,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -8227,10 +8226,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -8240,10 +8239,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -8253,10 +8252,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8266,111 +8265,111 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques8,
       isVirtual: false,
       description: undefined,
-      extensions: extensions134
+      extensions: extensions121
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
@@ -8378,23 +8377,23 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques13,
       isVirtual: false,
       description: undefined,
-      extensions: extensions139
+      extensions: extensions126
     },
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     list_bde_mutation: {
@@ -8404,33 +8403,33 @@ const registry = makeRegistry({
       from: fromCallback64,
       parameters: parameters64,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions142,
+      extensions: extensions129,
       description: undefined
     },
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions144
+      extensions: extensions131
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8442,42 +8441,42 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: extensions132,
       description: undefined
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions146
+      extensions: extensions133
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions147
+      extensions: extensions134
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
     authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
@@ -8498,7 +8497,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8511,7 +8510,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8524,7 +8523,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8537,7 +8536,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8550,7 +8549,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8563,7 +8562,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8573,10 +8572,10 @@ const registry = makeRegistry({
       from: fromCallback72,
       parameters: parameters72,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_text_array: {
@@ -8586,10 +8585,10 @@ const registry = makeRegistry({
       from: fromCallback73,
       parameters: parameters73,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8602,7 +8601,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8615,7 +8614,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8628,7 +8627,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8641,7 +8640,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8654,7 +8653,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -8671,7 +8670,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: extensions154,
       description: undefined
     },
     mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
@@ -8694,7 +8693,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8707,7 +8706,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8720,7 +8719,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8733,7 +8732,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8746,7 +8745,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8759,7 +8758,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8772,7 +8771,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8785,7 +8784,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8798,7 +8797,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8811,7 +8810,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8824,7 +8823,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8837,7 +8836,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -8866,7 +8865,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8881,7 +8880,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8898,7 +8897,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8913,7 +8912,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8928,7 +8927,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8945,7 +8944,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8962,7 +8961,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8979,7 +8978,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8994,7 +8993,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9011,7 +9010,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -9026,7 +9025,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -9041,7 +9040,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -9056,7 +9055,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -9073,7 +9072,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -9090,7 +9089,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9105,7 +9104,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9120,7 +9119,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9137,7 +9136,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9152,7 +9151,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9167,7 +9166,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -9184,7 +9183,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -9571,7 +9570,7 @@ function PeopleConnection_pageInfoPlan($connection) {
 const argDetailsSimple3 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -11612,7 +11611,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques26[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11628,7 +11627,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques26[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11794,7 +11793,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -11817,7 +11816,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -11840,7 +11839,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -11863,7 +11862,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -11943,7 +11942,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -11959,7 +11958,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12057,7 +12056,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes22.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -12080,7 +12079,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes22.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -12114,7 +12113,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12130,7 +12129,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12296,7 +12295,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -12319,7 +12318,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -12342,7 +12341,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -12365,7 +12364,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -12399,7 +12398,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12415,7 +12414,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -12785,7 +12784,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -12808,7 +12807,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -12831,7 +12830,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -12854,7 +12853,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -12877,7 +12876,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -12900,7 +12899,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -12923,7 +12922,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -12946,7 +12945,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -12969,7 +12968,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -12992,7 +12991,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -13015,7 +13014,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,32 +3371,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3412,12 +3412,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3430,17 +3430,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3449,12 +3449,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3469,15 +3469,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3729,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,16 +3791,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3820,11 +3820,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3944,11 +3944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3968,11 +3968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3992,11 +3992,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4016,11 +4016,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4040,11 +4040,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4088,11 +4088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4112,11 +4112,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4142,11 +4142,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4172,11 +4172,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4202,11 +4202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4232,11 +4232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4261,11 +4261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4291,11 +4291,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4320,11 +4320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4349,11 +4349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4378,11 +4378,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4407,11 +4407,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4436,11 +4436,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4465,11 +4465,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4499,11 +4499,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4533,11 +4533,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4567,11 +4567,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4635,11 +4635,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4669,11 +4669,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4703,11 +4703,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4737,11 +4737,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4771,11 +4771,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4805,11 +4805,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4839,11 +4839,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4873,11 +4873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4907,11 +4907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4942,11 +4942,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4966,11 +4966,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4990,11 +4990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5014,11 +5014,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5049,11 +5049,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5073,11 +5073,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5121,11 +5121,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5146,11 +5146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5185,11 +5185,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5224,11 +5224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5263,11 +5263,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5302,11 +5302,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5341,11 +5341,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5365,11 +5365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5394,11 +5394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5433,11 +5433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5472,11 +5472,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5496,11 +5496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5525,11 +5525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5578,11 +5578,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5602,11 +5602,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5626,11 +5626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5650,7 +5650,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5671,12 +5671,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5690,12 +5690,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5709,12 +5709,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5728,12 +5728,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5747,12 +5747,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5766,12 +5766,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5786,7 +5786,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5812,7 +5812,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5832,12 +5832,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5852,12 +5852,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5872,12 +5872,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5891,12 +5891,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5910,7 +5910,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5941,12 +5941,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5960,11 +5960,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5992,7 +5992,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6011,11 +6011,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6050,7 +6050,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6073,7 +6073,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6095,7 +6095,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6133,7 +6133,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6165,7 +6165,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6187,7 +6187,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6209,7 +6209,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6243,7 +6243,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6267,7 +6267,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6301,11 +6301,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6355,11 +6355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6409,11 +6409,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6438,11 +6438,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6467,11 +6467,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6496,11 +6496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6525,11 +6525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6561,11 +6561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6597,11 +6597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6626,11 +6626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6655,11 +6655,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6694,11 +6694,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6733,11 +6733,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6772,11 +6772,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6815,7 +6815,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6837,7 +6837,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6864,7 +6864,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6891,7 +6891,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6918,7 +6918,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6945,7 +6945,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6972,7 +6972,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7005,7 +7005,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7032,7 +7032,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7059,7 +7059,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7113,7 +7113,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7145,7 +7145,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7169,11 +7169,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7232,11 +7232,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7261,11 +7261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7330,11 +7330,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7394,11 +7394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7428,11 +7428,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7462,11 +7462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7496,11 +7496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7530,11 +7530,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7572,7 +7572,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7623,7 +7623,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7645,7 +7645,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7667,7 +7667,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7689,7 +7689,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7757,7 +7757,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7779,7 +7779,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7836,7 +7836,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7858,7 +7858,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7880,7 +7880,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7907,7 +7907,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7961,7 +7961,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7993,7 +7993,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8015,7 +8015,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8037,7 +8037,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30651,7 +30651,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30667,7 +30667,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33165,7 +33165,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33181,7 +33181,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33603,7 +33603,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33619,7 +33619,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34240,7 +34240,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34256,7 +34256,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35325,7 +35325,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35341,7 +35341,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35446,7 +35446,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35462,7 +35462,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35567,7 +35567,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35583,7 +35583,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35688,7 +35688,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35704,7 +35704,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35809,7 +35809,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35825,7 +35825,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35930,7 +35930,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35946,7 +35946,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36469,7 +36469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36485,7 +36485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36647,7 +36647,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36663,7 +36663,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36825,7 +36825,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36841,7 +36841,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37060,7 +37060,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37076,7 +37076,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37352,7 +37352,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37368,7 +37368,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37919,7 +37919,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37935,7 +37935,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38460,7 +38460,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38476,7 +38476,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38752,7 +38752,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38768,7 +38768,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42380,7 +42380,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42467,7 +42467,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42716,7 +42716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42773,7 +42773,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43030,7 +43030,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43141,7 +43141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43223,7 +43223,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43290,7 +43290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43357,7 +43357,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43424,7 +43424,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43491,7 +43491,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43558,7 +43558,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43786,7 +43786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43860,7 +43860,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43939,7 +43939,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44020,7 +44020,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44111,7 +44111,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44199,7 +44199,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44344,7 +44344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44482,7 +44482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44575,7 +44575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44649,7 +44649,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44712,7 +44712,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44849,7 +44849,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45262,7 +45262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45342,7 +45342,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45422,7 +45422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45502,7 +45502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45582,7 +45582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45662,7 +45662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45791,7 +45791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45878,7 +45878,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45970,7 +45970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46064,7 +46064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46169,7 +46169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46270,7 +46270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46371,7 +46371,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46472,7 +46472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46592,7 +46592,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46679,7 +46679,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46799,7 +46799,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46963,7 +46963,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47394,7 +47394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47458,7 +47458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47522,7 +47522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47586,7 +47586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47650,7 +47650,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47714,7 +47714,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47798,7 +47798,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47862,7 +47862,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47931,7 +47931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47995,7 +47995,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48070,7 +48070,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48134,7 +48134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48198,7 +48198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48262,7 +48262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48339,7 +48339,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48403,7 +48403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48472,7 +48472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48544,7 +48544,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,732 +3339,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6511,274 +3420,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6796,254 +3457,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7158,19 +3592,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7179,9 +3634,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7196,813 +3807,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8014,7 +5658,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8025,7 +5679,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8036,7 +5698,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8047,7 +5717,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8058,7 +5736,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8069,7 +5755,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8080,7 +5774,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8089,10 +5791,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8100,10 +5817,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8115,7 +5840,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8127,7 +5860,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8139,7 +5880,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8150,7 +5899,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8158,10 +5915,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8172,33 +5949,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8207,394 +6055,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9444,25 +8909,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9605,21 +9051,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9670,21 +9101,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9793,21 +9209,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10298,21 +9699,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,12 +9791,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10833,21 +10213,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10916,21 +10281,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11317,21 +10667,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11660,21 +10995,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11725,21 +11045,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11836,21 +11141,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11901,21 +11191,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11984,21 +11259,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12049,21 +11309,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12325,385 +11570,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13277,21 +12147,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13372,21 +12227,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13486,66 +12326,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13593,24 +12373,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13691,21 +12453,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14129,348 +12876,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14517,26 +12923,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14583,9 +12969,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,9 +13015,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14681,9 +13061,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14730,9 +13107,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14779,9 +13153,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14828,9 +13199,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14883,9 +13251,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14938,9 +13303,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14993,9 +13355,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15048,9 +13407,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15103,9 +13459,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15158,9 +13511,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15219,9 +13569,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15280,9 +13627,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15341,9 +13685,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15402,9 +13743,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15463,9 +13801,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15524,9 +13859,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15585,9 +13917,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15646,9 +13975,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15707,9 +14033,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15768,9 +14091,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15817,9 +14137,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15866,9 +14183,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15915,9 +14229,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15982,9 +14293,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16031,9 +14339,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16086,9 +14391,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16141,9 +14443,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16190,9 +14489,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16239,9 +14535,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16306,9 +14599,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16355,9 +14645,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16422,9 +14709,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16477,9 +14761,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16526,9 +14807,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16575,9 +14853,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16642,9 +14917,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16709,9 +14981,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16794,9 +15063,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16849,9 +15115,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16904,9 +15167,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16959,9 +15219,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17014,9 +15271,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17075,9 +15329,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17130,9 +15381,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17185,9 +15433,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17240,9 +15485,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17301,9 +15543,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17362,9 +15601,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17411,9 +15647,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17460,9 +15693,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17509,9 +15739,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17558,9 +15785,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17613,9 +15837,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17662,2061 +15883,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29823,7 +26134,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30069,27 +26382,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30109,23 +26435,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30137,23 +26473,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30175,23 +26521,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30275,23 +26631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30307,11 +26673,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30383,23 +26753,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30414,23 +26794,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30488,23 +26878,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30564,23 +26964,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30592,23 +27002,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30624,23 +27044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30652,23 +27082,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30696,23 +27136,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30724,23 +27174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30926,23 +27386,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30969,23 +27439,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31012,23 +27492,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31055,23 +27545,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31098,23 +27598,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31141,23 +27651,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31184,23 +27704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31227,23 +27757,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31270,23 +27810,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31313,23 +27863,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31356,23 +27916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31399,23 +27969,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31442,23 +28022,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31485,23 +28075,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31528,23 +28128,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31571,23 +28181,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31614,23 +28234,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31657,23 +28287,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31700,23 +28340,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31743,23 +28393,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31786,23 +28446,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31829,23 +28499,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31872,23 +28552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31915,23 +28605,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32075,23 +28775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32493,23 +29203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32530,23 +29250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32672,23 +29402,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32718,23 +29458,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32774,23 +29524,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32820,23 +29580,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33004,12 +29774,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33025,23 +29807,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33386,23 +30178,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33430,9 +30232,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33448,8 +30257,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33590,9 +30403,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36256,9 +33076,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36717,9 +33544,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37109,9 +33943,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37370,9 +34211,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37697,9 +34545,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37715,9 +34570,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37733,9 +34595,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37751,9 +34620,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37778,9 +34654,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37835,9 +34718,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37862,9 +34752,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37927,9 +34824,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37969,9 +34873,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38290,9 +35201,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38378,9 +35296,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38492,9 +35417,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38606,9 +35538,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38720,9 +35659,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38834,9 +35780,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38948,9 +35901,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39119,9 +36079,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39258,9 +36225,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39466,9 +36440,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39637,9 +36618,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39808,9 +36796,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40036,9 +37031,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40321,9 +37323,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40606,9 +37615,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40874,9 +37890,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41159,9 +38182,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41401,9 +38431,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41686,9 +38723,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41868,7 +38912,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41883,7 +38929,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41898,7 +38946,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41913,7 +38963,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41928,7 +38980,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41943,7 +38997,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41958,7 +39014,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41973,7 +39031,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41988,7 +39048,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42003,7 +39065,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42018,7 +39082,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42033,7 +39099,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42048,7 +39116,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42063,7 +39133,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42078,7 +39150,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42093,7 +39167,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42108,7 +39184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42123,7 +39201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42138,7 +39218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42153,7 +39235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42168,7 +39252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42183,7 +39269,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42198,7 +39286,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42213,7 +39303,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42228,7 +39320,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42243,7 +39337,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42258,7 +39354,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42273,7 +39371,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42288,7 +39388,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42303,7 +39405,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42318,7 +39422,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42333,7 +39439,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42348,7 +39456,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42363,7 +39473,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42378,7 +39490,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42393,7 +39507,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42408,7 +39524,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42423,7 +39541,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42438,7 +39558,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42453,7 +39575,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42468,7 +39592,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42483,7 +39609,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42498,7 +39626,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42513,7 +39643,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42528,7 +39660,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42543,7 +39677,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42558,7 +39694,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42573,7 +39711,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42588,7 +39728,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42603,7 +39745,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42618,7 +39762,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42633,7 +39779,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42648,7 +39796,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42663,7 +39813,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42678,7 +39830,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42693,7 +39847,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42708,7 +39864,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42723,7 +39881,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42738,7 +39898,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42753,7 +39915,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42768,7 +39932,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42783,7 +39949,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42798,7 +39966,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42813,7 +39983,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42828,7 +40000,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42843,7 +40017,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42858,7 +40034,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42873,7 +40051,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42888,7 +40068,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42903,7 +40085,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42918,7 +40102,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42933,7 +40119,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42948,7 +40136,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42963,7 +40153,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42978,7 +40170,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42993,7 +40187,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43008,7 +40204,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43023,7 +40221,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43038,7 +40238,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43052,7 +40254,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43068,7 +40272,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43082,7 +40288,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43098,7 +40306,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43112,7 +40322,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43128,7 +40340,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43142,7 +40356,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43158,7 +40374,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43172,7 +40390,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43188,7 +40408,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43202,7 +40424,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43218,7 +40442,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43234,7 +40460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43248,7 +40476,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43264,7 +40494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43278,7 +40510,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43294,7 +40528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43308,7 +40544,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43324,7 +40562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43338,7 +40578,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43355,7 +40597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43369,7 +40613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43385,7 +40631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43399,7 +40647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43415,7 +40665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43429,7 +40681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43445,7 +40699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43459,7 +40715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43475,7 +40733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43491,7 +40751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43505,7 +40767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43521,7 +40785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43535,7 +40801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43551,7 +40819,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43565,7 +40835,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43581,7 +40853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43597,7 +40871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43611,7 +40887,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43627,7 +40905,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43641,7 +40921,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43657,7 +40939,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43671,7 +40955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43687,7 +40973,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43701,7 +40989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43717,7 +41007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43731,7 +41023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43747,7 +41041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43761,7 +41057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43777,7 +41075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43791,7 +41091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43807,7 +41109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43823,7 +41127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43837,7 +41143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43853,7 +41161,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43867,7 +41177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43883,7 +41195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43897,7 +41211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43913,7 +41229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43927,7 +41245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43944,7 +41264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43958,7 +41280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43974,7 +41298,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43988,7 +41314,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44004,7 +41332,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44018,7 +41348,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44034,7 +41366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44048,7 +41382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44064,7 +41400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44080,7 +41418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44094,7 +41434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44110,7 +41452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44124,7 +41468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44140,7 +41486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44154,7 +41502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44170,7 +41520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44186,7 +41538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44200,7 +41554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44216,193 +41572,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44410,15 +41846,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44426,15 +41868,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44442,15 +41890,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44458,15 +41912,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44474,15 +41934,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44490,15 +41956,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44506,15 +41978,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44522,15 +42000,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44538,15 +42022,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44554,11 +42044,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44571,17 +42065,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44594,17 +42094,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44617,21 +42123,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44640,11 +42154,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44660,17 +42178,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44683,65 +42207,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44750,11 +42300,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44776,21 +42330,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44799,11 +42361,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44843,7 +42409,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44880,11 +42448,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44919,35 +42491,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44956,11 +42542,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44992,7 +42582,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45001,15 +42593,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45021,11 +42619,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45044,48 +42646,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45125,18 +42745,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45176,7 +42802,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45228,56 +42856,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45305,7 +42955,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45313,11 +42965,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45345,7 +43001,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45353,11 +43011,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45392,59 +43054,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45489,30 +43175,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45547,11 +43247,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45566,9 +43271,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45603,11 +43314,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45622,9 +43338,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45659,11 +43381,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45678,9 +43405,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45715,11 +43448,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45734,9 +43472,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45771,11 +43515,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45790,9 +43539,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45827,11 +43582,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45853,9 +43613,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45870,11 +43636,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45903,17 +43674,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45935,17 +43717,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45974,9 +43767,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46011,11 +43810,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46037,9 +43841,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46079,11 +43889,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46105,9 +43920,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46142,11 +43963,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46175,9 +44001,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46222,11 +44054,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46255,9 +44092,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46292,11 +44135,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46332,9 +44180,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46369,11 +44223,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46409,17 +44268,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46455,9 +44325,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46492,11 +44368,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46532,17 +44413,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46571,9 +44463,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46613,11 +44511,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46653,9 +44556,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46690,11 +44599,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46716,9 +44630,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46758,19 +44678,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46805,11 +44736,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46894,9 +44830,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46941,11 +44883,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47296,9 +45243,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47333,11 +45286,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47351,18 +45309,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47397,11 +45366,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47415,18 +45389,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47461,11 +45446,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47479,18 +45469,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47525,11 +45526,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47543,18 +45549,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47589,11 +45606,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47607,18 +45629,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47653,11 +45686,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47678,26 +45716,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47718,9 +45772,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47755,11 +45815,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47780,18 +45845,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47831,11 +45907,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47856,18 +45937,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47902,11 +45994,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47934,18 +46031,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47990,11 +46098,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48022,19 +46135,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48069,11 +46193,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48108,18 +46237,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48154,11 +46294,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48193,18 +46338,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48239,11 +46395,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48278,18 +46439,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48329,11 +46501,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48368,27 +46545,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48423,11 +46616,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48448,18 +46646,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48499,11 +46708,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48552,18 +46766,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48598,11 +46823,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48686,27 +46916,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48751,11 +46997,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49105,23 +47356,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49156,26 +47418,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49210,26 +47482,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49264,26 +47546,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49318,26 +47610,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49372,26 +47674,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49426,38 +47738,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49492,26 +47822,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49551,26 +47891,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49605,26 +47955,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49669,27 +48029,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49724,26 +48094,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49778,26 +48158,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49832,26 +48222,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49891,32 +48291,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49951,26 +48363,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50010,26 +48432,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50064,32 +48496,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50134,13 +48578,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1940,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1961,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,7 +1969,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1980,7 +1979,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1989,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2011,7 +2010,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2020,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2042,7 +2041,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2051,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2060,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2075,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2092,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2102,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2135,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2153,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2162,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2217,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2227,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2259,7 +2258,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2268,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2279,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,7 +2287,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2298,7 +2297,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2307,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2318,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,7 +2326,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2337,7 +2336,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2346,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2357,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,7 +2365,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2376,7 +2375,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2385,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2396,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,7 +2404,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2415,7 +2414,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2424,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2435,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,7 +2443,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2454,7 +2453,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2463,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2471,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2486,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2501,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2516,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2530,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2544,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2561,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2578,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2588,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2607,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2621,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2629,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2650,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2668,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2735,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2744,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2753,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2762,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2771,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2798,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2807,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2816,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2825,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2888,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2915,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2924,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2933,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3059,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3068,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3086,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3095,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3112,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3124,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3142,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3150,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3158,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3166,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3181,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3194,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3229,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3239,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3286,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3296,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3352,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,16 +3362,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3383,8 +3382,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3395,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3410,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3424,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3439,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3454,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3468,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3482,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3496,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3510,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3524,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3538,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3552,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3567,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3587,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3607,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3627,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3646,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3666,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3685,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3704,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3723,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3742,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3761,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3780,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3799,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3823,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3847,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3871,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3895,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3919,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3943,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3967,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3991,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4015,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4039,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4063,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4087,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4112,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4136,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4150,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4164,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4179,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4203,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4217,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4231,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4246,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4260,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4289,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4318,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4347,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4376,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4405,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4419,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4438,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4467,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4496,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4510,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4529,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4548,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4562,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4576,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4590,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4604,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4721,14 +4720,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4754,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4763,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4779,14 +4778,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4826,14 +4825,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,14 +4870,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4961,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +5004,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5032,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5061,20 +5060,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5175,26 +5174,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5376,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5420,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5464,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5483,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5502,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5521,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5542,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5568,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5592,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5611,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5630,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5659,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5688,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5717,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5757,20 +5756,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5928,12 +5927,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,18 +5956,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5992,18 +5991,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6021,18 +6020,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6049,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,23 +6107,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6142,18 +6141,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6170,7 +6169,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6185,15 +6184,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,15 +6204,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6224,15 +6223,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6244,20 +6243,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6268,20 +6267,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6293,20 +6292,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6317,15 +6316,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6336,8 +6335,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6349,7 +6348,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6360,8 +6359,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6373,7 +6372,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6384,8 +6383,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6397,7 +6396,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6408,8 +6407,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6421,7 +6420,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6432,13 +6431,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6451,18 +6450,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6479,7 +6478,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6507,20 +6506,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6540,12 +6539,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6564,12 +6563,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6588,12 +6587,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6612,12 +6611,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6635,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,12 +6659,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6686,12 +6685,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6710,18 +6709,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6740,18 +6739,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6769,7 +6768,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6777,7 +6776,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6792,20 +6791,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6824,12 +6823,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6848,12 +6847,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6877,12 +6876,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,18 +6905,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6935,18 +6934,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6969,12 +6968,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6993,12 +6992,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7017,18 +7016,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7065,61 +7064,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7130,18 +7129,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7151,38 +7150,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7190,14 +7189,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7210,7 +7209,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7223,7 +7222,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7236,7 +7235,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7249,7 +7248,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7262,7 +7261,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7275,7 +7274,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7288,7 +7287,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7301,7 +7300,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7314,7 +7313,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7327,7 +7326,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7340,7 +7339,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7353,7 +7352,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7366,7 +7365,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7379,7 +7378,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7392,7 +7391,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7405,7 +7404,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7418,7 +7417,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7431,7 +7430,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7444,7 +7443,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7457,7 +7456,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7470,7 +7469,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7483,7 +7482,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7496,7 +7495,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7509,7 +7508,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7522,7 +7521,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7535,7 +7534,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7548,7 +7547,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7561,7 +7560,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7574,7 +7573,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7587,7 +7586,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7600,7 +7599,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7613,7 +7612,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7626,7 +7625,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7639,7 +7638,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7652,7 +7651,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7665,7 +7664,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7678,7 +7677,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7691,7 +7690,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7704,7 +7703,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7717,7 +7716,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7730,7 +7729,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7743,7 +7742,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7756,7 +7755,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7769,7 +7768,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7782,7 +7781,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7795,7 +7794,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7808,7 +7807,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7821,7 +7820,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7834,7 +7833,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7847,7 +7846,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7860,7 +7859,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7873,7 +7872,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7886,7 +7885,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7899,7 +7898,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7912,7 +7911,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7925,7 +7924,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7938,7 +7937,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7948,10 +7947,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7961,10 +7960,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7974,10 +7973,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7987,10 +7986,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8000,180 +7999,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8185,7 +8184,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8196,22 +8195,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8232,7 +8231,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8245,7 +8244,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8258,7 +8257,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8271,7 +8270,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8281,10 +8280,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8294,10 +8293,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8310,7 +8309,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8323,7 +8322,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8336,7 +8335,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8349,7 +8348,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8362,7 +8361,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8375,7 +8374,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8388,7 +8387,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8401,7 +8400,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8428,7 +8427,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8441,7 +8440,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8454,7 +8453,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8467,7 +8466,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8480,7 +8479,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8493,7 +8492,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8506,7 +8505,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8519,7 +8518,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8532,7 +8531,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8545,7 +8544,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8558,7 +8557,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8571,7 +8570,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8600,7 +8599,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8615,7 +8614,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8632,7 +8631,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8647,7 +8646,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8662,7 +8661,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8679,7 +8678,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8696,7 +8695,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8713,7 +8712,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8728,7 +8727,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8745,7 +8744,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8760,7 +8759,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8775,7 +8774,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8790,7 +8789,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8807,7 +8806,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8824,7 +8823,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8839,7 +8838,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8854,7 +8853,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8871,7 +8870,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8886,7 +8885,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8901,7 +8900,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8918,7 +8917,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11091,7 +11090,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11103,7 +11102,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11336,7 +11335,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11440,7 +11439,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11492,7 +11491,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12953,7 +12952,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14080,7 +14079,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16093,7 +16092,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16246,7 +16245,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16429,7 +16428,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16734,7 +16733,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16746,7 +16745,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16856,7 +16855,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16911,7 +16910,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17021,7 +17020,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17082,7 +17081,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17137,7 +17136,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17192,7 +17191,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33833,7 +33832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33849,7 +33848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35137,7 +35136,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35160,7 +35159,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35183,7 +35182,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35206,7 +35205,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35229,7 +35228,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35252,7 +35251,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35275,7 +35274,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35298,7 +35297,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35321,7 +35320,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35344,7 +35343,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35367,7 +35366,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35390,7 +35389,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35413,7 +35412,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35436,7 +35435,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35459,7 +35458,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35482,7 +35481,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35505,7 +35504,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35528,7 +35527,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35551,7 +35550,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35574,7 +35573,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35597,7 +35596,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35620,7 +35619,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35643,7 +35642,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35666,7 +35665,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35689,7 +35688,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35712,7 +35711,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35735,7 +35734,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35758,7 +35757,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35781,7 +35780,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35804,7 +35803,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35827,7 +35826,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35850,7 +35849,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35873,7 +35872,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35896,7 +35895,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35919,7 +35918,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35942,7 +35941,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35965,7 +35964,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35988,7 +35987,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36011,7 +36010,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36034,7 +36033,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36057,7 +36056,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36080,7 +36079,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36103,7 +36102,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36126,7 +36125,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36149,7 +36148,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36172,7 +36171,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36195,7 +36194,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36340,7 +36339,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36356,7 +36355,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36771,7 +36770,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36787,7 +36786,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36953,7 +36952,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36976,7 +36975,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -36999,7 +36998,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37022,7 +37021,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37045,7 +37044,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37068,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37272,7 +37271,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37295,7 +37294,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37318,7 +37317,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37394,7 +37393,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37410,7 +37409,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37542,7 +37541,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37565,7 +37564,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37588,7 +37587,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38026,7 +38025,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38049,7 +38048,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38072,7 +38071,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38095,7 +38094,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38118,7 +38117,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38141,7 +38140,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38164,7 +38163,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38187,7 +38186,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38210,7 +38209,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38233,7 +38232,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38256,7 +38255,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38368,7 +38367,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38402,7 +38401,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38418,7 +38417,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38482,7 +38481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38516,7 +38515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38532,7 +38531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38596,7 +38595,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38630,7 +38629,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38646,7 +38645,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38710,7 +38709,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38744,7 +38743,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38760,7 +38759,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38824,7 +38823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38858,7 +38857,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38874,7 +38873,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38938,7 +38937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38972,7 +38971,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38988,7 +38987,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39086,7 +39085,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39109,7 +39108,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39225,7 +39224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39248,7 +39247,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39410,7 +39409,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39433,7 +39432,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39456,7 +39455,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39490,7 +39489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39506,7 +39505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39604,7 +39603,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39627,7 +39626,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39661,7 +39660,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39677,7 +39676,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39775,7 +39774,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39798,7 +39797,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39832,7 +39831,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39848,7 +39847,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39980,7 +39979,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40003,7 +40002,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40026,7 +40025,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40060,7 +40059,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40076,7 +40075,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40242,7 +40241,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40265,7 +40264,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40288,7 +40287,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40311,7 +40310,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40345,7 +40344,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40361,7 +40360,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40527,7 +40526,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40550,7 +40549,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40573,7 +40572,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40596,7 +40595,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40795,7 +40794,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40818,7 +40817,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40841,7 +40840,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40864,7 +40863,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40898,7 +40897,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40914,7 +40913,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41080,7 +41079,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41103,7 +41102,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41126,7 +41125,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41149,7 +41148,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41345,7 +41344,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41368,7 +41367,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41391,7 +41390,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41425,7 +41424,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41441,7 +41440,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41607,7 +41606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41630,7 +41629,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41653,7 +41652,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41676,7 +41675,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41710,7 +41709,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41726,7 +41725,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41824,7 +41823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41847,7 +41846,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -68,7 +68,7 @@ const peopleAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -92,7 +92,7 @@ const peopleCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -146,9 +146,9 @@ const postsCodec = recordCodec({
       }
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -157,12 +157,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.refs.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -175,7 +175,7 @@ const registryConfig_pgResources_people_people = {
     tags: {}
   }
 };
-const uniques2 = [{
+const postsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -184,12 +184,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.refs.posts",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -822,7 +822,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -838,7 +838,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1000,7 +1000,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1016,7 +1016,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const peopleAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -85,10 +85,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_people = {
+const peopleIdentifier = sql.identifier(...["refs", "people"]);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sql.identifier(...["refs", "people"]),
-  attributes: attributes_object_Object_,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -101,8 +102,8 @@ const spec_people = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -150,16 +151,16 @@ const extensions2 = {
   })
 };
 const parts2 = ["refs", "posts"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
+const postsCodec = recordCodec(postsCodecSpec);
 const extensions3 = {
   description: undefined,
   pg: {
@@ -181,8 +182,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.refs.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -211,8 +212,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.refs.posts",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -224,8 +225,8 @@ const registry = makeRegistry({
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
-    people: registryConfig_pgCodecs_people_people,
-    posts: registryConfig_pgCodecs_posts_posts
+    people: peopleCodec,
+    posts: postsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     people: registryConfig_pgResources_people_people,
@@ -234,7 +235,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
       postsByTheirUserId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -252,7 +253,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       peopleByMyUserId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["user_id"],
@@ -860,7 +861,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -876,7 +877,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -974,7 +975,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
             }
           });
         }
@@ -997,7 +998,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
             }
           });
         }
@@ -1031,7 +1032,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1047,7 +1048,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1111,7 +1112,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const flambleAttributes = Object.assign(Object.create(null), {
-  f: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -76,11 +58,20 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const flambleIdentifier = sql.identifier(...["d", "flibble"]);
-const flambleCodecSpec = {
+const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: flambleIdentifier,
-  attributes: flambleAttributes,
+  identifier: sql.identifier("d", "flibble"),
+  attributes: Object.assign(Object.create(null), {
+    f: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -94,8 +85,7 @@ const flambleCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const flambleCodec = recordCodec(flambleCodecSpec);
+});
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
@@ -109,28 +99,24 @@ const renamed_tableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "renamed_table"
-  })
-};
-const parts2 = ["d", "original_table"];
-const renamed_tableIdentifier = sql.identifier(...parts2);
-const renamed_tableCodecSpec = {
+const renamed_tableCodec = recordCodec({
   name: "renamed_table",
-  identifier: renamed_tableIdentifier,
+  identifier: sql.identifier("d", "original_table"),
   attributes: renamed_tableAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "original_table"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "renamed_table"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+});
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -151,26 +137,22 @@ const filmsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["d", "films"];
-const filmsIdentifier = sql.identifier(...parts3);
-const filmsCodecSpec = {
+const filmsCodec = recordCodec({
   name: "films",
-  identifier: filmsIdentifier,
+  identifier: sql.identifier("d", "films"),
   attributes: filmsAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const filmsCodec = recordCodec(filmsCodecSpec);
+});
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -191,26 +173,22 @@ const studiosAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["d", "studios"];
-const studiosIdentifier = sql.identifier(...parts4);
-const studiosCodecSpec = {
+const studiosCodec = recordCodec({
   name: "studios",
-  identifier: studiosIdentifier,
+  identifier: sql.identifier("d", "studios"),
   attributes: studiosAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const studiosCodec = recordCodec(studiosCodecSpec);
+});
 const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -240,26 +218,22 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["d", "post"];
-const postIdentifier = sql.identifier(...parts5);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("d", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
+});
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -289,26 +263,22 @@ const tvEpisodesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["d", "tv_episodes"];
-const tvEpisodesIdentifier = sql.identifier(...parts6);
-const tvEpisodesCodecSpec = {
+const tvEpisodesCodec = recordCodec({
   name: "tvEpisodes",
-  identifier: tvEpisodesIdentifier,
+  identifier: sql.identifier("d", "tv_episodes"),
   attributes: tvEpisodesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+});
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
@@ -338,75 +308,66 @@ const tvShowsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["d", "tv_shows"];
-const tvShowsIdentifier = sql.identifier(...parts7);
-const tvShowsCodecSpec = {
+const tvShowsCodec = recordCodec({
   name: "tvShows",
-  identifier: tvShowsIdentifier,
+  identifier: sql.identifier("d", "tv_shows"),
   attributes: tvShowsAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const tvShowsCodec = recordCodec(tvShowsCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions8 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["d", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts8);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("d", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -520,107 +481,24 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["d", "person"];
-const personIdentifier = sql.identifier(...parts9);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("d", "person"),
   attributes: personAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_function"
-  },
-  tags: {
-    name: "renamed_function",
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts10 = ["d", "original_function"];
-const sqlIdent = sql.identifier(...parts10);
-const parts11 = ["d", "getflamble"];
-const sqlIdent2 = sql.identifier(...parts11);
-const options_getflamble = {
-  name: "getflamble",
-  identifier: "main.d.getflamble()",
-  from(...args) {
-    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
   extensions: {
+    isTableLike: true,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "getflamble"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
+    tags: Object.create(null)
   },
-  description: undefined
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "flibble"
-  },
-  tags: {
-    name: "flamble",
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const resourceConfig_flamble = {
-  executor: executor_mainPgExecutor,
-  name: "flamble",
-  identifier: "main.d.flibble",
-  from: flambleCodec.sqlType,
-  codec: flambleCodec,
-  uniques: [],
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "original_table"
-  },
-  tags: {
-    name: "renamed_table"
-  }
-};
-const uniques2 = [];
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
+const sqlIdent = sql.identifier("d", "original_function");
+const sqlIdent2 = sql.identifier("d", "getflamble");
 const uniques3 = [{
   isPrimary: true,
   attributes: ["code"],
@@ -629,15 +507,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "studios"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -655,16 +524,15 @@ const registryConfig_pgResources_studios_studios = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "post"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "studios"
+    },
+    tags: {}
+  }
 };
 const uniques5 = [{
   isPrimary: true,
@@ -683,16 +551,15 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "post"
+    },
+    tags: {}
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +578,15 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,125 +605,19 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const parts12 = ["d", "authenticate"];
-const sqlIdent3 = sql.identifier(...parts12);
-const options_login = {
-  name: "login",
-  identifier: "main.d.authenticate(int4)",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "d",
-      name: "authenticate"
+      name: "tv_shows"
     },
-    tags: {
-      name: "login",
-      resultFieldName: "token",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques8 = [];
-const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
-  name: "jwt_token",
-  identifier: "main.d.jwt_token",
-  from: jwtTokenCodec.sqlType,
-  codec: jwtTokenCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions18
-};
-const extensions19 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person_full_name"
-  },
-  tags: {
-    fieldName: "name",
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
-    arg0variant: "nodeId"
-  }
-};
-const parts13 = ["d", "person_full_name"];
-const sqlIdent4 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-const parameters2 = [{
-  name: "n",
-  required: true,
-  notNull: false,
-  codec: personCodec,
-  extensions: {
-    variant: "nodeId"
-  }
-}];
-const parts14 = ["d", "search_posts"];
-const sqlIdent5 = sql.identifier(...parts14);
-const options_returnPostsMatching = {
-  name: "returnPostsMatching",
-  identifier: "main.d.search_posts(text)",
-  from(...args) {
-    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "search",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "d",
-      name: "search_posts"
-    },
-    tags: {
-      name: "returnPostsMatching",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions20 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent3 = sql.identifier("d", "authenticate");
+const sqlIdent4 = sql.identifier("d", "person_full_name");
+const sqlIdent5 = sql.identifier("d", "search_posts");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -877,7 +637,15 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions20
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "person"
+    },
+    tags: {}
+  }
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
@@ -908,20 +676,82 @@ const registryConfig = {
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions10,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_function"
+        },
+        tags: {
+          name: "renamed_function",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    getflamble: PgResource.functionResourceOptions(resourceConfig_flamble, options_getflamble),
+    getflamble: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "flamble",
+      identifier: "main.d.flibble",
+      from: flambleCodec.sqlType,
+      codec: flambleCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "flibble"
+        },
+        tags: {
+          name: "flamble",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "getflamble",
+      identifier: "main.d.getflamble()",
+      from(...args) {
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "getflamble"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     renamed_table: {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
       codec: renamed_tableCodec,
-      uniques: uniques2,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions12
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "original_table"
+        },
+        tags: {
+          name: "renamed_table"
+        }
+      }
     },
     films: {
       executor: executor_mainPgExecutor,
@@ -932,27 +762,131 @@ const registryConfig = {
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
-      extensions: extensions13
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "films"
+        },
+        tags: {}
+      }
     },
     studios: registryConfig_pgResources_studios_studios,
     post: registryConfig_pgResources_post_post,
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
-    login: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_login),
+    login: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "jwt_token",
+      identifier: "main.d.jwt_token",
+      from: jwtTokenCodec.sqlType,
+      codec: jwtTokenCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "jwt_token"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "login",
+      identifier: "main.d.authenticate(int4)",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "authenticate"
+        },
+        tags: {
+          name: "login",
+          resultFieldName: "token",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_full_name: {
       executor: executor_mainPgExecutor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "n",
+        required: true,
+        notNull: false,
+        codec: personCodec,
+        extensions: {
+          variant: "nodeId"
+        }
+      }],
       isUnique: !false,
       codec: TYPES.varchar,
       uniques: [],
       isMutation: false,
-      extensions: extensions19,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "person_full_name"
+        },
+        tags: {
+          fieldName: "name",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+queryField"],
+          arg0variant: "nodeId"
+        }
+      },
       description: undefined
     },
-    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_returnPostsMatching),
+    returnPostsMatching: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "returnPostsMatching",
+      identifier: "main.d.search_posts(text)",
+      from(...args) {
+        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "search",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "d",
+          name: "search_posts"
+        },
+        tags: {
+          name: "returnPostsMatching",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person: registryConfig_pgResources_person_person
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -1366,25 +1300,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_returnPostsMatchingPgResource.execute(selectArgs);
 };
-function Query_returnPostsMatchingPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_returnPostsMatching_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_returnPostsMatching_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_returnPostsMatching_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_returnPostsMatching_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_returnPostsMatching_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const fetcher = (handler => {
   const fn = $nodeId => {
     const $decoded = lambda($nodeId, specForHandler(handler));
@@ -1434,21 +1349,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
-function Query_allRenamedTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRenamedTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRenamedTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRenamedTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRenamedTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1467,106 +1367,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allFilms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFilms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFilms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFilms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFilms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStudios_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStudios_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStudios_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStudios_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStudios_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvEpisodes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvEpisodes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvEpisodes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvEpisodes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvEpisodes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTvShows_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTvShows_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTvShows_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTvShows_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTvShows_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -1615,21 +1415,6 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Person_posts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_posts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_posts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_posts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_posts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const getSpec2 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
@@ -1637,62 +1422,6 @@ const getSpec2 = $nodeId => {
   return nodeIdHandlerByTypeName.Person.getSpec($decoded);
 };
 const localAttributeCodecs = [TYPES.int];
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Studio_tvShowsByStudioId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Studio_tvShowsByStudioId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Studio_tvShowsByStudioId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Studio_tvShowsByStudioId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Studio_tvShowsByStudioId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvShowsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvShowsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvShowsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TvShow_tvEpisodesByShowId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function TvShow_tvEpisodesByShowId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function TvShow_tvEpisodesByShowId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function TvEpisodesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TvEpisodesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TvEpisodesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const getSpec3 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
@@ -1707,46 +1436,6 @@ const getSpec4 = $nodeId => {
   return nodeIdHandlerByTypeName.Studio.getSpec($decoded);
 };
 const localAttributeCodecs3 = [TYPES.int];
-function RenamedTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RenamedTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RenamedTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FilmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FilmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FilmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StudiosConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StudiosConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StudiosConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -1793,9 +1482,6 @@ const makeArgs5 = (args, path = []) => {
   return selectArgs;
 };
 const resource_getflamblePgResource = registry.pgResources["getflamble"];
-function Mutation_getflamble_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple6 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -1848,448 +1534,90 @@ const makeArgs6 = (args, path = []) => {
   return selectArgs;
 };
 const resource_loginPgResource = registry.pgResources["login"];
-function Mutation_login_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRenamedTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFilm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStudio_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_updateFilm_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_updateStudio_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_updateTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_updateTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Film, $nodeId);
 };
-function Mutation_deleteFilm_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Studio, $nodeId);
 };
-function Mutation_deleteStudio_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvEpisode, $nodeId);
 };
-function Mutation_deleteTvEpisode_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.TvShow, $nodeId);
 };
-function Mutation_deleteTvShow_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function GetflamblePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GetflamblePayload_queryPlan() {
-  return rootValue();
-}
-function GetflambleInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LoginPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LoginPayload_queryPlan() {
-  return rootValue();
-}
-function LoginInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRenamedTablePayload_renamedTablePlan($object) {
-  return $object.get("result");
-}
-function CreateRenamedTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateRenamedTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRenamedTableInput_renamedTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function CreateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFilmInput_film_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function CreateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStudioInput_studio_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec5 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.Person));
   return nodeIdHandlerByTypeName.Person.getSpec($decoded);
 };
-function CreateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function CreateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvEpisodeInput_tvEpisode_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec6 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.TvShow));
   return nodeIdHandlerByTypeName.TvShow.getSpec($decoded);
 };
-function CreateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function CreateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTvShowInput_tvShow_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec7 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.Studio));
   return nodeIdHandlerByTypeName.Studio.getSpec($decoded);
 };
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function UpdateFilmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFilmInput_filmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function UpdateStudioPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStudioInput_studioPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec8 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.Person));
   return nodeIdHandlerByTypeName.Person.getSpec($decoded);
 };
-function UpdateTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function UpdateTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvEpisodeInput_tvEpisodePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec9 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.TvShow));
   return nodeIdHandlerByTypeName.TvShow.getSpec($decoded);
 };
-function UpdateTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function UpdateTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTvShowInput_tvShowPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
 const getSpec10 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandlerByTypeName.Studio));
   return nodeIdHandlerByTypeName.Studio.getSpec($decoded);
 };
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteFilmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFilmPayload_filmPlan($object) {
-  return $object.get("result");
-}
-function DeleteFilmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFilmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStudioPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStudioPayload_studioPlan($object) {
-  return $object.get("result");
-}
-function DeleteStudioPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStudioInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvEpisodePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvEpisodePayload_tvEpisodePlan($object) {
-  return $object.get("result");
-}
-function DeleteTvEpisodePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvEpisodeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTvShowPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTvShowPayload_tvShowPlan($object) {
-  return $object.get("result");
-}
-function DeleteTvShowPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTvShowInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4130,7 +3458,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     id($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4157,28 +3487,41 @@ export const plans = {
       }
     },
     returnPostsMatching: {
-      plan: Query_returnPostsMatchingPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         search: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_returnPostsMatching_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -4243,23 +3586,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRenamedTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4286,23 +3639,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFilms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4329,23 +3692,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStudios_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4372,23 +3745,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4415,23 +3798,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvEpisodes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4458,23 +3851,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTvShows_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4501,23 +3904,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4540,9 +3953,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4636,23 +4056,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_posts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4812,8 +4242,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -4850,23 +4284,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Studio_tvShowsByStudioId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4889,9 +4333,16 @@ export const plans = {
   },
   TvShowsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvShowsConnection_nodesPlan,
-    edges: TvShowsConnection_edgesPlan,
-    pageInfo: TvShowsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4920,23 +4371,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: TvShow_tvEpisodesByShowId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4959,9 +4420,16 @@ export const plans = {
   },
   TvEpisodesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TvEpisodesConnection_nodesPlan,
-    edges: TvEpisodesConnection_edgesPlan,
-    pageInfo: TvEpisodesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5257,9 +4725,16 @@ export const plans = {
   },
   RenamedTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: RenamedTablesConnection_nodesPlan,
-    edges: RenamedTablesConnection_edgesPlan,
-    pageInfo: RenamedTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5345,9 +4820,16 @@ export const plans = {
   },
   FilmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: FilmsConnection_nodesPlan,
-    edges: FilmsConnection_edgesPlan,
-    pageInfo: FilmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5459,9 +4941,16 @@ export const plans = {
   },
   StudiosConnection: {
     __assertStep: ConnectionStep,
-    nodes: StudiosConnection_nodesPlan,
-    edges: StudiosConnection_edgesPlan,
-    pageInfo: StudiosConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5573,9 +5062,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5983,7 +5479,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_getflamble_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -5998,7 +5496,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_login_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6013,7 +5513,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRenamedTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6028,7 +5530,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6043,7 +5547,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6058,7 +5564,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6073,7 +5581,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6088,7 +5598,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6103,7 +5615,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6117,7 +5631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6131,7 +5647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6145,7 +5663,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6159,7 +5679,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6173,7 +5695,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6187,7 +5711,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6201,7 +5727,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFilm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6215,7 +5743,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStudio_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6229,7 +5759,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6243,7 +5775,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvEpisode_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6257,7 +5791,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTvShow_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6271,18 +5807,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   GetflamblePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GetflamblePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     flambles($object) {
       return $object.get("result");
     },
-    query: GetflamblePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Flamble: {
     __assertStep: assertPgClassSingleStep,
@@ -6292,17 +5834,23 @@ export const plans = {
   },
   GetflambleInput: {
     clientMutationId: {
-      applyPlan: GetflambleInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   LoginPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LoginPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     token($object) {
       return $object.get("result");
     },
-    query: LoginPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -6318,24 +5866,37 @@ export const plans = {
   },
   LoginInput: {
     clientMutationId: {
-      applyPlan: LoginInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined
   },
   CreateRenamedTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRenamedTablePayload_clientMutationIdPlan,
-    renamedTable: CreateRenamedTablePayload_renamedTablePlan,
-    query: CreateRenamedTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    renamedTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateRenamedTableInput: {
     clientMutationId: {
-      applyPlan: CreateRenamedTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     renamedTable: {
-      applyPlan: CreateRenamedTableInput_renamedTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6350,9 +5911,15 @@ export const plans = {
   },
   CreateFilmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFilmPayload_clientMutationIdPlan,
-    film: CreateFilmPayload_filmPlan,
-    query: CreateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6387,11 +5954,16 @@ export const plans = {
   },
   CreateFilmInput: {
     clientMutationId: {
-      applyPlan: CreateFilmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     film: {
-      applyPlan: CreateFilmInput_film_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6413,9 +5985,15 @@ export const plans = {
   },
   CreateStudioPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStudioPayload_clientMutationIdPlan,
-    studio: CreateStudioPayload_studioPlan,
-    query: CreateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6450,11 +6028,16 @@ export const plans = {
   },
   CreateStudioInput: {
     clientMutationId: {
-      applyPlan: CreateStudioInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     studio: {
-      applyPlan: CreateStudioInput_studio_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6476,9 +6059,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6513,11 +6102,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6552,9 +6146,15 @@ export const plans = {
   },
   CreateTvEpisodePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: CreateTvEpisodePayload_tvEpisodePlan,
-    query: CreateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6589,11 +6189,16 @@ export const plans = {
   },
   CreateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: CreateTvEpisodeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvEpisode: {
-      applyPlan: CreateTvEpisodeInput_tvEpisode_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6628,9 +6233,15 @@ export const plans = {
   },
   CreateTvShowPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTvShowPayload_clientMutationIdPlan,
-    tvShow: CreateTvShowPayload_tvShowPlan,
-    query: CreateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6665,11 +6276,16 @@ export const plans = {
   },
   CreateTvShowInput: {
     clientMutationId: {
-      applyPlan: CreateTvShowInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     tvShow: {
-      applyPlan: CreateTvShowInput_tvShow_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6704,9 +6320,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6741,11 +6363,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -6795,9 +6422,15 @@ export const plans = {
   },
   UpdateFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFilmPayload_clientMutationIdPlan,
-    film: UpdateFilmPayload_filmPlan,
-    query: UpdateFilmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6832,11 +6465,16 @@ export const plans = {
   },
   UpdateFilmInput: {
     clientMutationId: {
-      applyPlan: UpdateFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     filmPatch: {
-      applyPlan: UpdateFilmInput_filmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FilmPatch: {
@@ -6850,9 +6488,15 @@ export const plans = {
   },
   UpdateStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStudioPayload_clientMutationIdPlan,
-    studio: UpdateStudioPayload_studioPlan,
-    query: UpdateStudioPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6887,11 +6531,16 @@ export const plans = {
   },
   UpdateStudioInput: {
     clientMutationId: {
-      applyPlan: UpdateStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     studioPatch: {
-      applyPlan: UpdateStudioInput_studioPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StudioPatch: {
@@ -6905,9 +6554,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -6942,11 +6597,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -6973,9 +6633,15 @@ export const plans = {
   },
   UpdateTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: UpdateTvEpisodePayload_tvEpisodePlan,
-    query: UpdateTvEpisodePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7010,11 +6676,16 @@ export const plans = {
   },
   UpdateTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: UpdateTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     tvEpisodePatch: {
-      applyPlan: UpdateTvEpisodeInput_tvEpisodePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvEpisodePatch: {
@@ -7041,9 +6712,15 @@ export const plans = {
   },
   UpdateTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTvShowPayload_clientMutationIdPlan,
-    tvShow: UpdateTvShowPayload_tvShowPlan,
-    query: UpdateTvShowPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7078,11 +6755,16 @@ export const plans = {
   },
   UpdateTvShowInput: {
     clientMutationId: {
-      applyPlan: UpdateTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     tvShowPatch: {
-      applyPlan: UpdateTvShowInput_tvShowPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TvShowPatch: {
@@ -7109,9 +6791,15 @@ export const plans = {
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7146,11 +6834,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -7192,14 +6885,20 @@ export const plans = {
   },
   DeleteFilmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFilmPayload_clientMutationIdPlan,
-    film: DeleteFilmPayload_filmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    film($object) {
+      return $object.get("result");
+    },
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteFilmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     filmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7234,20 +6933,28 @@ export const plans = {
   },
   DeleteFilmInput: {
     clientMutationId: {
-      applyPlan: DeleteFilmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStudioPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStudioPayload_clientMutationIdPlan,
-    studio: DeleteStudioPayload_studioPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    studio($object) {
+      return $object.get("result");
+    },
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStudioPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     studioEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7282,20 +6989,28 @@ export const plans = {
   },
   DeleteStudioInput: {
     clientMutationId: {
-      applyPlan: DeleteStudioInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7330,20 +7045,28 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvEpisodePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvEpisodePayload_clientMutationIdPlan,
-    tvEpisode: DeleteTvEpisodePayload_tvEpisodePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvEpisode($object) {
+      return $object.get("result");
+    },
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvEpisodePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvEpisodeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7378,20 +7101,28 @@ export const plans = {
   },
   DeleteTvEpisodeInput: {
     clientMutationId: {
-      applyPlan: DeleteTvEpisodeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteTvShowPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTvShowPayload_clientMutationIdPlan,
-    tvShow: DeleteTvShowPayload_tvShowPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    tvShow($object) {
+      return $object.get("result");
+    },
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTvShowPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     tvShowEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7426,20 +7157,28 @@ export const plans = {
   },
   DeleteTvShowInput: {
     clientMutationId: {
-      applyPlan: DeleteTvShowInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7474,7 +7213,9 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const flambleAttributes = Object.assign(Object.create(null), {
+  f: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -65,20 +76,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_flamble = {
+const flambleIdentifier = sql.identifier(...["d", "flibble"]);
+const flambleCodecSpec = {
   name: "flamble",
-  identifier: sql.identifier(...["d", "flibble"]),
-  attributes: Object.assign(Object.create(null), {
-    f: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: false,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: flambleIdentifier,
+  attributes: flambleAttributes,
   description: undefined,
   extensions: {
     isTableLike: false,
@@ -93,8 +95,8 @@ const spec_flamble = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_flamble_flamble = recordCodec(spec_flamble);
-const attributes2 = Object.assign(Object.create(null), {
+const flambleCodec = recordCodec(flambleCodecSpec);
+const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
     description: undefined,
     codec: TYPES.int,
@@ -119,17 +121,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["d", "original_table"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_renamed_table = {
+const renamed_tableIdentifier = sql.identifier(...parts2);
+const renamed_tableCodecSpec = {
   name: "renamed_table",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: renamed_tableIdentifier,
+  attributes: renamed_tableAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_renamed_table_renamed_table = recordCodec(spec_renamed_table);
-const attributes3 = Object.assign(Object.create(null), {
+const renamed_tableCodec = recordCodec(renamed_tableCodecSpec);
+const filmsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -159,17 +161,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["d", "films"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_films = {
+const filmsIdentifier = sql.identifier(...parts3);
+const filmsCodecSpec = {
   name: "films",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: filmsIdentifier,
+  attributes: filmsAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_films_films = recordCodec(spec_films);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const filmsCodec = recordCodec(filmsCodecSpec);
+const studiosAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -199,17 +201,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["d", "studios"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_studios = {
+const studiosIdentifier = sql.identifier(...parts4);
+const studiosCodecSpec = {
   name: "studios",
-  identifier: sqlIdent4,
-  attributes: attributes_object_Object_,
+  identifier: studiosIdentifier,
+  attributes: studiosAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_studios_studios = recordCodec(spec_studios);
-const attributes4 = Object.assign(Object.create(null), {
+const studiosCodec = recordCodec(studiosCodecSpec);
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -248,17 +250,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["d", "post"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts5);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent5,
-  attributes: attributes4,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_post = recordCodec(spec_post);
-const attributes5 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -297,17 +299,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["d", "tv_episodes"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_tvEpisodes = {
+const tvEpisodesIdentifier = sql.identifier(...parts6);
+const tvEpisodesCodecSpec = {
   name: "tvEpisodes",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: tvEpisodesIdentifier,
+  attributes: tvEpisodesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvEpisodes_tvEpisodes = recordCodec(spec_tvEpisodes);
-const attributes6 = Object.assign(Object.create(null), {
+const tvEpisodesCodec = recordCodec(tvEpisodesCodecSpec);
+const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
     description: undefined,
     codec: TYPES.int,
@@ -346,17 +348,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["d", "tv_shows"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_tvShows = {
+const tvShowsIdentifier = sql.identifier(...parts7);
+const tvShowsCodecSpec = {
   name: "tvShows",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: tvShowsIdentifier,
+  attributes: tvShowsAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_tvShows_tvShows = recordCodec(spec_tvShows);
-const attributes7 = Object.assign(Object.create(null), {
+const tvShowsCodec = recordCodec(tvShowsCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -395,17 +397,17 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["d", "jwt_token"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts8);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const attributes8 = Object.assign(Object.create(null), {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -528,16 +530,16 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["d", "person"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts9);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent9,
-  attributes: attributes8,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_person_person = recordCodec(spec_person);
+const personCodec = recordCodec(personCodecSpec);
 const extensions10 = {
   pg: {
     serviceName: "main",
@@ -550,14 +552,14 @@ const extensions10 = {
   }
 };
 const parts10 = ["d", "original_function"];
-const sqlIdent10 = sql.identifier(...parts10);
+const sqlIdent = sql.identifier(...parts10);
 const parts11 = ["d", "getflamble"];
-const sqlIdent11 = sql.identifier(...parts11);
+const sqlIdent2 = sql.identifier(...parts11);
 const options_getflamble = {
   name: "getflamble",
   identifier: "main.d.getflamble()",
   from(...args) {
-    return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -591,8 +593,8 @@ const resourceConfig_flamble = {
   executor: executor_mainPgExecutor,
   name: "flamble",
   identifier: "main.d.flibble",
-  from: registryConfig_pgCodecs_flamble_flamble.sqlType,
-  codec: registryConfig_pgCodecs_flamble_flamble,
+  from: flambleCodec.sqlType,
+  codec: flambleCodec,
   uniques: [],
   isVirtual: true,
   description: undefined,
@@ -648,8 +650,8 @@ const registryConfig_pgResources_studios_studios = {
   executor: executor_mainPgExecutor,
   name: "studios",
   identifier: "main.d.studios",
-  from: registryConfig_pgCodecs_studios_studios.sqlType,
-  codec: registryConfig_pgCodecs_studios_studios,
+  from: studiosCodec.sqlType,
+  codec: studiosCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.d.post",
-  from: registryConfig_pgCodecs_post_post.sqlType,
-  codec: registryConfig_pgCodecs_post_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   executor: executor_mainPgExecutor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: registryConfig_pgCodecs_tvEpisodes_tvEpisodes.sqlType,
-  codec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+  from: tvEpisodesCodec.sqlType,
+  codec: tvEpisodesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,20 +734,20 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
   executor: executor_mainPgExecutor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: registryConfig_pgCodecs_tvShows_tvShows.sqlType,
-  codec: registryConfig_pgCodecs_tvShows_tvShows,
+  from: tvShowsCodec.sqlType,
+  codec: tvShowsCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
   extensions: extensions17
 };
 const parts12 = ["d", "authenticate"];
-const sqlIdent12 = sql.identifier(...parts12);
+const sqlIdent3 = sql.identifier(...parts12);
 const options_login = {
   name: "login",
   identifier: "main.d.authenticate(int4)",
   from(...args) {
-    return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -786,8 +788,8 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.d.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques8,
   isVirtual: true,
   description: undefined,
@@ -806,24 +808,24 @@ const extensions19 = {
   }
 };
 const parts13 = ["d", "person_full_name"];
-const sqlIdent13 = sql.identifier(...parts13);
-const fromCallback2 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+const sqlIdent4 = sql.identifier(...parts13);
+const fromCallback2 = (...args) => sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
 const parameters2 = [{
   name: "n",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_person_person,
+  codec: personCodec,
   extensions: {
     variant: "nodeId"
   }
 }];
 const parts14 = ["d", "search_posts"];
-const sqlIdent14 = sql.identifier(...parts14);
+const sqlIdent5 = sql.identifier(...parts14);
 const options_returnPostsMatching = {
   name: "returnPostsMatching",
   identifier: "main.d.search_posts(text)",
   from(...args) {
-    return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "search",
@@ -870,8 +872,8 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.d.person",
-  from: registryConfig_pgCodecs_person_person.sqlType,
-  codec: registryConfig_pgCodecs_person_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -880,17 +882,17 @@ const registryConfig_pgResources_person_person = {
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
-    flamble: registryConfig_pgCodecs_flamble_flamble,
+    flamble: flambleCodec,
     text: TYPES.text,
-    renamed_table: registryConfig_pgCodecs_renamed_table_renamed_table,
-    films: registryConfig_pgCodecs_films_films,
+    renamed_table: renamed_tableCodec,
+    films: filmsCodec,
     varchar: TYPES.varchar,
-    studios: registryConfig_pgCodecs_studios_studios,
-    post: registryConfig_pgCodecs_post_post,
-    tvEpisodes: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
-    tvShows: registryConfig_pgCodecs_tvShows_tvShows,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
-    person: registryConfig_pgCodecs_person_person,
+    studios: studiosCodec,
+    post: postCodec,
+    tvEpisodes: tvEpisodesCodec,
+    tvShows: tvShowsCodec,
+    jwtToken: jwtTokenCodec,
+    person: personCodec,
     bpchar: TYPES.bpchar
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -899,7 +901,7 @@ const registryConfig = {
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -914,8 +916,8 @@ const registryConfig = {
       executor: executor_mainPgExecutor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: registryConfig_pgCodecs_renamed_table_renamed_table.sqlType,
-      codec: registryConfig_pgCodecs_renamed_table_renamed_table,
+      from: renamed_tableCodec.sqlType,
+      codec: renamed_tableCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -925,8 +927,8 @@ const registryConfig = {
       executor: executor_mainPgExecutor,
       name: "films",
       identifier: "main.d.films",
-      from: registryConfig_pgCodecs_films_films.sqlType,
-      codec: registryConfig_pgCodecs_films_films,
+      from: filmsCodec.sqlType,
+      codec: filmsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: undefined,
@@ -956,7 +958,7 @@ const registryConfig = {
   pgRelations: Object.assign(Object.create(null), {
     person: Object.assign(Object.create(null), {
       posts: {
-        localCodec: registryConfig_pgCodecs_person_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -975,7 +977,7 @@ const registryConfig = {
     }),
     post: Object.assign(Object.create(null), {
       author: {
-        localCodec: registryConfig_pgCodecs_post_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -994,7 +996,7 @@ const registryConfig = {
     }),
     studios: Object.assign(Object.create(null), {
       tvShowsByTheirStudioId: {
-        localCodec: registryConfig_pgCodecs_studios_studios,
+        localCodec: studiosCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1011,7 +1013,7 @@ const registryConfig = {
     }),
     tvEpisodes: Object.assign(Object.create(null), {
       tvShowsByMyShowId: {
-        localCodec: registryConfig_pgCodecs_tvEpisodes_tvEpisodes,
+        localCodec: tvEpisodesCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_shows_tv_shows,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["show_id"],
@@ -1028,7 +1030,7 @@ const registryConfig = {
     }),
     tvShows: Object.assign(Object.create(null), {
       studiosByMyStudioId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_studios_studios,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["studio_id"],
@@ -1043,7 +1045,7 @@ const registryConfig = {
         }
       },
       tvEpisodesByTheirShowId: {
-        localCodec: registryConfig_pgCodecs_tvShows_tvShows,
+        localCodec: tvShowsCodec,
         remoteResourceOptions: registryConfig_pgResources_tv_episodes_tv_episodes,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["code"],
@@ -1257,7 +1259,7 @@ const getSpec = $nodeId => {
 const argDetailsSimple2 = [{
   graphqlArgName: "n",
   postgresArgName: "n",
-  pgCodec: registryConfig_pgCodecs_person_person,
+  pgCodec: personCodec,
   required: true,
   fetcher($nodeId) {
     return pgResource_personPgResource.get(getSpec($nodeId));
@@ -4678,7 +4680,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4694,7 +4696,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_post_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4758,7 +4760,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -4995,7 +4997,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5011,7 +5013,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvEpisodes_tvEpisodes.attributes[attributeName];
+          const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5075,7 +5077,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
             }
           });
         }
@@ -5132,7 +5134,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5148,7 +5150,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_tvShows_tvShows.attributes[attributeName];
+          const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5212,7 +5214,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
             }
           });
         }
@@ -5332,7 +5334,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
             }
           });
         }
@@ -5366,7 +5368,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5382,7 +5384,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_films_films.attributes[attributeName];
+          const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5446,7 +5448,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
             }
           });
         }
@@ -5480,7 +5482,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5496,7 +5498,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_studios_studios.attributes[attributeName];
+          const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5560,7 +5562,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
             }
           });
         }
@@ -5594,7 +5596,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5610,7 +5612,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_person_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5844,7 +5846,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
             }
           });
         }
@@ -5867,7 +5869,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
             }
           });
         }
@@ -5890,7 +5892,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
             }
           });
         }
@@ -5913,7 +5915,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
             }
           });
         }
@@ -5936,7 +5938,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
             }
           });
         }
@@ -5959,7 +5961,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -84,7 +84,7 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const renamed_tableAttributes = Object.assign(Object.create(null), {
   col1: {
@@ -115,7 +115,7 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const filmsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -151,7 +151,7 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const studiosAttributes = Object.assign(Object.create(null), {
   id: {
@@ -187,7 +187,7 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const postAttributes = Object.assign(Object.create(null), {
   id: {
@@ -232,7 +232,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvEpisodesAttributes = Object.assign(Object.create(null), {
   code: {
@@ -277,7 +277,7 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const tvShowsAttributes = Object.assign(Object.create(null), {
   code: {
@@ -322,7 +322,7 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -366,7 +366,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -495,11 +495,11 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const sqlIdent = sql.identifier("d", "original_function");
-const sqlIdent2 = sql.identifier("d", "getflamble");
-const uniques3 = [{
+const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
+const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
+const filmsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -507,7 +507,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const studiosUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -516,12 +516,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "studios",
   identifier: "main.d.studios",
   from: studiosCodec.sqlType,
   codec: studiosCodec,
-  uniques: uniques4,
+  uniques: studiosUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -534,7 +534,7 @@ const registryConfig_pgResources_studios_studios = {
     tags: {}
   }
 };
-const uniques5 = [{
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -543,12 +543,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.d.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques5,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -561,7 +561,7 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const uniques6 = [{
+const tv_episodesUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -570,12 +570,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
   from: tvEpisodesCodec.sqlType,
   codec: tvEpisodesCodec,
-  uniques: uniques6,
+  uniques: tv_episodesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -588,7 +588,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     tags: {}
   }
 };
-const uniques7 = [{
+const tv_showsUniques = [{
   isPrimary: true,
   attributes: ["code"],
   description: undefined,
@@ -597,12 +597,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
   from: tvShowsCodec.sqlType,
   codec: tvShowsCodec,
-  uniques: uniques7,
+  uniques: tv_showsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -615,10 +615,10 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     tags: {}
   }
 };
-const sqlIdent3 = sql.identifier("d", "authenticate");
-const sqlIdent4 = sql.identifier("d", "person_full_name");
-const sqlIdent5 = sql.identifier("d", "search_posts");
-const uniques9 = [{
+const authenticateFunctionIdentifer = sql.identifier("d", "authenticate");
+const person_full_nameFunctionIdentifer = sql.identifier("d", "person_full_name");
+const search_postsFunctionIdentifer = sql.identifier("d", "search_posts");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -629,12 +629,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.d.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,11 +665,11 @@ const registryConfig = {
   }),
   pgResources: Object.assign(Object.create(null), {
     renamed_function: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_function",
       identifier: "main.d.original_function()",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${original_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -690,7 +690,7 @@ const registryConfig = {
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "flamble",
       identifier: "main.d.flibble",
       from: flambleCodec.sqlType,
@@ -714,7 +714,7 @@ const registryConfig = {
       name: "getflamble",
       identifier: "main.d.getflamble()",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${getflambleFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -733,7 +733,7 @@ const registryConfig = {
       description: undefined
     }),
     renamed_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
       from: renamed_tableCodec.sqlType,
@@ -754,12 +754,12 @@ const registryConfig = {
       }
     },
     films: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "films",
       identifier: "main.d.films",
       from: filmsCodec.sqlType,
       codec: filmsCodec,
-      uniques: uniques3,
+      uniques: filmsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -777,7 +777,7 @@ const registryConfig = {
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
       from: jwtTokenCodec.sqlType,
@@ -800,7 +800,7 @@ const registryConfig = {
       name: "login",
       identifier: "main.d.authenticate(int4)",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -826,11 +826,11 @@ const registryConfig = {
       description: undefined
     }),
     person_full_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_full_name",
       identifier: "main.d.person_full_name(d.person)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${person_full_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "n",
@@ -863,7 +863,7 @@ const registryConfig = {
       name: "returnPostsMatching",
       identifier: "main.d.search_posts(text)",
       from(...args) {
-        return sql`${sqlIdent5}(${sqlFromArgDigests(args)})`;
+        return sql`${search_postsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "search",
@@ -4109,7 +4109,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4125,7 +4125,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4464,7 +4464,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4480,7 +4480,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        tv_episodesUniques[0].attributes.forEach(attributeName => {
           const attribute = tvEpisodesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4601,7 +4601,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4617,7 +4617,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        tv_showsUniques[0].attributes.forEach(attributeName => {
           const attribute = tvShowsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4849,7 +4849,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4865,7 +4865,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        filmsUniques[0].attributes.forEach(attributeName => {
           const attribute = filmsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4970,7 +4970,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4986,7 +4986,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        studiosUniques[0].attributes.forEach(attributeName => {
           const attribute = studiosCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5091,7 +5091,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5107,7 +5107,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5930,7 +5930,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6004,7 +6004,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6078,7 +6078,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6165,7 +6165,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6252,7 +6252,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6339,7 +6339,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6441,7 +6441,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6507,7 +6507,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6573,7 +6573,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6652,7 +6652,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6731,7 +6731,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6810,7 +6810,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6909,7 +6909,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = filmsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -6965,7 +6965,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = studiosUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7021,7 +7021,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7077,7 +7077,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_episodesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7133,7 +7133,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = tv_showsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7189,7 +7189,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -492,17 +493,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -541,17 +542,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -599,17 +600,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -648,17 +649,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -706,16 +707,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -725,13 +726,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -743,7 +744,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -761,16 +762,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -780,10 +781,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -798,10 +798,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -816,15 +816,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -845,7 +845,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -863,7 +863,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -872,7 +872,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -908,17 +908,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -929,7 +929,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -939,7 +939,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,7 +949,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -960,7 +960,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -970,7 +970,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,7 +980,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -989,7 +989,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -998,21 +998,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1020,7 +1020,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1040,7 +1040,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1050,23 +1050,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1105,7 +1105,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1114,7 +1114,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1122,7 +1122,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1132,17 +1132,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1153,7 +1153,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1161,7 +1161,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1171,7 +1171,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,7 +1181,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1202,7 +1202,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,7 +1212,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1233,7 +1233,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,7 +1243,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1251,13 +1251,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1266,13 +1266,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1281,16 +1281,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1298,7 +1298,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1308,17 +1308,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1341,7 +1341,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1359,7 +1359,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1368,7 +1368,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1423,7 +1423,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1433,20 +1433,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1464,7 +1464,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,7 +1474,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1485,7 +1485,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1493,7 +1493,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1503,7 +1503,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,7 +1513,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1524,7 +1524,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1532,7 +1532,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1542,7 +1542,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,7 +1552,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1563,7 +1563,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1571,7 +1571,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1581,7 +1581,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,7 +1591,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1602,7 +1602,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1610,7 +1610,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1620,7 +1620,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,7 +1630,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1641,7 +1641,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1649,7 +1649,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1659,7 +1659,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,7 +1669,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1677,13 +1677,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1692,13 +1692,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1707,13 +1707,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1722,12 +1722,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1736,12 +1736,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1750,12 +1750,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1763,16 +1763,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1781,7 +1781,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1798,7 +1798,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1808,17 +1808,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1827,13 +1827,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1841,7 +1841,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1849,20 +1849,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1870,13 +1870,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1888,8 +1888,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1955,7 +1955,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1964,7 +1964,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1973,7 +1973,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1982,7 +1982,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1991,7 +1991,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2018,7 +2018,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2027,7 +2027,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2036,7 +2036,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2045,7 +2045,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2108,7 +2108,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2126,7 +2126,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2135,7 +2135,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2144,7 +2144,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2153,7 +2153,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2279,7 +2279,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2288,7 +2288,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2306,7 +2306,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2315,7 +2315,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2324,7 +2324,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2332,7 +2332,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2344,17 +2344,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2362,7 +2362,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2370,13 +2370,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2385,12 +2385,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2401,8 +2401,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2414,10 +2414,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2429,10 +2429,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2443,10 +2443,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2458,10 +2458,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2473,10 +2473,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2487,10 +2487,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2501,10 +2501,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2515,10 +2515,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2530,15 +2530,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2550,15 +2550,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2570,15 +2570,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2590,15 +2590,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2609,15 +2609,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2628,15 +2628,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2647,15 +2647,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2666,15 +2666,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2685,15 +2685,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2704,15 +2704,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2724,8 +2724,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2737,7 +2737,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2748,10 +2748,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2762,10 +2762,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2776,10 +2776,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2791,8 +2791,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2804,7 +2804,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2815,10 +2815,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2829,10 +2829,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2843,10 +2843,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2857,10 +2857,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2871,15 +2871,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2890,8 +2890,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2908,7 +2908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2919,8 +2919,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2937,7 +2937,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2948,10 +2948,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2962,15 +2962,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2982,10 +2982,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3002,7 +3002,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3025,14 +3025,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3053,14 +3053,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3077,7 +3077,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3088,21 +3088,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3120,7 +3120,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3130,7 +3130,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3158,26 +3158,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3199,7 +3199,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3220,20 +3220,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3252,12 +3252,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3275,7 +3275,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3286,8 +3286,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3307,7 +3307,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3317,9 +3317,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3330,8 +3330,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3351,7 +3351,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3361,9 +3361,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3374,15 +3374,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3393,15 +3393,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3412,15 +3412,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3431,8 +3431,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3450,12 +3450,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3473,7 +3473,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3489,20 +3489,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3526,16 +3526,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3559,10 +3559,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3577,15 +3577,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3597,15 +3597,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3616,15 +3616,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3636,20 +3636,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3660,20 +3660,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3685,20 +3685,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3709,15 +3709,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3728,8 +3728,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3741,7 +3741,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3752,8 +3752,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3765,7 +3765,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3776,8 +3776,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3789,7 +3789,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3800,8 +3800,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3813,7 +3813,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3824,13 +3824,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3842,7 +3842,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3870,26 +3870,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3907,16 +3907,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3936,12 +3936,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3960,12 +3960,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3984,12 +3984,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4008,12 +4008,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4032,12 +4032,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4056,12 +4056,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4082,12 +4082,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4106,18 +4106,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4136,18 +4136,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4166,18 +4166,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4195,22 +4195,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4233,22 +4233,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4266,7 +4266,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4287,40 +4287,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4331,21 +4331,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4355,22 +4355,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4378,14 +4378,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4398,7 +4398,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4411,7 +4411,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4424,7 +4424,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4437,7 +4437,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4450,7 +4450,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4463,7 +4463,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4476,7 +4476,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4489,7 +4489,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4502,7 +4502,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4515,7 +4515,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4528,7 +4528,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4541,7 +4541,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4567,7 +4567,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4580,7 +4580,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4593,7 +4593,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4606,7 +4606,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4619,7 +4619,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4632,7 +4632,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4645,7 +4645,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4658,7 +4658,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4671,7 +4671,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4684,7 +4684,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4697,7 +4697,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4710,7 +4710,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4723,7 +4723,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4736,7 +4736,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4749,7 +4749,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4762,7 +4762,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4775,7 +4775,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4788,7 +4788,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4801,7 +4801,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4814,19 +4814,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4834,12 +4834,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4851,7 +4851,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4859,12 +4859,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4881,7 +4881,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4894,7 +4894,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4907,7 +4907,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4920,7 +4920,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4933,7 +4933,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4946,7 +4946,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4962,7 +4962,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4975,7 +4975,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4988,7 +4988,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5001,7 +5001,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5014,7 +5014,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5027,7 +5027,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5040,7 +5040,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5053,7 +5053,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5066,7 +5066,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5079,7 +5079,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5092,7 +5092,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5105,7 +5105,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5127,7 +5127,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5142,7 +5142,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5159,7 +5159,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5176,7 +5176,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5193,7 +5193,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5208,7 +5208,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5223,7 +5223,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5240,7 +5240,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6417,7 +6417,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6429,7 +6429,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7613,7 +7613,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -9365,7 +9365,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9536,7 +9536,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9548,7 +9548,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -17292,7 +17292,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17308,7 +17308,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17966,7 +17966,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17982,7 +17982,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18114,7 +18114,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -18137,7 +18137,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -18160,7 +18160,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -18495,7 +18495,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -18518,7 +18518,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -18541,7 +18541,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -18564,7 +18564,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -18587,7 +18587,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -18610,7 +18610,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -18633,7 +18633,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -18656,7 +18656,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -18679,7 +18679,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -18702,7 +18702,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -18725,7 +18725,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -18783,7 +18783,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18799,7 +18799,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18897,7 +18897,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -18920,7 +18920,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -18954,7 +18954,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18970,7 +18970,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19068,7 +19068,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -19091,7 +19091,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -19125,7 +19125,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19141,7 +19141,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19307,7 +19307,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -19330,7 +19330,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -19353,7 +19353,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -19376,7 +19376,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -19572,7 +19572,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -19595,7 +19595,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -19618,7 +19618,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -19652,7 +19652,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19668,7 +19668,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19834,7 +19834,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -19857,7 +19857,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -19880,7 +19880,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -19903,7 +19903,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -19937,7 +19937,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19953,7 +19953,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20051,7 +20051,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -20074,7 +20074,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,28 +462,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -532,26 +509,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -590,26 +563,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -639,26 +608,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -697,39 +662,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -752,194 +710,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -948,29 +886,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,198 +917,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1180,29 +1100,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1211,29 +1130,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,81 +1161,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1423,48 +1329,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1473,37 +1374,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1512,37 +1412,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1551,37 +1450,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1590,37 +1488,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1629,37 +1526,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,209 +1565,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1889,1111 +1755,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3002,17 +2281,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3030,16 +2298,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3058,16 +2327,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3077,68 +2345,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3163,51 +2371,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3225,632 +2399,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3875,400 +2456,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4363,7 +2574,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4385,436 +2603,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4826,7 +3537,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4839,290 +3558,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5545,25 +5235,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5764,21 +5435,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6037,21 +5693,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs12(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6200,21 +5841,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs15(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6283,21 +5909,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs16(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6344,12 +5955,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6644,21 +6249,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs22(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6831,21 +6421,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs25(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6896,21 +6471,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs26(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -7007,21 +6567,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -7072,21 +6617,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs29(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7155,21 +6685,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs30(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7244,127 +6759,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -7938,21 +7333,6 @@ const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -8033,21 +7413,6 @@ const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -8147,36 +7512,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -8224,173 +7559,9 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -8437,26 +7608,6 @@ const makeArgs46 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -8503,9 +7654,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8552,9 +7700,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8601,9 +7746,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8650,9 +7792,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8705,9 +7844,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8760,9 +7896,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8815,9 +7948,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8870,9 +8000,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8925,9 +8052,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8980,9 +8104,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9041,9 +8162,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -9090,9 +8208,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -9139,9 +8254,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -9188,9 +8300,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -9255,9 +8364,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -9304,9 +8410,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9359,9 +8462,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9414,9 +8514,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -9463,9 +8560,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9512,9 +8606,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9597,9 +8688,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9652,9 +8740,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9707,9 +8792,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9768,9 +8850,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9829,9 +8908,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -9878,9 +8954,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -9927,9 +9000,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -9976,851 +9046,62 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "id"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByRowIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByRowIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByRowIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByRowIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByRowIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -15292,7 +13573,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     id($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -15406,27 +13689,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15456,23 +13752,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15516,23 +13822,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15553,23 +13869,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15584,23 +13910,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15612,11 +13948,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15666,23 +14006,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15715,23 +14065,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15743,23 +14103,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15775,23 +14145,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15803,23 +14183,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15847,23 +14237,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15937,23 +14337,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15980,23 +14390,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16023,23 +14443,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16066,23 +14496,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16109,23 +14549,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16152,23 +14602,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16195,23 +14655,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16238,23 +14708,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16681,23 +15161,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16718,23 +15208,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16870,23 +15370,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16916,23 +15426,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17100,12 +15620,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -17198,9 +15730,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17216,8 +15755,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -17664,9 +16207,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17917,9 +16467,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18203,9 +16760,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18221,9 +16785,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18248,9 +16819,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18296,9 +16874,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18323,9 +16908,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18397,9 +16989,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18439,9 +17038,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18760,9 +17366,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18931,9 +17544,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19102,9 +17722,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19387,9 +18014,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19629,9 +18263,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19914,9 +18555,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20096,7 +18744,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20111,7 +18761,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20126,7 +18778,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20141,7 +18795,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20156,7 +18812,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20171,7 +18829,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20186,7 +18846,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20201,7 +18863,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20216,7 +18880,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20231,7 +18897,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20246,7 +18914,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20261,7 +18931,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20276,7 +18948,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20291,7 +18965,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20306,7 +18982,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20321,7 +18999,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20336,7 +19016,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20351,7 +19033,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20366,7 +19050,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20381,7 +19067,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20396,7 +19084,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20411,7 +19101,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20426,7 +19118,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20441,7 +19135,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20456,7 +19152,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20471,7 +19169,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20486,7 +19186,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20501,7 +19203,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20516,7 +19220,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20531,7 +19237,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20546,7 +19254,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20561,7 +19271,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20576,7 +19288,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20591,7 +19305,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20606,7 +19322,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20621,7 +19339,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20635,7 +19355,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20651,7 +19373,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20665,7 +19389,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20681,7 +19407,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20695,7 +19423,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20712,7 +19442,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20726,7 +19458,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20742,7 +19476,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20756,7 +19492,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20772,7 +19510,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20788,7 +19528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20802,7 +19544,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20818,7 +19562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20832,7 +19578,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20848,7 +19596,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20864,7 +19614,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20878,7 +19630,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20894,7 +19648,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20908,7 +19664,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20924,7 +19682,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20938,7 +19698,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20955,7 +19717,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20969,7 +19733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20985,7 +19751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -20999,7 +19767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21015,7 +19785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21031,7 +19803,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21045,7 +19819,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21061,7 +19837,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21075,7 +19853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21091,7 +19871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21107,168 +19889,236 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -21276,11 +20126,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21293,17 +20147,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21316,17 +20176,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21339,21 +20205,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -21362,11 +20236,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21382,17 +20260,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21405,18 +20289,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21456,7 +20346,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -21493,11 +20385,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21532,35 +20428,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21572,11 +20482,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21595,33 +20509,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21649,7 +20575,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21657,11 +20585,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -21689,7 +20621,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -21697,11 +20631,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21736,43 +20674,63 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21807,11 +20765,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -21833,9 +20796,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21875,11 +20844,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -21901,9 +20875,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -21948,11 +20928,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -21981,9 +20966,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22018,11 +21009,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22058,17 +21054,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22097,9 +21104,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22139,11 +21152,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22179,9 +21197,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22216,11 +21240,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22242,9 +21271,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22279,11 +21314,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22368,9 +21408,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22405,11 +21451,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -22430,18 +21481,29 @@ export const plans = {
   },
   UpdateMyTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByRowIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22481,11 +21543,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -22506,18 +21573,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22562,11 +21640,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -22594,19 +21677,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22641,11 +21735,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -22680,18 +21779,29 @@ export const plans = {
   },
   UpdateNullTestRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByRowIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22731,11 +21841,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -22770,27 +21885,43 @@ export const plans = {
   },
   UpdateLeftArmByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByRowIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22825,11 +21956,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -22850,18 +21986,29 @@ export const plans = {
   },
   UpdateIssue756ByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByRowIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22896,11 +22043,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -22984,32 +22136,48 @@ export const plans = {
   },
   UpdatePersonByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByRowIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23044,26 +22212,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23103,26 +22281,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23167,27 +22355,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23222,26 +22420,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23281,32 +22489,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23341,26 +22561,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteIssue756ByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23395,19 +22625,25 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -478,7 +478,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -523,7 +523,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -577,7 +577,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -622,7 +622,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -676,7 +676,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -724,7 +724,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -855,7 +855,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -884,7 +884,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -914,7 +914,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -977,7 +977,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1061,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1098,7 +1098,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1128,7 +1128,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1158,7 +1158,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1222,7 +1222,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1343,7 +1343,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1372,7 +1372,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1410,7 +1410,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1448,7 +1448,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1486,7 +1486,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1524,7 +1524,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1562,7 +1562,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1690,7 +1690,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2213,7 +2213,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2239,41 +2239,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2281,7 +2281,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2290,12 +2290,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2310,7 +2310,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2319,12 +2319,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2337,7 +2337,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2345,9 +2345,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2363,12 +2363,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2381,8 +2381,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2391,12 +2391,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2409,30 +2409,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2448,12 +2448,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2466,20 +2466,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2592,11 +2592,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2616,11 +2616,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2641,11 +2641,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2666,11 +2666,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2690,11 +2690,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2715,11 +2715,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2740,11 +2740,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2764,11 +2764,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2788,11 +2788,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2812,11 +2812,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2842,11 +2842,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2872,11 +2872,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2902,11 +2902,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2932,11 +2932,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2961,11 +2961,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2990,11 +2990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3019,11 +3019,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3048,11 +3048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3077,11 +3077,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3106,11 +3106,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3141,11 +3141,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3165,11 +3165,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3189,11 +3189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3213,11 +3213,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3248,11 +3248,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3272,11 +3272,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3296,11 +3296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3320,11 +3320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3344,11 +3344,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3373,11 +3373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3412,11 +3412,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3451,11 +3451,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3475,11 +3475,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3504,11 +3504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3529,12 +3529,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3550,12 +3550,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3569,11 +3569,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3601,7 +3601,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3620,7 +3620,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3643,7 +3643,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3698,7 +3698,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3717,11 +3717,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3771,11 +3771,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3825,11 +3825,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3854,11 +3854,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3883,11 +3883,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3912,11 +3912,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3951,7 +3951,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3974,7 +3974,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3994,12 +3994,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4024,12 +4024,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4053,11 +4053,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4086,11 +4086,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4116,11 +4116,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4145,11 +4145,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4180,11 +4180,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4214,11 +4214,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4249,11 +4249,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4278,11 +4278,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4312,11 +4312,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4346,11 +4346,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4380,11 +4380,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4414,11 +4414,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4455,12 +4455,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4487,7 +4487,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4510,7 +4510,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4532,7 +4532,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4576,7 +4576,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4598,7 +4598,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4620,7 +4620,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4644,7 +4644,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4666,7 +4666,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4694,7 +4694,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4720,12 +4720,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4750,12 +4750,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4785,12 +4785,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -15834,7 +15834,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15850,7 +15850,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16522,7 +16522,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16538,7 +16538,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17395,7 +17395,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17411,7 +17411,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17573,7 +17573,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17589,7 +17589,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17751,7 +17751,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17767,7 +17767,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18292,7 +18292,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18308,7 +18308,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18584,7 +18584,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18600,7 +18600,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -20317,7 +20317,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20404,7 +20404,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20650,7 +20650,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20741,7 +20741,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20815,7 +20815,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20894,7 +20894,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -20985,7 +20985,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21123,7 +21123,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21216,7 +21216,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21290,7 +21290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21427,7 +21427,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21514,7 +21514,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21606,7 +21606,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21711,7 +21711,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21812,7 +21812,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21932,7 +21932,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22019,7 +22019,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22188,7 +22188,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22252,7 +22252,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22321,7 +22321,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22396,7 +22396,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22460,7 +22460,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22537,7 +22537,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22601,7 +22601,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -492,17 +493,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -541,17 +542,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -599,17 +600,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -648,17 +649,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -706,16 +707,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -725,13 +726,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -743,7 +744,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -761,16 +762,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -780,10 +781,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -798,10 +798,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -816,15 +816,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -845,7 +845,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -863,7 +863,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -872,7 +872,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -908,17 +908,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -929,7 +929,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -939,7 +939,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,7 +949,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -960,7 +960,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -970,7 +970,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,7 +980,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -989,7 +989,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -998,21 +998,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1020,7 +1020,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1040,7 +1040,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1050,23 +1050,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1105,7 +1105,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1114,7 +1114,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1122,7 +1122,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1132,17 +1132,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1153,7 +1153,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1161,7 +1161,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1171,7 +1171,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,7 +1181,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1202,7 +1202,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,7 +1212,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1233,7 +1233,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,7 +1243,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1251,13 +1251,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1266,13 +1266,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1281,16 +1281,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1298,7 +1298,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1308,17 +1308,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1341,7 +1341,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1359,7 +1359,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1368,7 +1368,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1423,7 +1423,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1433,20 +1433,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1464,7 +1464,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,7 +1474,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1485,7 +1485,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1493,7 +1493,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1503,7 +1503,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,7 +1513,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1524,7 +1524,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1532,7 +1532,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1542,7 +1542,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,7 +1552,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1563,7 +1563,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1571,7 +1571,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1581,7 +1581,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,7 +1591,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1602,7 +1602,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1610,7 +1610,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1620,7 +1620,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,7 +1630,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1641,7 +1641,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1649,7 +1649,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1659,7 +1659,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,7 +1669,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1677,13 +1677,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1692,13 +1692,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1707,13 +1707,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1722,12 +1722,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1736,12 +1736,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1750,12 +1750,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1763,16 +1763,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1781,7 +1781,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1798,7 +1798,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1808,17 +1808,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1827,13 +1827,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1841,7 +1841,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1849,20 +1849,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1870,13 +1870,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1888,8 +1888,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1955,7 +1955,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1964,7 +1964,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1973,7 +1973,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1982,7 +1982,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1991,7 +1991,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2018,7 +2018,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2027,7 +2027,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2036,7 +2036,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2045,7 +2045,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2108,7 +2108,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2126,7 +2126,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2135,7 +2135,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2144,7 +2144,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2153,7 +2153,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2279,7 +2279,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2288,7 +2288,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2306,7 +2306,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2315,7 +2315,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2324,7 +2324,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2332,7 +2332,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2344,17 +2344,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2362,7 +2362,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2370,13 +2370,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2385,12 +2385,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2401,8 +2401,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2414,10 +2414,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2429,10 +2429,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2443,10 +2443,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2458,10 +2458,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2473,10 +2473,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2487,10 +2487,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2501,10 +2501,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2515,10 +2515,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2530,15 +2530,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2550,15 +2550,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2570,15 +2570,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2590,15 +2590,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2609,15 +2609,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2628,15 +2628,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2647,15 +2647,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2666,15 +2666,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2685,15 +2685,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2704,15 +2704,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2724,8 +2724,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2737,7 +2737,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2748,10 +2748,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2762,10 +2762,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2776,10 +2776,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2791,8 +2791,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2804,7 +2804,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2815,10 +2815,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2829,10 +2829,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2843,10 +2843,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2857,10 +2857,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2871,15 +2871,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2890,8 +2890,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2908,7 +2908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2919,8 +2919,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2937,7 +2937,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2948,10 +2948,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2962,15 +2962,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2982,10 +2982,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3002,7 +3002,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3025,14 +3025,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3053,14 +3053,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3077,7 +3077,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3088,21 +3088,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3120,7 +3120,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3130,7 +3130,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3158,26 +3158,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3199,7 +3199,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3220,20 +3220,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3252,12 +3252,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3275,7 +3275,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3286,8 +3286,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3307,7 +3307,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3317,9 +3317,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3330,8 +3330,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3351,7 +3351,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3361,9 +3361,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3374,15 +3374,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3393,15 +3393,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3412,15 +3412,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3431,8 +3431,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3450,12 +3450,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3473,7 +3473,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3489,20 +3489,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3526,16 +3526,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3559,10 +3559,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3577,15 +3577,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3597,15 +3597,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3616,15 +3616,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3636,20 +3636,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3660,20 +3660,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3685,20 +3685,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3709,15 +3709,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3728,8 +3728,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3741,7 +3741,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3752,8 +3752,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3765,7 +3765,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3776,8 +3776,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3789,7 +3789,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3800,8 +3800,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3813,7 +3813,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3824,13 +3824,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3842,7 +3842,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3870,26 +3870,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3907,16 +3907,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3936,12 +3936,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3960,12 +3960,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3984,12 +3984,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4008,12 +4008,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4032,12 +4032,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4056,12 +4056,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4082,12 +4082,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4106,18 +4106,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4136,18 +4136,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4166,18 +4166,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4195,22 +4195,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4233,22 +4233,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4266,7 +4266,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4287,40 +4287,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4331,21 +4331,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4355,22 +4355,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4378,14 +4378,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4398,7 +4398,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4411,7 +4411,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4424,7 +4424,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4437,7 +4437,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4450,7 +4450,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4463,7 +4463,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4476,7 +4476,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4489,7 +4489,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4502,7 +4502,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4515,7 +4515,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4528,7 +4528,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4541,7 +4541,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4567,7 +4567,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4580,7 +4580,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4593,7 +4593,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4606,7 +4606,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4619,7 +4619,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4632,7 +4632,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4645,7 +4645,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4658,7 +4658,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4671,7 +4671,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4684,7 +4684,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4697,7 +4697,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4710,7 +4710,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4723,7 +4723,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4736,7 +4736,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4749,7 +4749,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4762,7 +4762,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4775,7 +4775,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4788,7 +4788,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4801,7 +4801,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4814,19 +4814,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4834,12 +4834,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4851,7 +4851,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4859,12 +4859,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4881,7 +4881,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4894,7 +4894,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4907,7 +4907,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4920,7 +4920,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4933,7 +4933,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4946,7 +4946,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4962,7 +4962,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4975,7 +4975,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4988,7 +4988,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5001,7 +5001,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5014,7 +5014,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5027,7 +5027,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5040,7 +5040,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5053,7 +5053,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5066,7 +5066,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5079,7 +5079,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5092,7 +5092,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5105,7 +5105,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5127,7 +5127,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5142,7 +5142,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5159,7 +5159,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5176,7 +5176,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5193,7 +5193,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5208,7 +5208,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5223,7 +5223,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5240,7 +5240,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6447,7 +6447,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6459,7 +6459,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7727,7 +7727,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -9503,7 +9503,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9674,7 +9674,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9686,7 +9686,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -18205,7 +18205,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18221,7 +18221,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18879,7 +18879,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18895,7 +18895,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19027,7 +19027,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -19050,7 +19050,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -19073,7 +19073,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -19408,7 +19408,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -19431,7 +19431,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -19454,7 +19454,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -19477,7 +19477,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -19500,7 +19500,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -19523,7 +19523,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -19546,7 +19546,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -19569,7 +19569,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -19592,7 +19592,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -19615,7 +19615,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -19638,7 +19638,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -19678,7 +19678,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19694,7 +19694,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19792,7 +19792,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -19815,7 +19815,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -19849,7 +19849,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19865,7 +19865,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19963,7 +19963,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -19986,7 +19986,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -20020,7 +20020,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20036,7 +20036,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20202,7 +20202,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -20225,7 +20225,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -20248,7 +20248,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -20271,7 +20271,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -20467,7 +20467,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -20490,7 +20490,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -20513,7 +20513,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -20547,7 +20547,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20563,7 +20563,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20729,7 +20729,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -20752,7 +20752,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -20775,7 +20775,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -20798,7 +20798,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -20832,7 +20832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20848,7 +20848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20946,7 +20946,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -20969,7 +20969,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,28 +462,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -532,26 +509,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -590,26 +563,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -639,26 +608,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -697,39 +662,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -752,194 +710,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -948,29 +886,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,198 +917,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1180,29 +1100,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1211,29 +1130,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,81 +1161,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1423,48 +1329,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1473,37 +1374,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1512,37 +1412,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1551,37 +1450,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1590,37 +1488,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1629,37 +1526,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,209 +1565,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1889,1111 +1755,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3002,17 +2281,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3030,16 +2298,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3058,16 +2327,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3077,68 +2345,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3163,51 +2371,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3225,632 +2399,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3875,400 +2456,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4363,7 +2574,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4385,436 +2603,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4826,7 +3537,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4839,290 +3558,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5545,31 +5235,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcOutSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5770,27 +5435,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcReturnsTableOneColList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneColList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6049,27 +5693,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs12(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcOutOutSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6218,27 +5841,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs15(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcReturnsTableMultiColList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiColList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6307,27 +5909,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs16(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_intSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6374,12 +5955,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6674,27 +6249,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs22(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_compoundTypeSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6867,27 +6421,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs25(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcOutComplexSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6938,27 +6471,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs26(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_badlyBehavedFunctionList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunctionList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -7055,27 +6567,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_funcOutTableSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -7126,21 +6617,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs29(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7159,12 +6635,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_tableSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {
   const selectArgs = [];
@@ -7215,27 +6685,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs30(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_tableSetQueryPlpgsqlList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsqlList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7310,175 +6759,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTablesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTablesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecretsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecretsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeysList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeysList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecordsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecordsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCasesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCasesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArmsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArmsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756SList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756SList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeopleList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeopleList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -8052,27 +7333,6 @@ const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_friendsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friendsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -8153,27 +7413,6 @@ const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_typeFunctionConnectionList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnectionList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -8273,48 +7512,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1List_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1List_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2List_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2List_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -8362,163 +7559,9 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -8565,36 +7608,6 @@ const makeArgs46 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -8641,9 +7654,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8690,9 +7700,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8739,9 +7746,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8788,9 +7792,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8843,9 +7844,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8898,9 +7896,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8953,9 +7948,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -9008,9 +8000,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -9063,9 +8052,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -9118,9 +8104,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9179,9 +8162,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -9228,9 +8208,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -9277,9 +8254,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -9326,9 +8300,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -9393,9 +8364,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -9442,9 +8410,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9497,9 +8462,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -9552,9 +8514,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -9601,9 +8560,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9650,9 +8606,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9735,9 +8688,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9790,9 +8740,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9845,9 +8792,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9906,9 +8850,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9967,9 +8908,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -10016,9 +8954,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -10065,9 +9000,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -10114,851 +9046,62 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -15713,7 +13856,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -15827,27 +13972,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15856,11 +14014,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15890,23 +14052,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15916,11 +14088,15 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneColList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneColList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15964,23 +14140,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -15989,11 +14175,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16014,23 +14204,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16040,11 +14240,15 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiColList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiColList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16059,23 +14263,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16087,11 +14301,15 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16103,11 +14321,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16157,23 +14379,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16182,11 +14414,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16219,23 +14455,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16246,11 +14492,15 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16262,23 +14512,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16287,11 +14547,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunctionList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunctionList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16307,23 +14571,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16332,11 +14606,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16348,23 +14626,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16389,11 +14677,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16419,23 +14711,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -16444,11 +14746,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsqlList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsqlList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -16522,11 +14828,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTablesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTablesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16551,23 +14861,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16594,11 +14914,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecretsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecretsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16623,23 +14947,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16666,11 +15000,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeysList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeysList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16695,23 +15033,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16738,11 +15086,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecordsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecordsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16767,23 +15119,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16810,11 +15172,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCasesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCasesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16839,23 +15205,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16882,11 +15258,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArmsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArmsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16911,23 +15291,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16954,11 +15344,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756SList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756SList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16983,23 +15377,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17026,11 +15430,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeopleList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeopleList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17055,23 +15463,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17498,23 +15916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17532,11 +15960,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friendsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friendsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17556,23 +15988,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -17581,11 +16023,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnectionList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnectionList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -17721,23 +16167,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17766,11 +16222,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1List_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1List_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17798,23 +16258,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17843,11 +16313,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2List_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2List_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18013,12 +16487,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -18111,9 +16597,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18129,8 +16622,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -18577,9 +17074,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18830,9 +17334,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19116,9 +17627,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19134,9 +17652,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19161,9 +17686,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19209,9 +17741,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19236,9 +17775,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19310,9 +17856,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19352,9 +17905,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19826,9 +18386,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19997,9 +18564,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20282,9 +18856,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20524,9 +19105,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20809,9 +19397,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20980,9 +19575,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -21009,7 +19611,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21024,7 +19628,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21039,7 +19645,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21054,7 +19662,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21069,7 +19679,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21084,7 +19696,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21099,7 +19713,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21114,7 +19730,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21129,7 +19747,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21144,7 +19764,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21159,7 +19781,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21174,7 +19798,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21189,7 +19815,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21204,7 +19832,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21219,7 +19849,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21234,7 +19866,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21249,7 +19883,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21264,7 +19900,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21279,7 +19917,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21294,7 +19934,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21309,7 +19951,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21324,7 +19968,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21339,7 +19985,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21354,7 +20002,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21369,7 +20019,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21384,7 +20036,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21399,7 +20053,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21414,7 +20070,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21429,7 +20087,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21444,7 +20104,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21459,7 +20121,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21474,7 +20138,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21489,7 +20155,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21504,7 +20172,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21519,7 +20189,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21534,7 +20206,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21548,7 +20222,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21564,7 +20240,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21578,7 +20256,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21594,7 +20274,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21608,7 +20290,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21625,7 +20309,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21639,7 +20325,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21655,7 +20343,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21669,7 +20359,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21685,7 +20377,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21701,7 +20395,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21715,7 +20411,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21731,7 +20429,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21745,7 +20445,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21761,7 +20463,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21777,7 +20481,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21791,7 +20497,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21807,7 +20515,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21821,7 +20531,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21837,7 +20549,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21851,7 +20565,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21868,7 +20584,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21882,7 +20600,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21898,7 +20618,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21912,7 +20634,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21928,7 +20652,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21944,7 +20670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21958,7 +20686,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21974,7 +20704,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -21988,7 +20720,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -22004,7 +20738,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -22020,168 +20756,236 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -22189,11 +20993,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22206,17 +21014,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22229,17 +21043,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22252,21 +21072,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -22275,11 +21103,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22295,17 +21127,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22318,18 +21156,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22369,7 +21213,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -22406,11 +21252,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22445,35 +21295,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -22485,11 +21349,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22508,33 +21376,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22562,7 +21442,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -22570,11 +21452,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -22602,7 +21488,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -22610,11 +21498,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22649,43 +21541,63 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22720,11 +21632,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22746,9 +21663,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22788,11 +21711,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22814,9 +21742,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22861,11 +21795,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22894,9 +21833,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -22931,11 +21876,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -22971,17 +21921,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -23010,9 +21971,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23052,11 +22019,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -23092,9 +22064,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23129,11 +22107,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -23155,9 +22138,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23192,11 +22181,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -23281,9 +22275,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23318,11 +22318,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -23343,18 +22348,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23394,11 +22410,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -23419,18 +22440,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23475,11 +22507,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -23507,19 +22544,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23554,11 +22602,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -23593,18 +22646,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23644,11 +22708,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -23683,27 +22752,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23738,11 +22823,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -23763,18 +22853,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23809,11 +22910,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -23897,32 +23003,48 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -23957,26 +23079,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24016,26 +23148,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24080,27 +23222,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24135,26 +23287,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24194,32 +23356,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24254,26 +23428,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -24308,19 +23492,25 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -478,7 +478,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -523,7 +523,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -577,7 +577,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -622,7 +622,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -676,7 +676,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -724,7 +724,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -855,7 +855,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -884,7 +884,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -914,7 +914,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -977,7 +977,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1061,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1098,7 +1098,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1128,7 +1128,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1158,7 +1158,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1222,7 +1222,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1343,7 +1343,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1372,7 +1372,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1410,7 +1410,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1448,7 +1448,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1486,7 +1486,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1524,7 +1524,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1562,7 +1562,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1690,7 +1690,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2213,7 +2213,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2239,41 +2239,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2281,7 +2281,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2290,12 +2290,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2310,7 +2310,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2319,12 +2319,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2337,7 +2337,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2345,9 +2345,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2363,12 +2363,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2381,8 +2381,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2391,12 +2391,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2409,30 +2409,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2448,12 +2448,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2466,20 +2466,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2592,11 +2592,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2616,11 +2616,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2641,11 +2641,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2666,11 +2666,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2690,11 +2690,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2715,11 +2715,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2740,11 +2740,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2764,11 +2764,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2788,11 +2788,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2812,11 +2812,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2842,11 +2842,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2872,11 +2872,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2902,11 +2902,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2932,11 +2932,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2961,11 +2961,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2990,11 +2990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3019,11 +3019,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3048,11 +3048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3077,11 +3077,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3106,11 +3106,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3141,11 +3141,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3165,11 +3165,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3189,11 +3189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3213,11 +3213,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3248,11 +3248,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3272,11 +3272,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3296,11 +3296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3320,11 +3320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3344,11 +3344,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3373,11 +3373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3412,11 +3412,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3451,11 +3451,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3475,11 +3475,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3504,11 +3504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3529,12 +3529,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3550,12 +3550,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3569,11 +3569,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3601,7 +3601,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3620,7 +3620,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3643,7 +3643,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3698,7 +3698,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3717,11 +3717,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3771,11 +3771,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3825,11 +3825,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3854,11 +3854,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3883,11 +3883,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3912,11 +3912,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3951,7 +3951,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3974,7 +3974,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3994,12 +3994,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4024,12 +4024,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4053,11 +4053,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4086,11 +4086,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4116,11 +4116,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4145,11 +4145,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4180,11 +4180,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4214,11 +4214,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4249,11 +4249,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4278,11 +4278,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4312,11 +4312,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4346,11 +4346,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4380,11 +4380,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4414,11 +4414,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4455,12 +4455,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4487,7 +4487,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4510,7 +4510,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4532,7 +4532,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4576,7 +4576,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4598,7 +4598,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4620,7 +4620,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4644,7 +4644,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4666,7 +4666,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4694,7 +4694,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4720,12 +4720,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4750,12 +4750,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4785,12 +4785,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -16701,7 +16701,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16717,7 +16717,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17389,7 +17389,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17405,7 +17405,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18237,7 +18237,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18253,7 +18253,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18415,7 +18415,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18431,7 +18431,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18593,7 +18593,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18609,7 +18609,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19134,7 +19134,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19150,7 +19150,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19426,7 +19426,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19442,7 +19442,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -21184,7 +21184,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21271,7 +21271,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21517,7 +21517,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21608,7 +21608,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21682,7 +21682,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21761,7 +21761,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21852,7 +21852,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -21990,7 +21990,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22083,7 +22083,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22157,7 +22157,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22294,7 +22294,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22381,7 +22381,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22473,7 +22473,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22578,7 +22578,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22679,7 +22679,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22799,7 +22799,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -22886,7 +22886,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23055,7 +23055,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23119,7 +23119,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23188,7 +23188,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23263,7 +23263,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23327,7 +23327,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23404,7 +23404,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -23468,7 +23468,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const peopleAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -85,10 +85,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_people = {
+const peopleIdentifier = sql.identifier(...["simple_collections", "people"]);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sql.identifier(...["simple_collections", "people"]),
-  attributes: attributes_object_Object_,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -101,8 +102,8 @@ const spec_people = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const petsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -141,16 +142,16 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["simple_collections", "pets"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_pets = {
+const petsIdentifier = sql.identifier(...parts2);
+const petsCodecSpec = {
   name: "pets",
-  identifier: sqlIdent2,
-  attributes: attributes_object_Object_2,
+  identifier: petsIdentifier,
+  attributes: petsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_pets_pets = recordCodec(spec_pets);
+const petsCodec = recordCodec(petsCodecSpec);
 const extensions3 = {
   description: undefined,
   pg: {
@@ -172,8 +173,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -200,26 +201,26 @@ const registryConfig_pgResources_pets_pets = {
   executor: executor_mainPgExecutor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: registryConfig_pgCodecs_pets_pets.sqlType,
-  codec: registryConfig_pgCodecs_pets_pets,
+  from: petsCodec.sqlType,
+  codec: petsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
   extensions: extensions4
 };
 const parts3 = ["simple_collections", "people_odd_pets"];
-const sqlIdent3 = sql.identifier(...parts3);
+const sqlIdent = sql.identifier(...parts3);
 const options_people_odd_pets = {
   name: "people_odd_pets",
   identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
   from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_people_people
+    codec: peopleCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -239,10 +240,10 @@ const options_people_odd_pets = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    people: registryConfig_pgCodecs_people_people,
+    people: peopleCodec,
     int4: TYPES.int,
     text: TYPES.text,
-    pets: registryConfig_pgCodecs_pets_pets,
+    pets: petsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar
   }),
@@ -254,7 +255,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
       petsByTheirOwnerId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_pets_pets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -271,7 +272,7 @@ const registry = makeRegistry({
     }),
     pets: Object.assign(Object.create(null), {
       peopleByMyOwnerId: {
-        localCodec: registryConfig_pgCodecs_pets_pets,
+        localCodec: petsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["owner_id"],
@@ -1650,7 +1651,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1666,7 +1667,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1798,7 +1799,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.id.codec)}`;
             }
           });
         }
@@ -1821,7 +1822,7 @@ export const plans = {
             type: "attribute",
             attribute: "owner_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.owner_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.owner_id.codec)}`;
             }
           });
         }
@@ -1844,7 +1845,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.name.codec)}`;
             }
           });
         }
@@ -1878,7 +1879,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1894,7 +1895,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1992,7 +1993,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
             }
           });
         }
@@ -2015,7 +2016,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -68,7 +68,7 @@ const peopleAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -92,7 +92,7 @@ const peopleCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const petsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -137,9 +137,9 @@ const petsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -148,12 +148,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.simple_collections.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -166,7 +166,7 @@ const registryConfig_pgResources_people_people = {
     tags: {}
   }
 };
-const uniques2 = [{
+const petsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -175,12 +175,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
   from: petsCodec.sqlType,
   codec: petsCodec,
-  uniques: uniques2,
+  uniques: petsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -193,7 +193,7 @@ const registryConfig_pgResources_pets_pets = {
     tags: {}
   }
 };
-const sqlIdent = sql.identifier("simple_collections", "people_odd_pets");
+const people_odd_petsFunctionIdentifer = sql.identifier("simple_collections", "people_odd_pets");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     people: peopleCodec,
@@ -210,7 +210,7 @@ const registry = makeRegistry({
       name: "people_odd_pets",
       identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${people_odd_petsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -1465,7 +1465,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1481,7 +1481,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1700,7 +1700,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1716,7 +1716,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2041,7 +2041,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2115,7 +2115,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2201,7 +2201,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2288,7 +2288,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2392,7 +2392,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2456,7 +2456,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const peopleAttributes = Object.assign(Object.create(null), {
@@ -85,10 +78,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const peopleIdentifier = sql.identifier(...["simple_collections", "people"]);
-const peopleCodecSpec = {
+const peopleCodec = recordCodec({
   name: "people",
-  identifier: peopleIdentifier,
+  identifier: sql.identifier("simple_collections", "people"),
   attributes: peopleAttributes,
   description: undefined,
   extensions: {
@@ -101,8 +93,7 @@ const peopleCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const peopleCodec = recordCodec(peopleCodecSpec);
+});
 const petsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -132,35 +123,22 @@ const petsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "pets"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["simple_collections", "pets"];
-const petsIdentifier = sql.identifier(...parts2);
-const petsCodecSpec = {
+const petsCodec = recordCodec({
   name: "pets",
-  identifier: petsIdentifier,
+  identifier: sql.identifier("simple_collections", "pets"),
   attributes: petsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const petsCodec = recordCodec(petsCodecSpec);
-const extensions3 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "people"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "simple_collections",
+      name: "pets"
+    },
+    tags: Object.create(null)
   },
-  tags: {}
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -178,16 +156,15 @@ const registryConfig_pgResources_people_people = {
   uniques,
   isVirtual: false,
   description: undefined,
-  extensions: extensions3
-};
-const extensions4 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "pets"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "simple_collections",
+      name: "people"
+    },
+    tags: {}
+  }
 };
 const uniques2 = [{
   isPrimary: true,
@@ -206,38 +183,17 @@ const registryConfig_pgResources_pets_pets = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions4
-};
-const parts3 = ["simple_collections", "people_odd_pets"];
-const sqlIdent = sql.identifier(...parts3);
-const options_people_odd_pets = {
-  name: "people_odd_pets",
-  identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
-  from(...args) {
-    return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: peopleCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "simple_collections",
-      name: "people_odd_pets"
+      name: "pets"
     },
-    tags: {
-      simpleCollections: "only",
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "+list -connection"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
+const sqlIdent = sql.identifier("simple_collections", "people_odd_pets");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     people: peopleCodec,
@@ -250,7 +206,34 @@ const registry = makeRegistry({
   pgResources: Object.assign(Object.create(null), {
     people: registryConfig_pgResources_people_people,
     pets: registryConfig_pgResources_pets_pets,
-    people_odd_pets: PgResource.functionResourceOptions(registryConfig_pgResources_pets_pets, options_people_odd_pets)
+    people_odd_pets: PgResource.functionResourceOptions(registryConfig_pgResources_pets_pets, {
+      name: "people_odd_pets",
+      identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
+      from(...args) {
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: peopleCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "simple_collections",
+          name: "people_odd_pets"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "+list -connection"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
@@ -366,21 +349,6 @@ const fetcher2 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Pet);
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -399,21 +367,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allPets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -463,207 +416,22 @@ const makeArgs = (args, path = []) => {
   return selectArgs;
 };
 const resource_people_odd_petsPgResource = registry.pgResources["people_odd_pets"];
-function Person_oddPetsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_oddPetsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_petsByOwnerId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_petsByOwnerId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_petsByOwnerId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_petsByOwnerId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_petsByOwnerId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPet_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Pet, $nodeId);
 };
-function Mutation_updatePet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePetById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Pet, $nodeId);
 };
-function Mutation_deletePet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function CreatePetPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePetInput_pet_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function UpdatePetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePetInput_petPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePetByIdInput_petPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function DeletePetPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -1351,7 +1119,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -1409,23 +1179,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1452,23 +1232,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1533,11 +1323,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_oddPetsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_oddPetsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -1557,23 +1351,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1617,9 +1421,16 @@ export const plans = {
   },
   PetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PetsConnection_nodesPlan,
-    edges: PetsConnection_edgesPlan,
-    pageInfo: PetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1635,8 +1446,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1856,9 +1671,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -2038,7 +1860,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2053,7 +1877,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2067,7 +1893,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2083,7 +1911,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2097,7 +1927,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2113,7 +1945,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2127,7 +1961,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2143,7 +1979,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2157,7 +1995,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2173,16 +2013,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2217,11 +2065,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2243,9 +2096,15 @@ export const plans = {
   },
   CreatePetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePetPayload_clientMutationIdPlan,
-    pet: CreatePetPayload_petPlan,
-    query: CreatePetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     petEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2285,11 +2144,16 @@ export const plans = {
   },
   CreatePetInput: {
     clientMutationId: {
-      applyPlan: CreatePetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     pet: {
-      applyPlan: CreatePetInput_pet_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2318,9 +2182,15 @@ export const plans = {
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2355,11 +2225,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -2380,18 +2255,29 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePetPayload_clientMutationIdPlan,
-    pet: UpdatePetPayload_petPlan,
-    query: UpdatePetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     petEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2431,11 +2317,16 @@ export const plans = {
   },
   UpdatePetInput: {
     clientMutationId: {
-      applyPlan: UpdatePetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     petPatch: {
-      applyPlan: UpdatePetInput_petPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PetPatch: {
@@ -2463,23 +2354,34 @@ export const plans = {
   },
   UpdatePetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     petPatch: {
-      applyPlan: UpdatePetByIdInput_petPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2514,26 +2416,36 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePetPayload_clientMutationIdPlan,
-    pet: DeletePetPayload_petPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
     deletedPetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Pet.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     petEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2573,13 +2485,17 @@ export const plans = {
   },
   DeletePetInput: {
     clientMutationId: {
-      applyPlan: DeletePetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePetByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -68,7 +68,7 @@ const peopleAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -96,7 +96,7 @@ const peopleCodec = recordCodec({
   attributes: peopleAttributes,
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const petsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -141,9 +141,9 @@ const petsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -152,12 +152,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.simple_collections.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -173,7 +173,7 @@ const registryConfig_pgResources_people_people = {
     }
   }
 };
-const uniques2 = [{
+const petsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -182,12 +182,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
   from: petsCodec.sqlType,
   codec: petsCodec,
-  uniques: uniques2,
+  uniques: petsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -200,7 +200,7 @@ const registryConfig_pgResources_pets_pets = {
     tags: {}
   }
 };
-const sqlIdent = sql.identifier("simple_collections", "people_odd_pets");
+const people_odd_petsFunctionIdentifer = sql.identifier("simple_collections", "people_odd_pets");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     people: peopleCodec,
@@ -217,7 +217,7 @@ const registry = makeRegistry({
       name: "people_odd_pets",
       identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${people_odd_petsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -1322,7 +1322,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1338,7 +1338,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1572,7 +1572,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1588,7 +1588,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1913,7 +1913,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2042,7 +2042,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2202,7 +2202,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const peopleAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -97,16 +97,17 @@ const extensions = {
     behavior: ["-list +connection"]
   })
 };
-const spec_people = {
+const peopleIdentifier = sql.identifier(...["simple_collections", "people"]);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sql.identifier(...["simple_collections", "people"]),
-  attributes: attributes_object_Object_,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const petsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -145,16 +146,16 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["simple_collections", "pets"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_pets = {
+const petsIdentifier = sql.identifier(...parts2);
+const petsCodecSpec = {
   name: "pets",
-  identifier: sqlIdent2,
-  attributes: attributes_object_Object_2,
+  identifier: petsIdentifier,
+  attributes: petsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_pets_pets = recordCodec(spec_pets);
+const petsCodec = recordCodec(petsCodecSpec);
 const extensions3 = {
   description: undefined,
   pg: {
@@ -179,8 +180,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -207,26 +208,26 @@ const registryConfig_pgResources_pets_pets = {
   executor: executor_mainPgExecutor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: registryConfig_pgCodecs_pets_pets.sqlType,
-  codec: registryConfig_pgCodecs_pets_pets,
+  from: petsCodec.sqlType,
+  codec: petsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
   extensions: extensions4
 };
 const parts3 = ["simple_collections", "people_odd_pets"];
-const sqlIdent3 = sql.identifier(...parts3);
+const sqlIdent = sql.identifier(...parts3);
 const options_people_odd_pets = {
   name: "people_odd_pets",
   identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
   from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_people_people
+    codec: peopleCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -245,10 +246,10 @@ const options_people_odd_pets = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    people: registryConfig_pgCodecs_people_people,
+    people: peopleCodec,
     int4: TYPES.int,
     text: TYPES.text,
-    pets: registryConfig_pgCodecs_pets_pets,
+    pets: petsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar
   }),
@@ -260,7 +261,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
       petsByTheirOwnerId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_pets_pets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -277,7 +278,7 @@ const registry = makeRegistry({
     }),
     pets: Object.assign(Object.create(null), {
       peopleByMyOwnerId: {
-        localCodec: registryConfig_pgCodecs_pets_pets,
+        localCodec: petsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["owner_id"],
@@ -1502,7 +1503,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1518,7 +1519,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1650,7 +1651,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.id.codec)}`;
             }
           });
         }
@@ -1673,7 +1674,7 @@ export const plans = {
             type: "attribute",
             attribute: "owner_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.owner_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.owner_id.codec)}`;
             }
           });
         }
@@ -1696,7 +1697,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.name.codec)}`;
             }
           });
         }
@@ -1741,7 +1742,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1757,7 +1758,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1855,7 +1856,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
             }
           });
         }
@@ -1878,7 +1879,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const peopleAttributes = Object.assign(Object.create(null), {
@@ -97,16 +90,14 @@ const extensions = {
     behavior: ["-list +connection"]
   })
 };
-const peopleIdentifier = sql.identifier(...["simple_collections", "people"]);
-const peopleCodecSpec = {
+const peopleCodec = recordCodec({
   name: "people",
-  identifier: peopleIdentifier,
+  identifier: sql.identifier("simple_collections", "people"),
   attributes: peopleAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const peopleCodec = recordCodec(peopleCodecSpec);
+});
 const petsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -136,38 +127,22 @@ const petsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "pets"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["simple_collections", "pets"];
-const petsIdentifier = sql.identifier(...parts2);
-const petsCodecSpec = {
+const petsCodec = recordCodec({
   name: "pets",
-  identifier: petsIdentifier,
+  identifier: sql.identifier("simple_collections", "pets"),
   attributes: petsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const petsCodec = recordCodec(petsCodecSpec);
-const extensions3 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "people"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "simple_collections",
+      name: "pets"
+    },
+    tags: Object.create(null)
   },
-  tags: {
-    simpleCollections: "omit",
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -185,16 +160,18 @@ const registryConfig_pgResources_people_people = {
   uniques,
   isVirtual: false,
   description: undefined,
-  extensions: extensions3
-};
-const extensions4 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "simple_collections",
-    name: "pets"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "simple_collections",
+      name: "people"
+    },
+    tags: {
+      simpleCollections: "omit",
+      behavior: extensions.tags.behavior
+    }
+  }
 };
 const uniques2 = [{
   isPrimary: true,
@@ -213,37 +190,17 @@ const registryConfig_pgResources_pets_pets = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions4
-};
-const parts3 = ["simple_collections", "people_odd_pets"];
-const sqlIdent = sql.identifier(...parts3);
-const options_people_odd_pets = {
-  name: "people_odd_pets",
-  identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
-  from(...args) {
-    return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: peopleCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "simple_collections",
-      name: "people_odd_pets"
+      name: "pets"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
+const sqlIdent = sql.identifier("simple_collections", "people_odd_pets");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     people: peopleCodec,
@@ -256,7 +213,33 @@ const registry = makeRegistry({
   pgResources: Object.assign(Object.create(null), {
     people: registryConfig_pgResources_people_people,
     pets: registryConfig_pgResources_pets_pets,
-    people_odd_pets: PgResource.functionResourceOptions(registryConfig_pgResources_pets_pets, options_people_odd_pets)
+    people_odd_pets: PgResource.functionResourceOptions(registryConfig_pgResources_pets_pets, {
+      name: "people_odd_pets",
+      identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
+      from(...args) {
+        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: peopleCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "simple_collections",
+          name: "people_odd_pets"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
@@ -372,21 +355,6 @@ const fetcher2 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Pet);
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -405,12 +373,6 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allPetsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPetsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -460,188 +422,22 @@ const makeArgs = (args, path = []) => {
   return selectArgs;
 };
 const resource_people_odd_petsPgResource = registry.pgResources["people_odd_pets"];
-function Person_oddPetsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_oddPetsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_petsByOwnerIdList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_petsByOwnerIdList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPet_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Pet, $nodeId);
 };
-function Mutation_updatePet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePetById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Pet, $nodeId);
 };
-function Mutation_deletePet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function CreatePetPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePetInput_pet_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function UpdatePetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePetInput_petPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePetByIdInput_petPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePetPayload_petPlan($object) {
-  return $object.get("result");
-}
-function DeletePetPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -1261,7 +1057,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -1319,23 +1117,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1362,11 +1170,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPetsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPetsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1429,11 +1241,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_oddPetsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_oddPetsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -1452,11 +1268,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerIdList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_petsByOwnerIdList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -1708,9 +1528,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -1726,8 +1553,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -1901,7 +1732,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1916,7 +1749,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1930,7 +1765,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1946,7 +1783,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1960,7 +1799,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1976,7 +1817,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -1990,7 +1833,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2006,7 +1851,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2020,7 +1867,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -2036,16 +1885,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2080,11 +1937,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2106,9 +1968,15 @@ export const plans = {
   },
   CreatePetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePetPayload_clientMutationIdPlan,
-    pet: CreatePetPayload_petPlan,
-    query: CreatePetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByOwnerId($record) {
       return pgResource_peoplePgResource.get({
         id: $record.get("result").get("owner_id")
@@ -2117,11 +1985,16 @@ export const plans = {
   },
   CreatePetInput: {
     clientMutationId: {
-      applyPlan: CreatePetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     pet: {
-      applyPlan: CreatePetInput_pet_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -2150,9 +2023,15 @@ export const plans = {
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2187,11 +2066,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -2212,18 +2096,29 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePetPayload_clientMutationIdPlan,
-    pet: UpdatePetPayload_petPlan,
-    query: UpdatePetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByOwnerId($record) {
       return pgResource_peoplePgResource.get({
         id: $record.get("result").get("owner_id")
@@ -2232,11 +2127,16 @@ export const plans = {
   },
   UpdatePetInput: {
     clientMutationId: {
-      applyPlan: UpdatePetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     petPatch: {
-      applyPlan: UpdatePetInput_petPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PetPatch: {
@@ -2264,23 +2164,34 @@ export const plans = {
   },
   UpdatePetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     petPatch: {
-      applyPlan: UpdatePetByIdInput_petPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -2315,26 +2226,36 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePetPayload_clientMutationIdPlan,
-    pet: DeletePetPayload_petPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    pet($object) {
+      return $object.get("result");
+    },
     deletedPetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Pet.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personByOwnerId($record) {
       return pgResource_peoplePgResource.get({
         id: $record.get("result").get("owner_id")
@@ -2343,13 +2264,17 @@ export const plans = {
   },
   DeletePetInput: {
     clientMutationId: {
-      applyPlan: DeletePetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePetByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -421,7 +421,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes12 = Object.assign(Object.create(null), {
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -441,10 +441,11 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...["c", "my_table"]);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sql.identifier(...["c", "my_table"]),
-  attributes: attributes12,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -457,8 +458,8 @@ const spec_myTable = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes13 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -492,17 +493,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["c", "person_secret"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts2);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent2,
-  attributes: attributes13,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes14 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -541,17 +542,17 @@ const extensions3 = {
   tags: Object.create(null)
 };
 const parts3 = ["c", "compound_key"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts3);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent3,
-  attributes: attributes14,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes15 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -599,17 +600,17 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts4 = ["c", "null_test_record"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts4);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent4,
-  attributes: attributes15,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const attributes16 = Object.assign(Object.create(null), {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -648,17 +649,17 @@ const extensions5 = {
   tags: Object.create(null)
 };
 const parts5 = ["c", "edge_case"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts5);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent5,
-  attributes: attributes16,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes17 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -706,16 +707,16 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["c", "left_arm"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts6);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent6,
-  attributes: attributes17,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
+const leftArmCodec = recordCodec(leftArmCodecSpec);
 const extensions7 = {
   pg: {
     serviceName: "main",
@@ -725,13 +726,13 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["c", "not_null_timestamp"];
-const sqlIdent7 = sql.identifier(...parts7);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent7, {
+const notNullTimestampIdentifier = sql.identifier(...parts7);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
   extensions: extensions7,
   notNull: true
 });
-const attributes18 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -743,7 +744,7 @@ const attributes18 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -761,16 +762,16 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["c", "issue756"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts8);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
+const issue756Codec = recordCodec(issue756CodecSpec);
 const extensions9 = {
   pg: {
     serviceName: "main",
@@ -780,10 +781,9 @@ const extensions9 = {
   tags: Object.create(null)
 };
 const parts9 = ["b", "color"];
-const sqlIdent9 = sql.identifier(...parts9);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent9,
+  identifier: sql.identifier(...parts9),
   values: ["red", "green", "blue"],
   description: undefined,
   extensions: extensions9
@@ -798,10 +798,10 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["b", "enum_caps"];
-const sqlIdent10 = sql.identifier(...parts10);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts10);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent10,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
   extensions: extensions10
@@ -816,15 +816,15 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent11 = sql.identifier(...parts11);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts11);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent11,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
   extensions: extensions11
 });
-const attributes20 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -845,7 +845,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -863,7 +863,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -872,7 +872,7 @@ const attributes20 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -908,17 +908,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["c", "compound_type"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts12);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent12,
-  attributes: attributes20,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes19 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -929,7 +929,7 @@ const attributes19 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -939,7 +939,7 @@ const attributes19 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -949,7 +949,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes21 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -960,7 +960,7 @@ const attributes21 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -970,7 +970,7 @@ const attributes21 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,7 +980,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions13 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -989,7 +989,7 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions14 = {
+const extensions13 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -998,21 +998,21 @@ const extensions14 = {
   tags: Object.create(null)
 };
 const parts13 = ["a", "an_enum"];
-const sqlIdent13 = sql.identifier(...parts13);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts13);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent13,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions14
+  extensions: extensions13
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions13,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions15 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1020,7 +1020,7 @@ const extensions15 = {
   },
   tags: Object.create(null)
 };
-const attributes24 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1040,7 +1040,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1050,23 +1050,23 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts14 = ["a", "comptype"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts14);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions15,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes23 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1105,7 +1105,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1114,7 +1114,7 @@ const attributes23 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1122,7 +1122,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1132,17 +1132,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "post"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts15);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent15,
-  attributes: attributes23,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes22 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1153,7 +1153,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1161,7 +1161,7 @@ const attributes22 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1171,7 +1171,7 @@ const attributes22 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1181,7 +1181,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes25 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1202,7 +1202,7 @@ const attributes25 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes25,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1212,7 +1212,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes26 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1233,7 +1233,7 @@ const attributes26 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes26,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,7 +1243,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions18 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1251,13 +1251,13 @@ const extensions18 = {
   },
   tags: Object.create(null)
 };
-const attributes_aliases_codec_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions18,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions19 = {
+const extensions16 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1266,13 +1266,13 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts16 = ["b", "email"];
-const sqlIdent16 = sql.identifier(...parts16);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent16, {
+const emailIdentifier = sql.identifier(...parts16);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions16,
   notNull: false
 });
-const extensions20 = {
+const extensions17 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1281,16 +1281,16 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts17 = ["b", "not_null_url"];
-const sqlIdent17 = sql.identifier(...parts17);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent17, {
+const notNullUrlIdentifier = sql.identifier(...parts17);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions17,
   notNull: true
 });
-const attributes29 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1298,7 +1298,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions18 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1308,17 +1308,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts18 = ["b", "wrapped_url"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts18);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent18,
-  attributes: attributes29,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes28 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -1341,7 +1341,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1359,7 +1359,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1368,7 +1368,7 @@ const attributes28 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1423,7 +1423,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1433,20 +1433,20 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts19 = ["c", "person"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts19);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions22,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes27 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -1464,7 +1464,7 @@ const attributes27 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes27,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1474,7 +1474,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes30 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1485,7 +1485,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1493,7 +1493,7 @@ const attributes30 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1503,7 +1503,7 @@ const attributes30 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes30,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1513,7 +1513,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes31 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1524,7 +1524,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1532,7 +1532,7 @@ const attributes31 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1542,7 +1542,7 @@ const attributes31 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes31,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1552,7 +1552,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes32 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1563,7 +1563,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1571,7 +1571,7 @@ const attributes32 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1581,7 +1581,7 @@ const attributes32 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes32,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1591,7 +1591,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1602,7 +1602,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -1610,7 +1610,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -1620,7 +1620,7 @@ const attributes33 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes33,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1630,7 +1630,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes34 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -1641,7 +1641,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -1649,7 +1649,7 @@ const attributes34 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -1659,7 +1659,7 @@ const attributes34 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes34,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,7 +1669,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions23 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1677,13 +1677,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions23,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions24 = {
+const extensions20 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1692,13 +1692,13 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts20 = ["a", "an_int"];
-const sqlIdent20 = sql.identifier(...parts20);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent20, {
+const anIntIdentifier = sql.identifier(...parts20);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions20,
   notNull: false
 });
-const extensions25 = {
+const extensions21 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1707,13 +1707,13 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts21 = ["b", "another_int"];
-const sqlIdent21 = sql.identifier(...parts21);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent21, {
+const anotherIntIdentifier = sql.identifier(...parts21);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions25,
+  extensions: extensions21,
   notNull: false
 });
-const extensions26 = {
+const extensions22 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1722,12 +1722,12 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent22 = sql.identifier(...parts22);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent22, {
+const sqlIdent5 = sql.identifier(...parts22);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions26
+  extensions: extensions22
 });
-const extensions27 = {
+const extensions23 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1736,12 +1736,12 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent23 = sql.identifier(...parts23);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent23, {
+const sqlIdent6 = sql.identifier(...parts23);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions27
+  extensions: extensions23
 });
-const extensions28 = {
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1750,12 +1750,12 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts24 = ["a", "an_int_range"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent24, {
+const sqlIdent7 = sql.identifier(...parts24);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions28
+  extensions: extensions24
 });
-const extensions29 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1763,16 +1763,16 @@ const extensions29 = {
   },
   tags: Object.create(null)
 };
-const attributes_interval_array_codec_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions29,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const attributes36 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1781,7 +1781,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1798,7 +1798,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions30 = {
+const extensions25 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1808,17 +1808,17 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts25 = ["b", "nested_compound_type"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent25,
-  attributes: attributes36,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions30,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions31 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions26 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1827,13 +1827,13 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts26 = ["c", "text_array_domain"];
-const sqlIdent26 = sql.identifier(...parts26);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(attributes_aliases_codec_textArray, "textArrayDomain", sqlIdent26, {
+const textArrayDomainIdentifier = sql.identifier(...parts26);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions31,
+  extensions: extensions26,
   notNull: false
 });
-const extensions32 = {
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1841,7 +1841,7 @@ const extensions32 = {
   },
   tags: Object.create(null)
 };
-const extensions33 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1849,20 +1849,20 @@ const extensions33 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions33,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts27 = ["c", "int8_array_domain"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent27, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts27);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions32,
+  extensions: extensions27,
   notNull: false
 });
-const extensions34 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1870,13 +1870,13 @@ const extensions34 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions34,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1888,8 +1888,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes35 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1955,7 +1955,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1964,7 +1964,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1973,7 +1973,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1982,7 +1982,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -1991,7 +1991,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: attributes_aliases_codec_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2018,7 +2018,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2027,7 +2027,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2036,7 +2036,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2045,7 +2045,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2108,7 +2108,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: attributes_interval_array_codec_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2126,7 +2126,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2135,7 +2135,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2144,7 +2144,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2153,7 +2153,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2279,7 +2279,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2288,7 +2288,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2306,7 +2306,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2315,7 +2315,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2324,7 +2324,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2332,7 +2332,7 @@ const attributes35 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions35 = {
+const extensions28 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2344,17 +2344,17 @@ const extensions35 = {
   })
 };
 const parts28 = ["b", "types"];
-const sqlIdent28 = sql.identifier(...parts28);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts28);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent28,
-  attributes: attributes35,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions35,
+  extensions: extensions28,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions36 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2362,7 +2362,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const extensions37 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2370,13 +2370,13 @@ const extensions37 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions37,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions38 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2385,12 +2385,12 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts29 = ["c", "floatrange"];
-const sqlIdent29 = sql.identifier(...parts29);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent29, {
+const sqlIdent8 = sql.identifier(...parts29);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions38
+  extensions: extensions29
 });
-const extensions39 = {
+const extensions30 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2401,8 +2401,8 @@ const extensions39 = {
   }
 };
 const parts30 = ["c", "current_user_id"];
-const sqlIdent30 = sql.identifier(...parts30);
-const extensions40 = {
+const sqlIdent9 = sql.identifier(...parts30);
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2414,10 +2414,10 @@ const extensions40 = {
   singleOutputParameterName: "o"
 };
 const parts31 = ["c", "func_out"];
-const sqlIdent31 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts31);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions41 = {
+const extensions32 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2429,10 +2429,10 @@ const extensions41 = {
   singleOutputParameterName: "o"
 };
 const parts32 = ["c", "func_out_setof"];
-const sqlIdent32 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts32);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions42 = {
+const extensions33 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2443,10 +2443,10 @@ const extensions42 = {
   }
 };
 const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent33 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts33);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions43 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2458,10 +2458,10 @@ const extensions43 = {
   singleOutputParameterName: "o"
 };
 const parts34 = ["c", "mutation_out"];
-const sqlIdent34 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts34);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions44 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2473,10 +2473,10 @@ const extensions44 = {
   singleOutputParameterName: "o"
 };
 const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent35 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts35);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions45 = {
+const extensions36 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2487,10 +2487,10 @@ const extensions45 = {
   }
 };
 const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts36);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions46 = {
+const extensions37 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2501,10 +2501,10 @@ const extensions46 = {
   }
 };
 const parts37 = ["c", "no_args_mutation"];
-const sqlIdent37 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts37);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions47 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2515,10 +2515,10 @@ const extensions47 = {
   }
 };
 const parts38 = ["c", "no_args_query"];
-const sqlIdent38 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts38);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions48 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2530,15 +2530,15 @@ const extensions48 = {
   singleOutputParameterName: "o"
 };
 const parts39 = ["c", "func_in_out"];
-const sqlIdent39 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts39);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions49 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2550,15 +2550,15 @@ const extensions49 = {
   singleOutputParameterName: "col1"
 };
 const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent40 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts40);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions50 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2570,15 +2570,15 @@ const extensions50 = {
   singleOutputParameterName: "o"
 };
 const parts41 = ["c", "mutation_in_out"];
-const sqlIdent41 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts41);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions51 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2590,15 +2590,15 @@ const extensions51 = {
   singleOutputParameterName: "col1"
 };
 const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent42 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts42);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions52 = {
+const extensions43 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2609,15 +2609,15 @@ const extensions52 = {
   }
 };
 const parts43 = ["c", "json_identity"];
-const sqlIdent43 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts43);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions53 = {
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2628,15 +2628,15 @@ const extensions53 = {
   }
 };
 const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent44 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts44);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions54 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2647,15 +2647,15 @@ const extensions54 = {
   }
 };
 const parts45 = ["c", "jsonb_identity"];
-const sqlIdent45 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts45);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions55 = {
+const extensions46 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2666,15 +2666,15 @@ const extensions55 = {
   }
 };
 const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent46 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts46);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions56 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2685,15 +2685,15 @@ const extensions56 = {
   }
 };
 const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent47 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts47);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions57 = {
+const extensions48 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2704,15 +2704,15 @@ const extensions57 = {
   }
 };
 const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent48 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts48);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions58 = {
+const extensions49 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2724,8 +2724,8 @@ const extensions58 = {
   singleOutputParameterName: "ino"
 };
 const parts49 = ["c", "func_in_inout"];
-const sqlIdent49 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts49);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "i",
   required: true,
@@ -2737,7 +2737,7 @@ const parameters20 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions59 = {
+const extensions50 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2748,10 +2748,10 @@ const extensions59 = {
   }
 };
 const parts50 = ["c", "func_out_out"];
-const sqlIdent50 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts50);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [];
-const extensions60 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2762,10 +2762,10 @@ const extensions60 = {
   }
 };
 const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent51 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts51);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [];
-const extensions61 = {
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2776,10 +2776,10 @@ const extensions61 = {
   }
 };
 const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts52);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [];
-const extensions62 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2791,8 +2791,8 @@ const extensions62 = {
   singleOutputParameterName: "ino"
 };
 const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts53);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "i",
   required: true,
@@ -2804,7 +2804,7 @@ const parameters24 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions63 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2815,10 +2815,10 @@ const extensions63 = {
   }
 };
 const parts54 = ["c", "mutation_out_out"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts54);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [];
-const extensions64 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2829,10 +2829,10 @@ const extensions64 = {
   }
 };
 const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts55);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [];
-const extensions65 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2843,10 +2843,10 @@ const extensions65 = {
   }
 };
 const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts56);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [];
-const extensions66 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2857,10 +2857,10 @@ const extensions66 = {
   }
 };
 const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts57);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [];
-const extensions67 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2871,15 +2871,15 @@ const extensions67 = {
   }
 };
 const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts58);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions68 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2890,8 +2890,8 @@ const extensions68 = {
   }
 };
 const parts59 = ["c", "int_set_mutation"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts59);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "x",
   required: true,
@@ -2908,7 +2908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions69 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2919,8 +2919,8 @@ const extensions69 = {
   }
 };
 const parts60 = ["c", "int_set_query"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts60);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "x",
   required: true,
@@ -2937,7 +2937,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions70 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2948,10 +2948,10 @@ const extensions70 = {
   }
 };
 const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts61);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [];
-const extensions71 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2962,15 +2962,15 @@ const extensions71 = {
   }
 };
 const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts62);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions72 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2982,10 +2982,10 @@ const extensions72 = {
   }
 };
 const parts63 = ["c", "search_test_summaries"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts63);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [];
-const extensions73 = {
+const extensions64 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3002,7 +3002,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions74 = {
+const extensions65 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -3025,14 +3025,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions74
+  extensions: extensions65
 };
-const extensions75 = {
+const extensions66 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3053,14 +3053,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions75
+  extensions: extensions66
 };
-const extensions76 = {
+const extensions67 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3077,7 +3077,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions77 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3088,21 +3088,21 @@ const extensions77 = {
   }
 };
 const parts64 = ["c", "edge_case_computed"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts64);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent65 = sql.identifier(...parts65);
+const sqlIdent44 = sql.identifier(...parts65);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3120,7 +3120,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions78 = {
+const extensions69 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3130,7 +3130,7 @@ const extensions78 = {
   tags: {}
 };
 const uniques5 = [];
-const extensions79 = {
+const extensions70 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -3158,26 +3158,26 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions79
+  extensions: extensions70
 };
 const parts66 = ["c", "left_arm_identity"];
-const sqlIdent66 = sql.identifier(...parts66);
+const sqlIdent45 = sql.identifier(...parts66);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -3199,7 +3199,7 @@ const options_left_arm_identity = {
   },
   description: undefined
 };
-const extensions80 = {
+const extensions71 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -3220,20 +3220,20 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions80
+  extensions: extensions71
 };
 const parts67 = ["c", "issue756_mutation"];
-const sqlIdent67 = sql.identifier(...parts67);
+const sqlIdent46 = sql.identifier(...parts67);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3252,12 +3252,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent68 = sql.identifier(...parts68);
+const sqlIdent47 = sql.identifier(...parts68);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3275,7 +3275,7 @@ const options_issue756_set_mutation = {
   },
   description: undefined
 };
-const extensions81 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3286,8 +3286,8 @@ const extensions81 = {
   }
 };
 const parts69 = ["c", "types_mutation"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts69);
+const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: "a",
   required: true,
@@ -3307,7 +3307,7 @@ const parameters36 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3317,9 +3317,9 @@ const parameters36 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions82 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3330,8 +3330,8 @@ const extensions82 = {
   }
 };
 const parts70 = ["c", "types_query"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts70);
+const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: "a",
   required: true,
@@ -3351,7 +3351,7 @@ const parameters37 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -3361,9 +3361,9 @@ const parameters37 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions83 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3374,15 +3374,15 @@ const extensions83 = {
   }
 };
 const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts71);
+const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions84 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3393,15 +3393,15 @@ const extensions84 = {
   }
 };
 const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts72);
+const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions85 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3412,15 +3412,15 @@ const extensions85 = {
   }
 };
 const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts73);
+const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters40 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions86 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3431,8 +3431,8 @@ const extensions86 = {
   }
 };
 const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts74);
+const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters41 = [{
   name: "left_arm_id",
   required: true,
@@ -3450,12 +3450,12 @@ const parameters41 = [{
   codec: TYPES.text
 }];
 const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent75 = sql.identifier(...parts75);
+const sqlIdent54 = sql.identifier(...parts75);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3473,7 +3473,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions87 = {
+const extensions78 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -3489,20 +3489,20 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques8,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions87
+  extensions: extensions78
 };
 const parts76 = ["c", "table_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
+const sqlIdent55 = sql.identifier(...parts76);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3526,16 +3526,16 @@ const options_table_mutation = {
   description: undefined
 };
 const resourceConfig = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts77 = ["c", "table_query"];
-const sqlIdent77 = sql.identifier(...parts77);
+const sqlIdent56 = sql.identifier(...parts77);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3559,10 +3559,10 @@ const options_table_query = {
   description: undefined
 };
 const resourceConfig2 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
-const extensions88 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3577,15 +3577,15 @@ const extensions88 = {
   singleOutputParameterName: "o1"
 };
 const parts78 = ["c", "person_computed_out"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts78);
+const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters42 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions89 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3597,15 +3597,15 @@ const extensions89 = {
   }
 };
 const parts79 = ["c", "person_first_name"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts79);
+const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions90 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3616,15 +3616,15 @@ const extensions90 = {
   }
 };
 const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts80);
+const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters44 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions91 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3636,20 +3636,20 @@ const extensions91 = {
   singleOutputParameterName: "ino"
 };
 const parts81 = ["c", "person_computed_inout"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts81);
+const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters45 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions92 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3660,20 +3660,20 @@ const extensions92 = {
   }
 };
 const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts82);
+const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters46 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions93 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3685,20 +3685,20 @@ const extensions93 = {
   }
 };
 const parts83 = ["c", "person_exists"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts83);
+const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters47 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions94 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3709,15 +3709,15 @@ const extensions94 = {
   }
 };
 const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts84);
+const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions95 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3728,8 +3728,8 @@ const extensions95 = {
   }
 };
 const parts85 = ["c", "func_out_complex"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts85);
+const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -3741,7 +3741,7 @@ const parameters49 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions96 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3752,8 +3752,8 @@ const extensions96 = {
   }
 };
 const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts86);
+const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -3765,7 +3765,7 @@ const parameters50 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions97 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3776,8 +3776,8 @@ const extensions97 = {
   }
 };
 const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts87);
+const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "a",
   required: true,
@@ -3789,7 +3789,7 @@ const parameters51 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions98 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3800,8 +3800,8 @@ const extensions98 = {
   }
 };
 const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts88);
+const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -3813,7 +3813,7 @@ const parameters52 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions99 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3824,13 +3824,13 @@ const extensions99 = {
   }
 };
 const parts89 = ["c", "person_computed_complex"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts89);
+const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters53 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -3842,7 +3842,7 @@ const parameters53 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions100 = {
+const extensions91 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -3870,26 +3870,26 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions100
+  extensions: extensions91
 };
 const parts90 = ["c", "person_first_post"];
-const sqlIdent90 = sql.identifier(...parts90);
+const sqlIdent69 = sql.identifier(...parts90);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -3907,16 +3907,16 @@ const options_person_first_post = {
   description: "The first post by the person."
 };
 const resourceConfig3 = {
-  codec: attributes_post_codec_post,
+  codec: postCodec,
   executor: executor_mainPgExecutor
 };
 const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent91 = sql.identifier(...parts91);
+const sqlIdent70 = sql.identifier(...parts91);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3936,12 +3936,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts92 = ["c", "func_out_table"];
-const sqlIdent92 = sql.identifier(...parts92);
+const sqlIdent71 = sql.identifier(...parts92);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3960,12 +3960,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent93 = sql.identifier(...parts93);
+const sqlIdent72 = sql.identifier(...parts93);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -3984,12 +3984,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts94 = ["c", "mutation_out_table"];
-const sqlIdent94 = sql.identifier(...parts94);
+const sqlIdent73 = sql.identifier(...parts94);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4008,12 +4008,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
+const sqlIdent74 = sql.identifier(...parts95);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4032,12 +4032,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts96 = ["c", "table_set_mutation"];
-const sqlIdent96 = sql.identifier(...parts96);
+const sqlIdent75 = sql.identifier(...parts96);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4056,12 +4056,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts97 = ["c", "table_set_query"];
-const sqlIdent97 = sql.identifier(...parts97);
+const sqlIdent76 = sql.identifier(...parts97);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4082,12 +4082,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent98 = sql.identifier(...parts98);
+const sqlIdent77 = sql.identifier(...parts98);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4106,18 +4106,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent99 = sql.identifier(...parts99);
+const sqlIdent78 = sql.identifier(...parts99);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -4136,18 +4136,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts100 = ["c", "person_friends"];
-const sqlIdent100 = sql.identifier(...parts100);
+const sqlIdent79 = sql.identifier(...parts100);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4166,18 +4166,18 @@ const options_person_friends = {
   description: undefined
 };
 const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent101 = sql.identifier(...parts101);
+const sqlIdent80 = sql.identifier(...parts101);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -4195,22 +4195,22 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const resourceConfig4 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts102 = ["c", "person_type_function"];
-const sqlIdent102 = sql.identifier(...parts102);
+const sqlIdent81 = sql.identifier(...parts102);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -4233,22 +4233,22 @@ const options_person_type_function = {
   description: undefined
 };
 const resourceConfig5 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const parts103 = ["c", "person_type_function_list"];
-const sqlIdent103 = sql.identifier(...parts103);
+const sqlIdent82 = sql.identifier(...parts103);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -4266,7 +4266,7 @@ const options_person_type_function_list = {
   description: undefined
 };
 const resourceConfig6 = {
-  codec: registryConfig_pgCodecs_types_types,
+  codec: typesCodec,
   executor: executor_mainPgExecutor
 };
 const registry = makeRegistry({
@@ -4287,40 +4287,40 @@ const registry = makeRegistry({
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
     SearchTestSummariesRecord: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
     interval: TYPES.interval,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    nullTestRecord: nullTestRecordCodec,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
     uuid: TYPES.uuid,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
+    person: personCodec,
     varchar: TYPES.varchar,
-    textArray: attributes_aliases_codec_textArray,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    textArray: textArrayCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -4331,21 +4331,21 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
+    types: typesCodec,
     int8: TYPES.bigint,
     numeric: TYPES.numeric,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
-    intervalArray: attributes_interval_array_codec_intervalArray,
+    intervalArray: intervalArrayCodec,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -4355,22 +4355,22 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions36,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    int8Array: innerCodec_int8Array
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    int8Array: int8ArrayCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -4378,14 +4378,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: extensions30,
       description: undefined
     },
     func_out: {
@@ -4398,7 +4398,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: extensions31,
       description: undefined
     },
     func_out_setof: {
@@ -4411,7 +4411,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions41,
+      extensions: extensions32,
       description: undefined
     },
     func_out_unnamed: {
@@ -4424,7 +4424,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions42,
+      extensions: extensions33,
       description: undefined
     },
     mutation_out: {
@@ -4437,7 +4437,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions43,
+      extensions: extensions34,
       description: undefined
     },
     mutation_out_setof: {
@@ -4450,7 +4450,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: extensions35,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -4463,7 +4463,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions45,
+      extensions: extensions36,
       description: undefined
     },
     no_args_mutation: {
@@ -4476,7 +4476,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: extensions37,
       description: undefined
     },
     no_args_query: {
@@ -4489,7 +4489,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions47,
+      extensions: extensions38,
       description: undefined
     },
     func_in_out: {
@@ -4502,7 +4502,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions48,
+      extensions: extensions39,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -4515,7 +4515,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: extensions40,
       description: undefined
     },
     mutation_in_out: {
@@ -4528,7 +4528,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions50,
+      extensions: extensions41,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -4541,7 +4541,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions51,
+      extensions: extensions42,
       description: undefined
     },
     json_identity: {
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: extensions43,
       description: undefined
     },
     json_identity_mutation: {
@@ -4567,7 +4567,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: extensions44,
       description: undefined
     },
     jsonb_identity: {
@@ -4580,7 +4580,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: extensions45,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -4593,7 +4593,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: extensions46,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -4606,7 +4606,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: extensions47,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -4619,7 +4619,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: extensions48,
       description: undefined
     },
     func_in_inout: {
@@ -4632,7 +4632,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: extensions49,
       description: undefined
     },
     func_out_out: {
@@ -4645,7 +4645,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: extensions50,
       description: undefined
     },
     func_out_out_setof: {
@@ -4658,7 +4658,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: extensions51,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -4671,7 +4671,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions61,
+      extensions: extensions52,
       description: undefined
     },
     mutation_in_inout: {
@@ -4684,7 +4684,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: extensions53,
       description: undefined
     },
     mutation_out_out: {
@@ -4697,7 +4697,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions63,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -4710,7 +4710,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions64,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -4723,7 +4723,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions65,
+      extensions: extensions56,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -4736,7 +4736,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions57,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -4749,7 +4749,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions58,
       description: undefined
     },
     int_set_mutation: {
@@ -4762,7 +4762,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions59,
       description: undefined
     },
     int_set_query: {
@@ -4775,7 +4775,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: extensions60,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -4788,7 +4788,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions61,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -4801,7 +4801,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions62,
       description: undefined
     },
     search_test_summaries: {
@@ -4814,19 +4814,19 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions63,
       description: undefined
     },
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions73
+      extensions: extensions64
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4834,12 +4834,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions76
+      extensions: extensions67
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -4851,7 +4851,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions68,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -4859,12 +4859,12 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques5,
       isVirtual: false,
       description: undefined,
-      extensions: extensions78
+      extensions: extensions69
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
@@ -4881,7 +4881,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions81,
+      extensions: extensions72,
       description: undefined
     },
     types_query: {
@@ -4894,7 +4894,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions73,
       description: undefined
     },
     compound_type_computed_field: {
@@ -4907,7 +4907,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions74,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -4920,7 +4920,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: extensions75,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -4933,7 +4933,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: extensions76,
       description: undefined
     },
     query_output_two_rows: {
@@ -4946,7 +4946,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: extensions77,
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
@@ -4962,7 +4962,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions88,
+      extensions: extensions79,
       description: undefined
     },
     person_first_name: {
@@ -4975,7 +4975,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: extensions80,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -4988,7 +4988,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions81,
       description: undefined
     },
     person_computed_inout: {
@@ -5001,7 +5001,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: extensions82,
       description: undefined
     },
     person_computed_inout_out: {
@@ -5014,7 +5014,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions83,
       description: undefined
     },
     person_exists: {
@@ -5027,7 +5027,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions93,
+      extensions: extensions84,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -5040,7 +5040,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions85,
       description: undefined
     },
     func_out_complex: {
@@ -5053,7 +5053,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions95,
+      extensions: extensions86,
       description: undefined
     },
     func_out_complex_setof: {
@@ -5066,7 +5066,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions96,
+      extensions: extensions87,
       description: undefined
     },
     mutation_out_complex: {
@@ -5079,7 +5079,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions97,
+      extensions: extensions88,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -5092,7 +5092,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions89,
       description: undefined
     },
     person_computed_complex: {
@@ -5105,7 +5105,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: extensions90,
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
@@ -5127,7 +5127,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -5142,7 +5142,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -5159,7 +5159,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -5176,7 +5176,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5193,7 +5193,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5208,7 +5208,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5223,7 +5223,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5240,7 +5240,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -6348,7 +6348,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -6360,7 +6360,7 @@ const argDetailsSimple19 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -7394,7 +7394,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple36 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -8876,7 +8876,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -9047,7 +9047,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -9059,7 +9059,7 @@ const argDetailsSimple67 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -15646,7 +15646,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15662,7 +15662,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16284,7 +16284,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16300,7 +16300,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16432,7 +16432,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -16455,7 +16455,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -16478,7 +16478,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -16687,7 +16687,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -16710,7 +16710,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -16733,7 +16733,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -16756,7 +16756,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -16779,7 +16779,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -16802,7 +16802,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -16825,7 +16825,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -16848,7 +16848,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -16871,7 +16871,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -16894,7 +16894,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -16917,7 +16917,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -16957,7 +16957,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16973,7 +16973,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17071,7 +17071,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -17094,7 +17094,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -17110,7 +17110,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17126,7 +17126,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17224,7 +17224,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -17247,7 +17247,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -17263,7 +17263,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17279,7 +17279,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17445,7 +17445,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -17468,7 +17468,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -17491,7 +17491,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -17514,7 +17514,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -17692,7 +17692,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -17715,7 +17715,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -17738,7 +17738,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -17754,7 +17754,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17770,7 +17770,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17936,7 +17936,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -17959,7 +17959,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -17982,7 +17982,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -18005,7 +18005,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -18021,7 +18021,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18037,7 +18037,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18135,7 +18135,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -18158,7 +18158,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -2,9 +2,6 @@ import { PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllSte
 import { ObjectStep, SafeError, __ValueStep, access, assertExecutableStep, constant, context, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,37 +237,36 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -288,29 +275,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,37 +305,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -358,29 +343,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -390,28 +374,27 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes11 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
-});
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -441,10 +424,9 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const myTableIdentifier = sql.identifier(...["c", "my_table"]);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
   extensions: {
@@ -457,8 +439,7 @@ const myTableCodecSpec = {
     tags: Object.create(null)
   },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -481,28 +462,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts2 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts2);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -532,26 +509,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts3);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -590,26 +563,22 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts4);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+});
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
@@ -639,26 +608,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts5);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -697,39 +662,32 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts6);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions6,
-  executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const extensions7 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts7 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts7);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -752,194 +710,174 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts8);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const extensions9 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts9 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts9),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions9
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions10 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts10);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions10
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions11 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts11);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions11
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions12 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts12);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions12,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -948,29 +886,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -980,198 +917,181 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions13 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts13);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions13
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts14 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts14);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts15);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
-  attributes: postAttributes,
+  identifier: sql.identifier("a", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1180,29 +1100,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1211,29 +1130,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1243,81 +1161,69 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const extensions16 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts16);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions17 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts17);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions18 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts18);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -1423,48 +1329,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts19);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions19,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1473,37 +1374,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1512,37 +1412,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1551,37 +1450,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1590,37 +1488,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1629,37 +1526,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1669,209 +1565,179 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions20 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts20);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions20,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions21 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts21);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions22 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts22);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions22
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions23 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts23);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
   description: "range of dates",
-  extensions: extensions23
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts24 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts24);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
   description: undefined,
-  extensions: extensions24
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts25);
-const nestedCompoundTypeCodecSpec = {
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions26 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts26 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts26);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions26,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts27 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts27);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions27,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -1889,1111 +1755,524 @@ const typesAttributes_ltree_codec_ltree = {
   attributes: undefined
 };
 const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions28 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const parts28 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts28);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
-  attributes: typesAttributes,
+  identifier: sql.identifier("b", "types"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: typesAttributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: typesAttributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions28,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts29);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions29
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const extensions30 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts30 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts30);
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts31 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts31);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions32 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts32 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts32);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions33 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts33 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts33);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts34 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts34);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts35 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts35);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions36 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts36 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts36);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions37 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts37 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts37);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts38 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts38);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts39 = ["c", "func_in_out"];
-const sqlIdent18 = sql.identifier(...parts39);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts40 = ["c", "func_returns_table_one_col"];
-const sqlIdent19 = sql.identifier(...parts40);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts41 = ["c", "mutation_in_out"];
-const sqlIdent20 = sql.identifier(...parts41);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts42 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent21 = sql.identifier(...parts42);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions43 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts43 = ["c", "json_identity"];
-const sqlIdent22 = sql.identifier(...parts43);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts44 = ["c", "json_identity_mutation"];
-const sqlIdent23 = sql.identifier(...parts44);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts45 = ["c", "jsonb_identity"];
-const sqlIdent24 = sql.identifier(...parts45);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions46 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts46 = ["c", "jsonb_identity_mutation"];
-const sqlIdent25 = sql.identifier(...parts46);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts47 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent26 = sql.identifier(...parts47);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions48 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts48 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent27 = sql.identifier(...parts48);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts49 = ["c", "func_in_inout"];
-const sqlIdent28 = sql.identifier(...parts49);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions50 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts50 = ["c", "func_out_out"];
-const sqlIdent29 = sql.identifier(...parts50);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [];
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "func_out_out_setof"];
-const sqlIdent30 = sql.identifier(...parts51);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [];
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts52 = ["c", "func_out_out_unnamed"];
-const sqlIdent31 = sql.identifier(...parts52);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts53 = ["c", "mutation_in_inout"];
-const sqlIdent32 = sql.identifier(...parts53);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "mutation_out_out"];
-const sqlIdent33 = sql.identifier(...parts54);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts55 = ["c", "mutation_out_out_setof"];
-const sqlIdent34 = sql.identifier(...parts55);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts56 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent35 = sql.identifier(...parts56);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent36 = sql.identifier(...parts57);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "func_returns_table_multi_col"];
-const sqlIdent37 = sql.identifier(...parts58);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "int_set_mutation"];
-const sqlIdent38 = sql.identifier(...parts59);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["c", "int_set_query"];
-const sqlIdent39 = sql.identifier(...parts60);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent40 = sql.identifier(...parts61);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent41 = sql.identifier(...parts62);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts63 = ["c", "search_test_summaries"];
-const sqlIdent42 = sql.identifier(...parts63);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [];
-const extensions64 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("c", "func_in_out");
+const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent20 = sql.identifier("c", "mutation_in_out");
+const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent22 = sql.identifier("c", "json_identity");
+const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent24 = sql.identifier("c", "jsonb_identity");
+const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent28 = sql.identifier("c", "func_in_inout");
+const sqlIdent29 = sql.identifier("c", "func_out_out");
+const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent33 = sql.identifier("c", "mutation_out_out");
+const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent38 = sql.identifier("c", "int_set_mutation");
+const sqlIdent39 = sql.identifier("c", "int_set_query");
+const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent42 = sql.identifier("c", "search_test_summaries");
 const uniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3002,17 +2281,6 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const extensions65 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques2 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -3030,16 +2298,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques2,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions65
-};
-const extensions66 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques3 = [{
   isPrimary: true,
@@ -3058,16 +2327,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions66
-};
-const extensions67 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques4 = [{
   isPrimary: true,
@@ -3077,68 +2345,8 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts64 = ["c", "edge_case_computed"];
-const sqlIdent43 = sql.identifier(...parts64);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts65 = ["c", "return_table_without_grants"];
-const sqlIdent44 = sql.identifier(...parts65);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions69 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques5 = [];
-const extensions70 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent43 = sql.identifier("c", "edge_case_computed");
+const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3163,51 +2371,17 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques6,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions70
-};
-const parts66 = ["c", "left_arm_identity"];
-const sqlIdent45 = sql.identifier(...parts66);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "left_arm"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
+    tags: {}
+  }
 };
-const extensions71 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent45 = sql.identifier("c", "left_arm_identity");
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3225,632 +2399,39 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions71
-};
-const parts67 = ["c", "issue756_mutation"];
-const sqlIdent46 = sql.identifier(...parts67);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "issue756_mutation"
+      name: "issue756"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts68 = ["c", "issue756_set_mutation"];
-const sqlIdent47 = sql.identifier(...parts68);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+    tags: {}
   }
 };
-const parts69 = ["c", "types_mutation"];
-const sqlIdent48 = sql.identifier(...parts69);
-const fromCallback36 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "types_query"];
-const sqlIdent49 = sql.identifier(...parts70);
-const fromCallback37 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "compound_type_computed_field"];
-const sqlIdent50 = sql.identifier(...parts71);
-const fromCallback38 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "func_out_out_compound_type"];
-const sqlIdent51 = sql.identifier(...parts72);
-const fromCallback39 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent52 = sql.identifier(...parts73);
-const fromCallback40 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters40 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "query_output_two_rows"];
-const sqlIdent53 = sql.identifier(...parts74);
-const fromCallback41 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters41 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts75 = ["c", "compound_type_set_query"];
-const sqlIdent54 = sql.identifier(...parts75);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions78 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const uniques8 = [];
-const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
-  name: "compound_type",
-  identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
-  codec: compoundTypeCodec,
-  uniques: uniques8,
-  isVirtual: true,
-  description: "Awesome feature!",
-  extensions: extensions78
-};
-const parts76 = ["c", "table_mutation"];
-const sqlIdent55 = sql.identifier(...parts76);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts77 = ["c", "table_query"];
-const sqlIdent56 = sql.identifier(...parts77);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig2 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts78 = ["c", "person_computed_out"];
-const sqlIdent57 = sql.identifier(...parts78);
-const fromCallback42 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters42 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-  }
-};
-const parts79 = ["c", "person_first_name"];
-const sqlIdent58 = sql.identifier(...parts79);
-const fromCallback43 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts80 = ["c", "person_computed_out_out"];
-const sqlIdent59 = sql.identifier(...parts80);
-const fromCallback44 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters44 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts81 = ["c", "person_computed_inout"];
-const sqlIdent60 = sql.identifier(...parts81);
-const fromCallback45 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters45 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts82 = ["c", "person_computed_inout_out"];
-const sqlIdent61 = sql.identifier(...parts82);
-const fromCallback46 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters46 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts83 = ["c", "person_exists"];
-const sqlIdent62 = sql.identifier(...parts83);
-const fromCallback47 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters47 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts84 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent63 = sql.identifier(...parts84);
-const fromCallback48 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["c", "func_out_complex"];
-const sqlIdent64 = sql.identifier(...parts85);
-const fromCallback49 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["c", "func_out_complex_setof"];
-const sqlIdent65 = sql.identifier(...parts86);
-const fromCallback50 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["c", "mutation_out_complex"];
-const sqlIdent66 = sql.identifier(...parts87);
-const fromCallback51 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["c", "mutation_out_complex_setof"];
-const sqlIdent67 = sql.identifier(...parts88);
-const fromCallback52 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts89 = ["c", "person_computed_complex"];
-const sqlIdent68 = sql.identifier(...parts89);
-const fromCallback53 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters53 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions91 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent46 = sql.identifier("c", "issue756_mutation");
+const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent48 = sql.identifier("c", "types_mutation");
+const sqlIdent49 = sql.identifier("c", "types_query");
+const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
+const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
+const sqlIdent55 = sql.identifier("c", "table_mutation");
+const sqlIdent56 = sql.identifier("c", "table_query");
+const sqlIdent57 = sql.identifier("c", "person_computed_out");
+const sqlIdent58 = sql.identifier("c", "person_first_name");
+const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent60 = sql.identifier("c", "person_computed_inout");
+const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent62 = sql.identifier("c", "person_exists");
+const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent64 = sql.identifier("c", "func_out_complex");
+const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent68 = sql.identifier("c", "person_computed_complex");
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3875,400 +2456,30 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques9,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions91
-};
-const parts90 = ["c", "person_first_post"];
-const sqlIdent69 = sql.identifier(...parts90);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "person_first_post"
+      name: "person"
     },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
+    tags: {}
+  }
 };
-const resourceConfig3 = {
-  codec: postCodec,
-  executor: executor_mainPgExecutor
-};
-const parts91 = ["c", "badly_behaved_function"];
-const sqlIdent70 = sql.identifier(...parts91);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "badly_behaved_function"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts92 = ["c", "func_out_table"];
-const sqlIdent71 = sql.identifier(...parts92);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts93 = ["c", "func_out_table_setof"];
-const sqlIdent72 = sql.identifier(...parts93);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts94 = ["c", "mutation_out_table"];
-const sqlIdent73 = sql.identifier(...parts94);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts95 = ["c", "mutation_out_table_setof"];
-const sqlIdent74 = sql.identifier(...parts95);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts96 = ["c", "table_set_mutation"];
-const sqlIdent75 = sql.identifier(...parts96);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts97 = ["c", "table_set_query"];
-const sqlIdent76 = sql.identifier(...parts97);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts98 = ["c", "table_set_query_plpgsql"];
-const sqlIdent77 = sql.identifier(...parts98);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts99 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent78 = sql.identifier(...parts99);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts100 = ["c", "person_friends"];
-const sqlIdent79 = sql.identifier(...parts100);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts101 = ["c", "person_type_function_connection"];
-const sqlIdent80 = sql.identifier(...parts101);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig4 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts102 = ["c", "person_type_function"];
-const sqlIdent81 = sql.identifier(...parts102);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig5 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
-const parts103 = ["c", "person_type_function_list"];
-const sqlIdent82 = sql.identifier(...parts103);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const resourceConfig6 = {
-  codec: typesCodec,
-  executor: executor_mainPgExecutor
-};
+const sqlIdent69 = sql.identifier("c", "person_first_post");
+const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent71 = sql.identifier("c", "func_out_table");
+const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent73 = sql.identifier("c", "mutation_out_table");
+const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent75 = sql.identifier("c", "table_set_mutation");
+const sqlIdent76 = sql.identifier("c", "table_set_query");
+const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent79 = sql.identifier("c", "person_friends");
+const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent81 = sql.identifier("c", "person_type_function");
+const sqlIdent82 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -4363,7 +2574,14 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -4385,436 +2603,929 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions30,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions31,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions32,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions33,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions34,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions35,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions36,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions37,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions38,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions39,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions40,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions41,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions42,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions43,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions44,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions45,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions46,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions47,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions48,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions50,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     my_table: {
@@ -4826,7 +3537,15 @@ const registry = makeRegistry({
       uniques,
       isVirtual: false,
       description: undefined,
-      extensions: extensions64
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
@@ -4839,290 +3558,1261 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions67
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques5,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions69
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    table_mutation: PgResource.functionResourceOptions(resourceConfig, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(resourceConfig2, options_table_query),
+    compound_type_set_query: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "compound_type",
+      identifier: "main.c.compound_type",
+      from: compoundTypeCodec.sqlType,
+      codec: compoundTypeCodec,
+      uniques: [],
+      isVirtual: true,
+      description: "Awesome feature!",
+      extensions: {
+        description: "Awesome feature!",
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person: registryConfig_pgResources_person_person,
-    person_first_post: PgResource.functionResourceOptions(resourceConfig3, options_person_first_post),
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
-    person_type_function_connection: PgResource.functionResourceOptions(resourceConfig4, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(resourceConfig5, options_person_type_function),
-    person_type_function_list: PgResource.functionResourceOptions(resourceConfig6, options_person_type_function_list)
+    person_first_post: PgResource.functionResourceOptions({
+      codec: postCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions({
+      codec: typesCodec,
+      executor: executor_mainPgExecutor
+    }, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     compoundKey: Object.assign(Object.create(null), {
@@ -5541,12 +5231,6 @@ const makeArgs3 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_out_setofPgResource = registry.pgResources["func_out_setof"];
-function Query_funcOutSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -5743,12 +5427,6 @@ const makeArgs7 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_returns_table_one_colPgResource = registry.pgResources["func_returns_table_one_col"];
-function Query_funcReturnsTableOneColList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneColList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -6003,12 +5681,6 @@ const makeArgs12 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_out_out_setofPgResource = registry.pgResources["func_out_out_setof"];
-function Query_funcOutOutSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple13 = [];
 const makeArgs13 = (args, path = []) => {
   const selectArgs = [];
@@ -6153,12 +5825,6 @@ const makeArgs15 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_returns_table_multi_colPgResource = registry.pgResources["func_returns_table_multi_col"];
-function Query_funcReturnsTableMultiColList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiColList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple16 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -6223,12 +5889,6 @@ const makeArgs16 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_queryPgResource = registry.pgResources["int_set_query"];
-function Query_intSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple17 = [];
 const makeArgs17 = (args, path = []) => {
   const selectArgs = [];
@@ -6275,12 +5935,6 @@ const makeArgs17 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple18 = [];
 const makeArgs18 = (args, path = []) => {
   const selectArgs = [];
@@ -6571,12 +6225,6 @@ const makeArgs22 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_queryPgResource = registry.pgResources["compound_type_set_query"];
-function Query_compoundTypeSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple23 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6745,12 +6393,6 @@ const makeArgs25 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_out_complex_setofPgResource = registry.pgResources["func_out_complex_setof"];
-function Query_funcOutComplexSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple26 = [];
 const makeArgs26 = (args, path = []) => {
   const selectArgs = [];
@@ -6797,12 +6439,6 @@ const makeArgs26 = (args, path = []) => {
   return selectArgs;
 };
 const resource_badly_behaved_functionPgResource = registry.pgResources["badly_behaved_function"];
-function Query_badlyBehavedFunctionList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunctionList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple27 = [];
 const makeArgs27 = (args, path = []) => {
   const selectArgs = [];
@@ -6895,12 +6531,6 @@ const makeArgs28 = (args, path = []) => {
   return selectArgs;
 };
 const resource_func_out_table_setofPgResource = registry.pgResources["func_out_table_setof"];
-function Query_funcOutTableSetofList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetofList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -6947,12 +6577,6 @@ const makeArgs29 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_queryPgResource = registry.pgResources["table_set_query"];
-function Query_tableSetQueryList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -7017,12 +6641,6 @@ const makeArgs30 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_set_query_plpgsql"];
-function Query_tableSetQueryPlpgsqlList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsqlList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 function specForHandler(handler) {
   function spec(nodeId) {
     // We only want to return the specifier if it matches
@@ -7097,55 +6715,7 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Person);
-function Query_allMyTablesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTablesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecretsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecretsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeysList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeysList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecordsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecordsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCasesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCasesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArmsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArmsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756SList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756SList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeopleList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeopleList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -7685,12 +7255,6 @@ const makeArgs41 = (args, path = []) => {
   return selectArgs;
 };
 const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-function Person_friendsList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friendsList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -7737,12 +7301,6 @@ const makeArgs42 = (args, path = []) => {
   return selectArgs;
 };
 const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-function Person_typeFunctionConnectionList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnectionList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple43 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -7842,18 +7400,6 @@ const makeArgs44 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_compoundKeysByPersonId1List_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1List_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2List_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2List_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
@@ -7901,24 +7447,6 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
@@ -8014,9 +7542,6 @@ const makeArgs47 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -8063,9 +7588,6 @@ const makeArgs48 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple49 = [];
 const makeArgs49 = (args, path = []) => {
   const selectArgs = [];
@@ -8112,9 +7634,6 @@ const makeArgs49 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple50 = [];
 const makeArgs50 = (args, path = []) => {
   const selectArgs = [];
@@ -8161,9 +7680,6 @@ const makeArgs50 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple51 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8216,9 +7732,6 @@ const makeArgs51 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple52 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8271,9 +7784,6 @@ const makeArgs52 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple53 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8326,9 +7836,6 @@ const makeArgs53 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple54 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -8381,9 +7888,6 @@ const makeArgs54 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple55 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8436,9 +7940,6 @@ const makeArgs55 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple56 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -8491,9 +7992,6 @@ const makeArgs56 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8552,9 +8050,6 @@ const makeArgs57 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple58 = [];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
@@ -8601,9 +8096,6 @@ const makeArgs58 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple59 = [];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
@@ -8650,9 +8142,6 @@ const makeArgs59 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple60 = [];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
@@ -8699,9 +8188,6 @@ const makeArgs60 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple61 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -8766,9 +8252,6 @@ const makeArgs61 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -8815,9 +8298,6 @@ const makeArgs62 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -8870,9 +8350,6 @@ const makeArgs63 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple64 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -8925,9 +8402,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8974,9 +8448,6 @@ const makeArgs65 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -9023,9 +8494,6 @@ const makeArgs66 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple67 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9108,9 +8576,6 @@ const makeArgs67 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple68 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -9163,9 +8628,6 @@ const makeArgs68 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple69 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -9218,9 +8680,6 @@ const makeArgs69 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple70 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9279,9 +8738,6 @@ const makeArgs70 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple71 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -9340,9 +8796,6 @@ const makeArgs71 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
@@ -9389,9 +8842,6 @@ const makeArgs72 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
@@ -9438,9 +8888,6 @@ const makeArgs73 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -9487,851 +8934,62 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -13913,7 +12571,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -14034,11 +12694,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14068,11 +12732,15 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneColList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneColList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14116,11 +12784,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14141,11 +12813,15 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiColList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiColList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14160,11 +12836,15 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14176,11 +12856,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14230,11 +12914,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14267,11 +12955,15 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14283,11 +12975,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunctionList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunctionList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14303,11 +12999,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetofList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetofList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14319,11 +13019,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14349,11 +13053,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsqlList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsqlList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -14427,11 +13135,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTablesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTablesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14456,11 +13168,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecretsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecretsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14485,11 +13201,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeysList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeysList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14514,11 +13234,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecordsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecordsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14543,11 +13267,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCasesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCasesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14572,11 +13300,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArmsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArmsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14601,11 +13333,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756SList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756SList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14630,11 +13366,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeopleList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeopleList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15089,11 +13829,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friendsList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friendsList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15143,11 +13887,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnectionList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnectionList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -15282,11 +14030,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1List_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1List_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15313,11 +14065,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2List_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2List_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15483,12 +14239,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -18180,7 +16948,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18195,7 +16965,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18210,7 +16982,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18225,7 +16999,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18240,7 +17016,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18255,7 +17033,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18270,7 +17050,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18285,7 +17067,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18300,7 +17084,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18315,7 +17101,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18330,7 +17118,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18345,7 +17135,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18360,7 +17152,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18375,7 +17169,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18390,7 +17186,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18405,7 +17203,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18420,7 +17220,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18435,7 +17237,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18450,7 +17254,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18465,7 +17271,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18480,7 +17288,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18495,7 +17305,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18510,7 +17322,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18525,7 +17339,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18540,7 +17356,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18555,7 +17373,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18570,7 +17390,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18585,7 +17407,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18600,7 +17424,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18615,7 +17441,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18630,7 +17458,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18645,7 +17475,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18660,7 +17492,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18675,7 +17509,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18690,7 +17526,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18705,7 +17543,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18719,7 +17559,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18735,7 +17577,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18749,7 +17593,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18765,7 +17611,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18779,7 +17627,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18796,7 +17646,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18810,7 +17662,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18826,7 +17680,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18840,7 +17696,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18856,7 +17714,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18872,7 +17732,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18886,7 +17748,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18902,7 +17766,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18916,7 +17782,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18932,7 +17800,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18948,7 +17818,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18962,7 +17834,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18978,7 +17852,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -18992,7 +17868,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19008,7 +17886,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19022,7 +17902,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19039,7 +17921,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19053,7 +17937,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19069,7 +17955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19083,7 +17971,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19099,7 +17989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19115,7 +18007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19129,7 +18023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19145,7 +18041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19159,7 +18057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19175,7 +18075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -19191,168 +18093,236 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -19360,11 +18330,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19377,17 +18351,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19400,17 +18380,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19423,21 +18409,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -19446,11 +18440,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19466,17 +18464,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19489,18 +18493,24 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -19509,7 +18519,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -19546,43 +18558,61 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -19594,11 +18624,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19617,33 +18651,45 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19671,7 +18717,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -19679,11 +18727,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -19711,7 +18763,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -19719,59 +18773,88 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -19793,9 +18876,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -19804,11 +18893,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -19830,9 +18924,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId1($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id_1")
@@ -19846,11 +18946,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -19879,17 +18984,28 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -19925,17 +19041,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -19964,9 +19091,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -19975,11 +19108,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -20015,17 +19153,28 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -20047,17 +19196,28 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -20142,17 +19302,28 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -20173,18 +19344,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -20193,11 +19375,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -20218,18 +19405,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId1($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id_1")
@@ -20243,11 +19441,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -20275,27 +19478,43 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -20330,18 +19549,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -20350,11 +19580,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -20389,35 +19624,56 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -20438,26 +19694,42 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -20541,55 +19813,81 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -20598,26 +19896,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personByPersonId1($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id_1")
@@ -20631,50 +19939,70 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personByPersonId($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("person_id")
@@ -20683,71 +20011,99 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -273,7 +273,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -341,7 +341,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const myTableAttributes = Object.assign(Object.create(null), {
@@ -438,7 +438,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -478,7 +478,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -523,7 +523,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -577,7 +577,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
@@ -622,7 +622,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -676,7 +676,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -724,7 +724,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -855,7 +855,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -884,7 +884,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -914,7 +914,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -977,7 +977,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1061,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1098,7 +1098,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1128,7 +1128,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1158,7 +1158,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const textArrayCodec = listOfCodec(TYPES.text, {
@@ -1222,7 +1222,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1343,7 +1343,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -1372,7 +1372,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -1410,7 +1410,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -1448,7 +1448,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -1486,7 +1486,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -1524,7 +1524,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -1562,7 +1562,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -1690,7 +1690,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2213,7 +2213,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2239,41 +2239,41 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     tags: Object.create(null)
   }
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("c", "func_in_out");
-const sqlIdent19 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent20 = sql.identifier("c", "mutation_in_out");
-const sqlIdent21 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent22 = sql.identifier("c", "json_identity");
-const sqlIdent23 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent24 = sql.identifier("c", "jsonb_identity");
-const sqlIdent25 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent26 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent27 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent28 = sql.identifier("c", "func_in_inout");
-const sqlIdent29 = sql.identifier("c", "func_out_out");
-const sqlIdent30 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent31 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent32 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent33 = sql.identifier("c", "mutation_out_out");
-const sqlIdent34 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent35 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent36 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent37 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent38 = sql.identifier("c", "int_set_mutation");
-const sqlIdent39 = sql.identifier("c", "int_set_query");
-const sqlIdent40 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent41 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent42 = sql.identifier("c", "search_test_summaries");
-const uniques = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2281,7 +2281,7 @@ const uniques = [{
     tags: Object.create(null)
   }
 }];
-const uniques2 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2290,12 +2290,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques2,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -2310,7 +2310,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques3 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -2319,12 +2319,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques3,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2337,7 +2337,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques4 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2345,9 +2345,9 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent43 = sql.identifier("c", "edge_case_computed");
-const sqlIdent44 = sql.identifier("c", "return_table_without_grants");
-const uniques6 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2363,12 +2363,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques6,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -2381,8 +2381,8 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent45 = sql.identifier("c", "left_arm_identity");
-const uniques7 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2391,12 +2391,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques7,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2409,30 +2409,30 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent46 = sql.identifier("c", "issue756_mutation");
-const sqlIdent47 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent48 = sql.identifier("c", "types_mutation");
-const sqlIdent49 = sql.identifier("c", "types_query");
-const sqlIdent50 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent51 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent53 = sql.identifier("c", "query_output_two_rows");
-const sqlIdent54 = sql.identifier("c", "compound_type_set_query");
-const sqlIdent55 = sql.identifier("c", "table_mutation");
-const sqlIdent56 = sql.identifier("c", "table_query");
-const sqlIdent57 = sql.identifier("c", "person_computed_out");
-const sqlIdent58 = sql.identifier("c", "person_first_name");
-const sqlIdent59 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent60 = sql.identifier("c", "person_computed_inout");
-const sqlIdent61 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent62 = sql.identifier("c", "person_exists");
-const sqlIdent63 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent64 = sql.identifier("c", "func_out_complex");
-const sqlIdent65 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent66 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent67 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent68 = sql.identifier("c", "person_computed_complex");
-const uniques9 = [{
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2448,12 +2448,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques9,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -2466,20 +2466,20 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent69 = sql.identifier("c", "person_first_post");
-const sqlIdent70 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent71 = sql.identifier("c", "func_out_table");
-const sqlIdent72 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent73 = sql.identifier("c", "mutation_out_table");
-const sqlIdent74 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent75 = sql.identifier("c", "table_set_mutation");
-const sqlIdent76 = sql.identifier("c", "table_set_query");
-const sqlIdent77 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent78 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent79 = sql.identifier("c", "person_friends");
-const sqlIdent80 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent81 = sql.identifier("c", "person_type_function");
-const sqlIdent82 = sql.identifier("c", "person_type_function_list");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -2592,11 +2592,11 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2616,11 +2616,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2641,11 +2641,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2666,11 +2666,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2690,11 +2690,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2715,11 +2715,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -2740,11 +2740,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2764,11 +2764,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2788,11 +2788,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -2812,11 +2812,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2842,11 +2842,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2872,11 +2872,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2902,11 +2902,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -2932,11 +2932,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2961,11 +2961,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -2990,11 +2990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3019,11 +3019,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -3048,11 +3048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3077,11 +3077,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -3106,11 +3106,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3141,11 +3141,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3165,11 +3165,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3189,11 +3189,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3213,11 +3213,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3248,11 +3248,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3272,11 +3272,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3296,11 +3296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3320,11 +3320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3344,11 +3344,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3373,11 +3373,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3412,11 +3412,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -3451,11 +3451,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3475,11 +3475,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -3504,11 +3504,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3529,12 +3529,12 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3550,12 +3550,12 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques4,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -3569,11 +3569,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -3601,7 +3601,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3620,7 +3620,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -3643,7 +3643,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3698,7 +3698,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3717,11 +3717,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3771,11 +3771,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -3825,11 +3825,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -3854,11 +3854,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3883,11 +3883,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -3912,11 +3912,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -3951,7 +3951,7 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
       from: compoundTypeCodec.sqlType,
@@ -3974,7 +3974,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -3994,12 +3994,12 @@ const registry = makeRegistry({
     }),
     table_mutation: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4024,12 +4024,12 @@ const registry = makeRegistry({
     }),
     table_query: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -4053,11 +4053,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4086,11 +4086,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4116,11 +4116,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4145,11 +4145,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4180,11 +4180,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4214,11 +4214,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4249,11 +4249,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4278,11 +4278,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4312,11 +4312,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4346,11 +4346,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4380,11 +4380,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4414,11 +4414,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4455,12 +4455,12 @@ const registry = makeRegistry({
     person: registryConfig_pgResources_person_person,
     person_first_post: PgResource.functionResourceOptions({
       codec: postCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4487,7 +4487,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4510,7 +4510,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4532,7 +4532,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4554,7 +4554,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4576,7 +4576,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4598,7 +4598,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4620,7 +4620,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4644,7 +4644,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -4666,7 +4666,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4694,7 +4694,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -4720,12 +4720,12 @@ const registry = makeRegistry({
     }),
     person_type_function_connection: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4750,12 +4750,12 @@ const registry = makeRegistry({
     }),
     person_type_function: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -4785,12 +4785,12 @@ const registry = makeRegistry({
     }),
     person_type_function_list: PgResource.functionResourceOptions({
       codec: typesCodec,
-      executor: executor_mainPgExecutor
+      executor: executor
     }, {
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -14413,7 +14413,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14429,7 +14429,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15051,7 +15051,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15067,7 +15067,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15724,7 +15724,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15740,7 +15740,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15877,7 +15877,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15893,7 +15893,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16030,7 +16030,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16046,7 +16046,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16521,7 +16521,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16537,7 +16537,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16788,7 +16788,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16804,7 +16804,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -55,7 +55,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const peopleAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -85,10 +85,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_people = {
+const peopleIdentifier = sql.identifier(...["simple_collections", "people"]);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sql.identifier(...["simple_collections", "people"]),
-  attributes: attributes_object_Object_,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -101,8 +102,8 @@ const spec_people = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const petsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -141,16 +142,16 @@ const extensions2 = {
   tags: Object.create(null)
 };
 const parts2 = ["simple_collections", "pets"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_pets = {
+const petsIdentifier = sql.identifier(...parts2);
+const petsCodecSpec = {
   name: "pets",
-  identifier: sqlIdent2,
-  attributes: attributes_object_Object_2,
+  identifier: petsIdentifier,
+  attributes: petsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_pets_pets = recordCodec(spec_pets);
+const petsCodec = recordCodec(petsCodecSpec);
 const extensions3 = {
   description: undefined,
   pg: {
@@ -172,8 +173,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -200,26 +201,26 @@ const registryConfig_pgResources_pets_pets = {
   executor: executor_mainPgExecutor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: registryConfig_pgCodecs_pets_pets.sqlType,
-  codec: registryConfig_pgCodecs_pets_pets,
+  from: petsCodec.sqlType,
+  codec: petsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
   extensions: extensions4
 };
 const parts3 = ["simple_collections", "people_odd_pets"];
-const sqlIdent3 = sql.identifier(...parts3);
+const sqlIdent = sql.identifier(...parts3);
 const options_people_odd_pets = {
   name: "people_odd_pets",
   identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
   from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_people_people
+    codec: peopleCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -238,10 +239,10 @@ const options_people_odd_pets = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    people: registryConfig_pgCodecs_people_people,
+    people: peopleCodec,
     int4: TYPES.int,
     text: TYPES.text,
-    pets: registryConfig_pgCodecs_pets_pets,
+    pets: petsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar
   }),
@@ -253,7 +254,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     people: Object.assign(Object.create(null), {
       petsByTheirOwnerId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_pets_pets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -271,7 +272,7 @@ const registry = makeRegistry({
     }),
     pets: Object.assign(Object.create(null), {
       peopleByMyOwnerId: {
-        localCodec: registryConfig_pgCodecs_pets_pets,
+        localCodec: petsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["owner_id"],
@@ -1655,7 +1656,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1671,7 +1672,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_pets_pets.attributes[attributeName];
+          const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1803,7 +1804,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.id.codec)}`;
             }
           });
         }
@@ -1826,7 +1827,7 @@ export const plans = {
             type: "attribute",
             attribute: "owner_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.owner_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.owner_id.codec)}`;
             }
           });
         }
@@ -1849,7 +1850,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.name.codec)}`;
             }
           });
         }
@@ -1883,7 +1884,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1899,7 +1900,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -1997,7 +1998,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
             }
           });
         }
@@ -2020,7 +2021,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -68,7 +68,7 @@ const peopleAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -92,7 +92,7 @@ const peopleCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const petsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -137,9 +137,9 @@ const petsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
-const uniques = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -148,12 +148,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.simple_collections.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -166,7 +166,7 @@ const registryConfig_pgResources_people_people = {
     tags: {}
   }
 };
-const uniques2 = [{
+const petsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -175,12 +175,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
   from: petsCodec.sqlType,
   codec: petsCodec,
-  uniques: uniques2,
+  uniques: petsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -193,7 +193,7 @@ const registryConfig_pgResources_pets_pets = {
     tags: {}
   }
 };
-const sqlIdent = sql.identifier("simple_collections", "people_odd_pets");
+const people_odd_petsFunctionIdentifer = sql.identifier("simple_collections", "people_odd_pets");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     people: peopleCodec,
@@ -210,7 +210,7 @@ const registry = makeRegistry({
       name: "people_odd_pets",
       identifier: "main.simple_collections.people_odd_pets(simple_collections.people)",
       from(...args) {
-        return sql`${sqlIdent}(${sqlFromArgDigests(args)})`;
+        return sql`${people_odd_petsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -1469,7 +1469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1485,7 +1485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        petsUniques[0].attributes.forEach(attributeName => {
           const attribute = petsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1704,7 +1704,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -1720,7 +1720,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -2045,7 +2045,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2119,7 +2119,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2205,7 +2205,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2292,7 +2292,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2396,7 +2396,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -2460,7 +2460,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = petsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -85,7 +85,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -115,7 +115,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -145,7 +145,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -175,7 +175,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -205,7 +205,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -235,7 +235,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -265,7 +265,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -303,7 +303,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -333,7 +333,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -371,7 +371,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -401,7 +401,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -467,7 +467,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -494,7 +494,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -521,7 +521,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -548,7 +548,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -575,7 +575,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -602,7 +602,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -638,7 +638,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -683,7 +683,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -719,7 +719,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -764,7 +764,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -803,7 +803,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -839,7 +839,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -879,7 +879,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -924,7 +924,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -969,7 +969,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1023,7 +1023,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1077,7 +1077,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1134,7 +1134,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1188,7 +1188,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1246,7 +1246,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1300,7 +1300,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1362,7 +1362,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1410,7 +1410,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1456,7 +1456,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1587,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1616,7 +1616,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1646,7 +1646,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1709,7 +1709,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1794,7 +1794,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1831,7 +1831,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1861,7 +1861,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1891,7 +1891,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1942,7 +1942,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2063,7 +2063,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2092,7 +2092,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2130,7 +2130,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2168,7 +2168,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2206,7 +2206,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2244,7 +2244,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2282,7 +2282,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2397,7 +2397,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2922,7 +2922,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2961,70 +2961,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3032,7 +3032,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3040,7 +3040,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3048,7 +3048,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3056,7 +3056,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3064,7 +3064,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3073,7 +3073,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3092,7 +3092,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3120,7 +3120,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3128,7 +3128,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3137,12 +3137,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3157,7 +3157,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3165,7 +3165,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3174,12 +3174,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3192,7 +3192,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3200,7 +3200,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3208,7 +3208,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3216,10 +3216,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3235,12 +3235,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3253,9 +3253,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3275,8 +3275,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,26 +3303,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3331,12 +3331,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3349,9 +3349,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3371,32 +3371,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3412,12 +3412,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3430,17 +3430,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3449,12 +3449,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3469,15 +3469,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3676,7 +3676,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3729,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,16 +3791,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3820,11 +3820,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3894,11 +3894,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3944,11 +3944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3968,11 +3968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3992,11 +3992,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4016,11 +4016,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4040,11 +4040,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4064,11 +4064,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4088,11 +4088,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4112,11 +4112,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4142,11 +4142,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4172,11 +4172,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4202,11 +4202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4232,11 +4232,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4261,11 +4261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4291,11 +4291,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4320,11 +4320,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4349,11 +4349,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4378,11 +4378,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4407,11 +4407,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4436,11 +4436,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4465,11 +4465,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4499,11 +4499,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4533,11 +4533,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4567,11 +4567,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4601,11 +4601,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4635,11 +4635,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4669,11 +4669,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4703,11 +4703,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4737,11 +4737,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4771,11 +4771,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4805,11 +4805,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4839,11 +4839,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4873,11 +4873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4907,11 +4907,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4942,11 +4942,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4966,11 +4966,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4990,11 +4990,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5014,11 +5014,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5049,11 +5049,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5073,11 +5073,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5121,11 +5121,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5146,11 +5146,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5185,11 +5185,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5224,11 +5224,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5263,11 +5263,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5302,11 +5302,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5341,11 +5341,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5365,11 +5365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5394,11 +5394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5433,11 +5433,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5472,11 +5472,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5496,11 +5496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5525,11 +5525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5554,11 +5554,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5578,11 +5578,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5602,11 +5602,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5626,11 +5626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5650,7 +5650,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5671,12 +5671,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5690,12 +5690,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5709,12 +5709,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5728,12 +5728,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5747,12 +5747,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5766,12 +5766,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5786,7 +5786,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5812,7 +5812,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5832,12 +5832,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5852,12 +5852,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5872,12 +5872,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5891,12 +5891,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5910,7 +5910,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5941,12 +5941,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5960,11 +5960,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5992,7 +5992,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6011,11 +6011,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6050,7 +6050,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6073,7 +6073,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6095,7 +6095,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6133,7 +6133,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6165,7 +6165,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6187,7 +6187,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6209,7 +6209,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6243,7 +6243,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6267,7 +6267,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6301,11 +6301,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6355,11 +6355,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6409,11 +6409,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6438,11 +6438,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6467,11 +6467,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6496,11 +6496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6525,11 +6525,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6561,11 +6561,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6597,11 +6597,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6626,11 +6626,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6655,11 +6655,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6694,11 +6694,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6733,11 +6733,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6772,11 +6772,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6815,7 +6815,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6837,7 +6837,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6864,7 +6864,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6891,7 +6891,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6918,7 +6918,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6945,7 +6945,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6972,7 +6972,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7005,7 +7005,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7032,7 +7032,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7059,7 +7059,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7113,7 +7113,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7145,7 +7145,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7169,11 +7169,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7232,11 +7232,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7261,11 +7261,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7296,11 +7296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7330,11 +7330,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7365,11 +7365,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7394,11 +7394,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7428,11 +7428,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7462,11 +7462,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7496,11 +7496,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7530,11 +7530,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7572,7 +7572,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7600,7 +7600,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7623,7 +7623,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7645,7 +7645,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7667,7 +7667,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7689,7 +7689,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7757,7 +7757,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7779,7 +7779,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7807,7 +7807,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7836,7 +7836,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7858,7 +7858,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7880,7 +7880,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7907,7 +7907,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7961,7 +7961,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7993,7 +7993,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8015,7 +8015,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -8037,7 +8037,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -30651,7 +30651,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30667,7 +30667,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33165,7 +33165,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33181,7 +33181,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33603,7 +33603,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33619,7 +33619,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34240,7 +34240,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34256,7 +34256,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35325,7 +35325,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35341,7 +35341,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35446,7 +35446,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35462,7 +35462,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35567,7 +35567,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35583,7 +35583,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35688,7 +35688,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35704,7 +35704,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35809,7 +35809,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35825,7 +35825,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35930,7 +35930,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35946,7 +35946,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36469,7 +36469,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36485,7 +36485,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36647,7 +36647,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36663,7 +36663,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36825,7 +36825,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36841,7 +36841,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37060,7 +37060,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37076,7 +37076,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37352,7 +37352,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37368,7 +37368,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37919,7 +37919,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -37935,7 +37935,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38460,7 +38460,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38476,7 +38476,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38752,7 +38752,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -38768,7 +38768,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -42380,7 +42380,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42467,7 +42467,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42716,7 +42716,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42773,7 +42773,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43030,7 +43030,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43141,7 +43141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43223,7 +43223,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43290,7 +43290,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43357,7 +43357,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43424,7 +43424,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43491,7 +43491,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43558,7 +43558,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43786,7 +43786,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43860,7 +43860,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43939,7 +43939,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44020,7 +44020,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44111,7 +44111,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44199,7 +44199,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44344,7 +44344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44482,7 +44482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44575,7 +44575,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44649,7 +44649,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44712,7 +44712,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44849,7 +44849,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45262,7 +45262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45342,7 +45342,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45422,7 +45422,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45502,7 +45502,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45582,7 +45582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45662,7 +45662,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45791,7 +45791,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45878,7 +45878,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45970,7 +45970,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46064,7 +46064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46169,7 +46169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46270,7 +46270,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46371,7 +46371,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46472,7 +46472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46592,7 +46592,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46679,7 +46679,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46799,7 +46799,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -46963,7 +46963,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47394,7 +47394,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47458,7 +47458,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47522,7 +47522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47586,7 +47586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47650,7 +47650,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47714,7 +47714,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47798,7 +47798,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47862,7 +47862,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47931,7 +47931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -47995,7 +47995,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48070,7 +48070,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48134,7 +48134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48198,7 +48198,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48262,7 +48262,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48339,7 +48339,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48403,7 +48403,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48472,7 +48472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -48544,7 +48544,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,30 +26,26 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
+    }
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -95,28 +88,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -125,29 +117,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -156,29 +147,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -187,29 +177,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -218,29 +207,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -249,29 +237,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -280,37 +267,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -319,29 +305,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -350,37 +335,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -389,29 +373,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -421,8 +404,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -434,30 +416,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -473,26 +453,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -504,26 +480,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -535,26 +507,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -566,26 +534,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -597,26 +561,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -628,26 +588,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -668,26 +624,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -717,26 +669,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -757,26 +705,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -806,45 +750,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -858,17 +778,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -889,26 +825,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -931,28 +863,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -982,26 +910,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1031,26 +955,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1089,26 +1009,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1147,26 +1063,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1205,29 +1117,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1266,36 +1174,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1329,26 +1232,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1387,106 +1286,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1509,245 +1396,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1756,29 +1618,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1788,88 +1649,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1930,56 +1780,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1988,29 +1833,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2019,29 +1863,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2051,67 +1894,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2217,48 +2049,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2267,37 +2094,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2306,37 +2132,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2345,37 +2170,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2384,37 +2208,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2423,37 +2246,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2463,195 +2285,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3123,1496 +2916,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4621,15 +3032,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4638,15 +3040,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4655,15 +3048,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4672,15 +3056,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4689,15 +3064,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4706,93 +3072,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4802,17 +3128,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4830,16 +3145,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4849,15 +3165,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4875,16 +3182,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4894,15 +3200,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4911,37 +3208,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4950,97 +3216,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5065,103 +3243,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5179,571 +3293,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5761,732 +3339,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6511,274 +3420,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6796,254 +3457,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7158,19 +3592,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7179,9 +3634,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7196,813 +3807,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -8014,7 +5658,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -8025,7 +5679,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -8036,7 +5698,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -8047,7 +5717,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8058,7 +5736,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8069,7 +5755,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8080,7 +5774,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8089,10 +5791,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8100,10 +5817,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8115,7 +5840,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8127,7 +5860,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8139,7 +5880,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8150,7 +5899,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8158,10 +5915,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8172,33 +5949,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8207,394 +6055,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9444,25 +8909,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9605,21 +9051,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9670,21 +9101,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9793,21 +9209,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -10298,21 +9699,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10405,12 +9791,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10833,21 +10213,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10916,21 +10281,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -11317,21 +10667,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11660,21 +10995,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11725,21 +11045,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11836,21 +11141,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11901,21 +11191,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11984,21 +11259,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -12049,21 +11309,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12325,385 +11570,10 @@ const fetcher18 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -13277,21 +12147,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -13372,21 +12227,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -13486,66 +12326,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13593,24 +12373,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13691,21 +12453,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -14129,348 +12876,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -14517,26 +12923,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14583,9 +12969,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,9 +13015,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14681,9 +13061,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14730,9 +13107,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14779,9 +13153,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14828,9 +13199,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14883,9 +13251,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14938,9 +13303,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14993,9 +13355,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -15048,9 +13407,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15103,9 +13459,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -15158,9 +13511,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15219,9 +13569,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15280,9 +13627,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15341,9 +13685,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15402,9 +13743,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15463,9 +13801,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15524,9 +13859,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15585,9 +13917,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15646,9 +13975,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15707,9 +14033,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15768,9 +14091,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15817,9 +14137,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15866,9 +14183,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15915,9 +14229,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15982,9 +14293,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -16031,9 +14339,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -16086,9 +14391,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -16141,9 +14443,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -16190,9 +14489,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -16239,9 +14535,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -16306,9 +14599,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -16355,9 +14645,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16422,9 +14709,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16477,9 +14761,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -16526,9 +14807,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16575,9 +14853,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16642,9 +14917,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16709,9 +14981,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16794,9 +15063,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16849,9 +15115,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16904,9 +15167,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16959,9 +15219,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17014,9 +15271,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -17075,9 +15329,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17130,9 +15381,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -17185,9 +15433,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -17240,9 +15485,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17301,9 +15543,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17362,9 +15601,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -17411,9 +15647,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -17460,9 +15693,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -17509,9 +15739,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17558,9 +15785,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17613,9 +15837,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17662,2061 +15883,151 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_updateInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_updatePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_updateReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_updateReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_updateReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_updateDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_updateMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_updatePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_updateViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_updateCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_updateSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_updateSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs13 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_updateNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs14 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_updateLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs15 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_updateIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs16 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs17 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_updatePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs18 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_updateType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs19 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Input, $nodeId);
 };
-function Mutation_deleteInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs20 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Patch, $nodeId);
 };
-function Mutation_deletePatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs21 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Reserved, $nodeId);
 };
-function Mutation_deleteReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs22 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedPatchRecord, $nodeId);
 };
-function Mutation_deleteReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs23 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ReservedInputRecord, $nodeId);
 };
-function Mutation_deleteReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs24 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.DefaultValue, $nodeId);
 };
-function Mutation_deleteDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs25 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.MyTable, $nodeId);
 };
-function Mutation_deleteMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs26 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.PersonSecret, $nodeId);
 };
-function Mutation_deletePersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs27 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.ViewTable, $nodeId);
 };
-function Mutation_deleteViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs28 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.CompoundKey, $nodeId);
 };
-function Mutation_deleteCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs29 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable1, $nodeId);
 };
-function Mutation_deleteSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs30 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.SimilarTable2, $nodeId);
 };
-function Mutation_deleteSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs31 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.NullTestRecord, $nodeId);
 };
-function Mutation_deleteNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs32 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.LeftArm, $nodeId);
 };
-function Mutation_deleteLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs33 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Issue756, $nodeId);
 };
-function Mutation_deleteIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs34 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs35 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
 };
-function Mutation_deletePerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs36 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
-function Mutation_deleteType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyInput_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1Input_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2Input_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756Input_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -29823,7 +26134,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -30069,27 +26382,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30109,23 +26435,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30137,23 +26473,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30175,23 +26521,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30275,23 +26631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30307,11 +26673,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -30383,23 +26753,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30414,23 +26794,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30488,23 +26878,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30564,23 +26964,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30592,23 +27002,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30624,23 +27044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30652,23 +27082,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30696,23 +27136,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30724,23 +27174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30926,23 +27386,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30969,23 +27439,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31012,23 +27492,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31055,23 +27545,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31098,23 +27598,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31141,23 +27651,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31184,23 +27704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31227,23 +27757,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31270,23 +27810,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31313,23 +27863,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31356,23 +27916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31399,23 +27969,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31442,23 +28022,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31485,23 +28075,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31528,23 +28128,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31571,23 +28181,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31614,23 +28234,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31657,23 +28287,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31700,23 +28340,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31743,23 +28393,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31786,23 +28446,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31829,23 +28499,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31872,23 +28552,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31915,23 +28605,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32075,23 +28775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32493,23 +29203,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32530,23 +29250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -32672,23 +29402,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32718,23 +29458,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32774,23 +29524,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -32820,23 +29580,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33004,12 +29774,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -33025,23 +29807,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -33386,23 +30178,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -33430,9 +30232,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33448,8 +30257,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -33590,9 +30403,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36256,9 +33076,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36717,9 +33544,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37109,9 +33943,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37370,9 +34211,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37697,9 +34545,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37715,9 +34570,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37733,9 +34595,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37751,9 +34620,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37778,9 +34654,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37835,9 +34718,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37862,9 +34752,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37927,9 +34824,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37969,9 +34873,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38290,9 +35201,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38378,9 +35296,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38492,9 +35417,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38606,9 +35538,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38720,9 +35659,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38834,9 +35780,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38948,9 +35901,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39119,9 +36079,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39258,9 +36225,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39466,9 +36440,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39637,9 +36618,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39808,9 +36796,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40036,9 +37031,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40321,9 +37323,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40606,9 +37615,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -40874,9 +37890,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41159,9 +38182,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41401,9 +38431,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41686,9 +38723,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -41868,7 +38912,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41883,7 +38929,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41898,7 +38946,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41913,7 +38963,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41928,7 +38980,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41943,7 +38997,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41958,7 +39014,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41973,7 +39031,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41988,7 +39048,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42003,7 +39065,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42018,7 +39082,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42033,7 +39099,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42048,7 +39116,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42063,7 +39133,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42078,7 +39150,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42093,7 +39167,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42108,7 +39184,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42123,7 +39201,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42138,7 +39218,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42153,7 +39235,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42168,7 +39252,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42183,7 +39269,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42198,7 +39286,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42213,7 +39303,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42228,7 +39320,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42243,7 +39337,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42258,7 +39354,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42273,7 +39371,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42288,7 +39388,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42303,7 +39405,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42318,7 +39422,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42333,7 +39439,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42348,7 +39456,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42363,7 +39473,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42378,7 +39490,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42393,7 +39507,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42408,7 +39524,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42423,7 +39541,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42438,7 +39558,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42453,7 +39575,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42468,7 +39592,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42483,7 +39609,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42498,7 +39626,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42513,7 +39643,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42528,7 +39660,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42543,7 +39677,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42558,7 +39694,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42573,7 +39711,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42588,7 +39728,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42603,7 +39745,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42618,7 +39762,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42633,7 +39779,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42648,7 +39796,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42663,7 +39813,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42678,7 +39830,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42693,7 +39847,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42708,7 +39864,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42723,7 +39881,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42738,7 +39898,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42753,7 +39915,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42768,7 +39932,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42783,7 +39949,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42798,7 +39966,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42813,7 +39983,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42828,7 +40000,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42843,7 +40017,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42858,7 +40034,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42873,7 +40051,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42888,7 +40068,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42903,7 +40085,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42918,7 +40102,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42933,7 +40119,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42948,7 +40136,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42963,7 +40153,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42978,7 +40170,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -42993,7 +40187,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43008,7 +40204,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43023,7 +40221,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43038,7 +40238,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43052,7 +40254,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43068,7 +40272,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43082,7 +40288,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43098,7 +40306,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43112,7 +40322,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43128,7 +40340,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43142,7 +40356,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43158,7 +40374,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43172,7 +40390,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43188,7 +40408,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43202,7 +40424,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43218,7 +40442,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43234,7 +40460,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43248,7 +40476,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43264,7 +40494,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43278,7 +40510,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43294,7 +40528,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43308,7 +40544,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43324,7 +40562,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43338,7 +40578,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43355,7 +40597,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43369,7 +40613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43385,7 +40631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43399,7 +40647,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43415,7 +40665,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43429,7 +40681,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43445,7 +40699,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43459,7 +40715,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43475,7 +40733,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43491,7 +40751,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43505,7 +40767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43521,7 +40785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43535,7 +40801,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43551,7 +40819,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43565,7 +40835,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43581,7 +40853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43597,7 +40871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43611,7 +40887,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43627,7 +40905,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43641,7 +40921,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43657,7 +40939,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43671,7 +40955,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43687,7 +40973,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43701,7 +40989,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43717,7 +41007,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43731,7 +41023,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43747,7 +41041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43761,7 +41057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43777,7 +41075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43791,7 +41091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43807,7 +41109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43823,7 +41127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43837,7 +41143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43853,7 +41161,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43867,7 +41177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43883,7 +41195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43897,7 +41211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43913,7 +41229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43927,7 +41245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43944,7 +41264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43958,7 +41280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43974,7 +41298,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -43988,7 +41314,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44004,7 +41332,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44018,7 +41348,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44034,7 +41366,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44048,7 +41382,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44064,7 +41400,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44080,7 +41418,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44094,7 +41434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44110,7 +41452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44124,7 +41468,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44140,7 +41486,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44154,7 +41502,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44170,7 +41520,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44186,7 +41538,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44200,7 +41554,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -44216,193 +41572,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44410,15 +41846,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44426,15 +41868,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44442,15 +41890,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44458,15 +41912,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44474,15 +41934,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44490,15 +41956,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44506,15 +41978,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44522,15 +42000,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -44538,15 +42022,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -44554,11 +42044,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44571,17 +42065,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44594,17 +42094,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44617,21 +42123,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -44640,11 +42154,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44660,17 +42178,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -44683,65 +42207,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -44750,11 +42300,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -44776,21 +42330,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44799,11 +42361,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44843,7 +42409,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -44880,11 +42448,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44919,35 +42491,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -44956,11 +42542,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return pgResource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -44992,7 +42582,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45001,15 +42593,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45021,11 +42619,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45044,48 +42646,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45125,18 +42745,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45176,7 +42802,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -45228,56 +42856,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45305,7 +42955,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45313,11 +42965,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -45345,7 +43001,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -45353,11 +43011,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45392,59 +43054,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45489,30 +43175,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45547,11 +43247,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45566,9 +43271,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45603,11 +43314,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45622,9 +43338,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45659,11 +43381,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45678,9 +43405,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45715,11 +43448,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45734,9 +43472,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45771,11 +43515,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45790,9 +43539,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45827,11 +43582,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45853,9 +43613,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return pgResource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -45870,11 +43636,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45903,17 +43674,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45935,17 +43717,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -45974,9 +43767,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46011,11 +43810,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46037,9 +43841,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46079,11 +43889,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46105,9 +43920,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46142,11 +43963,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46175,9 +44001,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46222,11 +44054,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46255,9 +44092,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46292,11 +44135,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46332,9 +44180,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46369,11 +44223,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46409,17 +44268,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46455,9 +44325,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46492,11 +44368,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46532,17 +44413,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46571,9 +44463,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46613,11 +44511,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46653,9 +44556,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46690,11 +44599,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46716,9 +44630,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46758,19 +44678,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46805,11 +44736,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -46894,9 +44830,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46941,11 +44883,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -47296,9 +45243,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47333,11 +45286,16 @@ export const plans = {
   },
   UpdateInputInput: {
     clientMutationId: {
-      applyPlan: UpdateInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -47351,18 +45309,29 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47397,11 +45366,16 @@ export const plans = {
   },
   UpdatePatchInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -47415,18 +45389,29 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47461,11 +45446,16 @@ export const plans = {
   },
   UpdateReservedInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -47479,18 +45469,29 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47525,11 +45526,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -47543,18 +45549,29 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47589,11 +45606,16 @@ export const plans = {
   },
   UpdateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -47607,18 +45629,29 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47653,11 +45686,16 @@ export const plans = {
   },
   UpdateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -47678,26 +45716,42 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -47718,9 +45772,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47755,11 +45815,16 @@ export const plans = {
   },
   UpdateMyTableInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -47780,18 +45845,29 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47831,11 +45907,16 @@ export const plans = {
   },
   UpdatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -47856,18 +45937,29 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47902,11 +45994,16 @@ export const plans = {
   },
   UpdateViewTableInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -47934,18 +46031,29 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -47990,11 +46098,16 @@ export const plans = {
   },
   UpdateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyInput_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -48022,19 +46135,30 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48069,11 +46193,16 @@ export const plans = {
   },
   UpdateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1Input_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -48108,18 +46237,29 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48154,11 +46294,16 @@ export const plans = {
   },
   UpdateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2Input_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -48193,18 +46338,29 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48239,11 +46395,16 @@ export const plans = {
   },
   UpdateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -48278,18 +46439,29 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48329,11 +46501,16 @@ export const plans = {
   },
   UpdateLeftArmInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -48368,27 +46545,43 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48423,11 +46616,16 @@ export const plans = {
   },
   UpdateIssue756Input: {
     clientMutationId: {
-      applyPlan: UpdateIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756Input_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -48448,18 +46646,29 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48499,11 +46708,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -48552,18 +46766,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48598,11 +46823,16 @@ export const plans = {
   },
   UpdatePersonInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -48686,27 +46916,43 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -48751,11 +46997,16 @@ export const plans = {
   },
   UpdateTypeInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     typePatch: {
-      applyPlan: UpdateTypeInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -49105,23 +47356,34 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteInputPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49156,26 +47418,36 @@ export const plans = {
   },
   DeleteInputInput: {
     clientMutationId: {
-      applyPlan: DeleteInputInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePatchPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49210,26 +47482,36 @@ export const plans = {
   },
   DeletePatchInput: {
     clientMutationId: {
-      applyPlan: DeletePatchInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49264,26 +47546,36 @@ export const plans = {
   },
   DeleteReservedInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49318,26 +47610,36 @@ export const plans = {
   },
   DeleteReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49372,26 +47674,36 @@ export const plans = {
   },
   DeleteReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteDefaultValuePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49426,38 +47738,56 @@ export const plans = {
   },
   DeleteDefaultValueInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteMyTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49492,26 +47822,36 @@ export const plans = {
   },
   DeleteMyTableInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonSecretPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49551,26 +47891,36 @@ export const plans = {
   },
   DeletePersonSecretInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteViewTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49605,26 +47955,36 @@ export const plans = {
   },
   DeleteViewTableInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteCompoundKeyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49669,27 +48029,37 @@ export const plans = {
   },
   DeleteCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable1Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49724,26 +48094,36 @@ export const plans = {
   },
   DeleteSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteSimilarTable2Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49778,26 +48158,36 @@ export const plans = {
   },
   DeleteSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteNullTestRecordPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49832,26 +48222,36 @@ export const plans = {
   },
   DeleteNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteLeftArmPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49891,32 +48291,44 @@ export const plans = {
   },
   DeleteLeftArmInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteIssue756Payload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -49951,26 +48363,36 @@ export const plans = {
   },
   DeleteIssue756Input: {
     clientMutationId: {
-      applyPlan: DeleteIssue756Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50010,26 +48432,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePersonPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50064,32 +48496,44 @@ export const plans = {
   },
   DeletePersonInput: {
     clientMutationId: {
-      applyPlan: DeletePersonInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteTypePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -50134,13 +48578,17 @@ export const plans = {
   },
   DeleteTypeInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -421,8 +421,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -434,7 +434,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -442,13 +442,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -456,13 +456,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -473,7 +473,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -483,17 +483,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -509,22 +571,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -540,22 +602,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -571,84 +633,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -668,7 +668,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -678,17 +678,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -717,7 +717,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -727,17 +727,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -757,7 +757,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -767,17 +767,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -806,7 +806,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -816,17 +816,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -846,7 +846,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -859,17 +859,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -889,7 +889,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -899,17 +899,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -943,17 +943,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -982,7 +982,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -992,17 +992,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1031,7 +1031,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1041,17 +1041,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1089,7 +1089,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1099,17 +1099,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1147,7 +1147,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1157,17 +1157,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1205,7 +1205,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1218,17 +1218,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1266,7 +1266,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1276,17 +1276,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1294,13 +1294,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1329,7 +1329,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1339,17 +1339,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1387,7 +1387,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1397,17 +1397,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1454,7 +1454,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1464,17 +1464,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1483,13 +1483,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1501,7 +1501,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1509,7 +1509,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1519,20 +1519,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1558,7 +1558,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1570,17 +1570,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1589,16 +1589,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1607,16 +1606,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1625,15 +1624,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1654,7 +1653,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1672,7 +1671,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1681,7 +1680,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1707,7 +1706,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1717,17 +1716,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1738,7 +1737,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1748,7 +1747,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1758,7 +1757,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1769,7 +1768,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1779,7 +1778,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1789,7 +1788,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1798,7 +1797,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1807,21 +1806,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1829,7 +1828,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1849,7 +1848,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1859,23 +1858,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1914,7 +1913,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1923,7 +1922,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1931,7 +1930,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1941,17 +1940,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1962,7 +1961,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1970,7 +1969,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1980,7 +1979,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1990,7 +1989,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -2011,7 +2010,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2021,7 +2020,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -2042,7 +2041,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2052,7 +2051,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2061,13 +2060,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2076,16 +2075,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2093,7 +2092,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2103,17 +2102,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2136,7 +2135,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2154,7 +2153,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2163,7 +2162,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2218,7 +2217,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2228,20 +2227,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2259,7 +2258,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2269,7 +2268,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2280,7 +2279,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2288,7 +2287,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2298,7 +2297,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2308,7 +2307,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2319,7 +2318,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2327,7 +2326,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2337,7 +2336,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2347,7 +2346,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2358,7 +2357,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2366,7 +2365,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2376,7 +2375,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2386,7 +2385,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2397,7 +2396,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2405,7 +2404,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2415,7 +2414,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2425,7 +2424,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2436,7 +2435,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2444,7 +2443,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2454,7 +2453,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2464,7 +2463,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2472,13 +2471,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2487,13 +2486,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2502,13 +2501,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2517,12 +2516,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2531,12 +2530,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2545,15 +2544,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2562,7 +2561,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2579,7 +2578,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2589,17 +2588,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2608,13 +2607,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2622,7 +2621,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2630,20 +2629,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2651,13 +2650,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2669,8 +2668,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2736,7 +2735,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2745,7 +2744,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2754,7 +2753,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2763,7 +2762,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2772,7 +2771,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2799,7 +2798,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2808,7 +2807,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2817,7 +2816,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2826,7 +2825,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2889,7 +2888,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2907,7 +2906,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2916,7 +2915,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2925,7 +2924,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2934,7 +2933,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3060,7 +3059,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3069,7 +3068,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3087,7 +3086,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3096,7 +3095,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3105,7 +3104,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3113,7 +3112,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3125,17 +3124,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3143,7 +3142,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3151,7 +3150,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3159,7 +3158,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3167,13 +3166,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3182,12 +3181,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3195,13 +3194,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3230,7 +3229,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3240,16 +3239,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3287,7 +3286,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3297,16 +3296,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3353,7 +3352,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3363,16 +3362,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3383,8 +3382,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3396,10 +3395,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3411,10 +3410,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3425,10 +3424,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3440,10 +3439,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3455,10 +3454,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3469,10 +3468,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3483,10 +3482,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3497,10 +3496,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3511,10 +3510,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3525,10 +3524,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3539,10 +3538,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3553,10 +3552,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3568,15 +3567,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3588,15 +3587,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3608,15 +3607,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3628,15 +3627,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3647,15 +3646,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3667,15 +3666,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3686,15 +3685,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3705,15 +3704,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3724,15 +3723,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3743,15 +3742,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3762,15 +3761,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3781,15 +3780,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3800,8 +3799,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3813,7 +3812,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3824,8 +3823,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3837,7 +3836,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3848,8 +3847,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3861,7 +3860,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3872,8 +3871,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3885,7 +3884,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3896,8 +3895,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3909,7 +3908,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3920,8 +3919,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3933,7 +3932,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3944,8 +3943,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3957,7 +3956,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3968,8 +3967,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3981,7 +3980,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3992,8 +3991,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -4005,7 +4004,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4016,8 +4015,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -4029,7 +4028,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4040,8 +4039,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4053,7 +4052,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4064,8 +4063,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4077,7 +4076,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4088,8 +4087,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4101,7 +4100,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,8 +4112,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4126,7 +4125,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4137,10 +4136,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4151,10 +4150,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4165,10 +4164,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,8 +4179,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4193,7 +4192,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4204,10 +4203,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4218,10 +4217,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4232,10 +4231,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4247,10 +4246,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4261,8 +4260,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4279,7 +4278,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4290,8 +4289,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4308,7 +4307,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4319,8 +4318,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4337,7 +4336,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4348,8 +4347,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4366,7 +4365,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4377,8 +4376,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4395,7 +4394,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4406,10 +4405,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4420,15 +4419,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4439,8 +4438,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4457,7 +4456,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4468,8 +4467,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4486,7 +4485,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4497,10 +4496,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4511,15 +4510,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4530,15 +4529,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4549,10 +4548,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4563,10 +4562,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4577,10 +4576,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4591,10 +4590,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4605,7 +4604,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4622,7 +4621,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4639,7 +4638,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4656,7 +4655,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4673,7 +4672,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4690,7 +4689,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4707,7 +4706,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4721,14 +4720,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4745,7 +4744,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4755,7 +4754,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4764,7 +4763,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4779,14 +4778,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4803,7 +4802,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4826,14 +4825,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4850,7 +4849,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,14 +4870,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4895,7 +4894,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4912,7 +4911,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4934,7 +4933,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4951,7 +4950,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4962,21 +4961,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4994,7 +4993,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -5005,13 +5004,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -5023,7 +5022,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5033,7 +5032,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5061,20 +5060,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5092,7 +5091,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5108,20 +5107,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5154,7 +5153,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5175,26 +5174,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5217,12 +5216,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5241,12 +5240,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5265,12 +5264,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5304,12 +5303,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5342,7 +5341,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5359,14 +5358,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5377,8 +5376,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5398,7 +5397,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5408,9 +5407,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5421,8 +5420,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5442,7 +5441,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5452,9 +5451,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5465,15 +5464,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5484,15 +5483,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5503,15 +5502,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5522,15 +5521,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5543,20 +5542,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5569,20 +5568,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5593,15 +5592,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5612,15 +5611,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5631,13 +5630,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5649,7 +5648,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5660,13 +5659,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5678,7 +5677,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5689,13 +5688,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5707,7 +5706,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5718,8 +5717,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5736,7 +5735,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5757,20 +5756,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5788,7 +5787,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5804,26 +5803,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5841,18 +5840,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5870,18 +5869,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5899,12 +5898,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5928,12 +5927,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5957,18 +5956,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5992,18 +5991,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6021,18 +6020,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6050,18 +6049,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6108,23 +6107,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6142,18 +6141,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6170,7 +6169,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6185,15 +6184,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,15 +6204,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6224,15 +6223,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6244,20 +6243,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6268,20 +6267,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6293,20 +6292,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6317,15 +6316,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6336,8 +6335,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6349,7 +6348,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6360,8 +6359,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6373,7 +6372,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6384,8 +6383,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6397,7 +6396,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6408,8 +6407,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6421,7 +6420,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6432,13 +6431,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6451,18 +6450,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6479,7 +6478,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6507,20 +6506,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6540,12 +6539,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6564,12 +6563,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6588,12 +6587,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6612,12 +6611,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6635,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,12 +6659,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6686,12 +6685,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6710,18 +6709,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6740,18 +6739,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6769,7 +6768,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6777,7 +6776,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6792,20 +6791,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6824,12 +6823,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6848,12 +6847,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6877,12 +6876,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6906,18 +6905,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6935,18 +6934,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6969,12 +6968,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6993,12 +6992,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -7017,18 +7016,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7065,61 +7064,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7130,18 +7129,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7151,38 +7150,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7190,14 +7189,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7210,7 +7209,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7223,7 +7222,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7236,7 +7235,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7249,7 +7248,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7262,7 +7261,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7275,7 +7274,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7288,7 +7287,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7301,7 +7300,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7314,7 +7313,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7327,7 +7326,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7340,7 +7339,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7353,7 +7352,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7366,7 +7365,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7379,7 +7378,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7392,7 +7391,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7405,7 +7404,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7418,7 +7417,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7431,7 +7430,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7444,7 +7443,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7457,7 +7456,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7470,7 +7469,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7483,7 +7482,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7496,7 +7495,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7509,7 +7508,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7522,7 +7521,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7535,7 +7534,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7548,7 +7547,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7561,7 +7560,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7574,7 +7573,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7587,7 +7586,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7600,7 +7599,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7613,7 +7612,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7626,7 +7625,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7639,7 +7638,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7652,7 +7651,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7665,7 +7664,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7678,7 +7677,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7691,7 +7690,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7704,7 +7703,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7717,7 +7716,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7730,7 +7729,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7743,7 +7742,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7756,7 +7755,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7769,7 +7768,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7782,7 +7781,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7795,7 +7794,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7808,7 +7807,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7821,7 +7820,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7834,7 +7833,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7847,7 +7846,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7860,7 +7859,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7873,7 +7872,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7886,7 +7885,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7899,7 +7898,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7912,7 +7911,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7925,7 +7924,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7938,7 +7937,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7948,10 +7947,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7961,10 +7960,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7974,10 +7973,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7987,10 +7986,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -8000,180 +7999,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8185,7 +8184,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8196,22 +8195,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8232,7 +8231,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8245,7 +8244,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8258,7 +8257,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8271,7 +8270,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8281,10 +8280,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8294,10 +8293,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8310,7 +8309,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8323,7 +8322,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8336,7 +8335,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8349,7 +8348,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8362,7 +8361,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8375,7 +8374,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8388,7 +8387,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8401,7 +8400,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8428,7 +8427,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8441,7 +8440,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8454,7 +8453,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8467,7 +8466,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8480,7 +8479,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8493,7 +8492,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8506,7 +8505,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8519,7 +8518,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8532,7 +8531,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8545,7 +8544,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8558,7 +8557,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8571,7 +8570,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8600,7 +8599,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8615,7 +8614,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8632,7 +8631,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8647,7 +8646,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8662,7 +8661,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8679,7 +8678,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8696,7 +8695,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8713,7 +8712,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8728,7 +8727,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8745,7 +8744,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8760,7 +8759,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8775,7 +8774,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8790,7 +8789,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8807,7 +8806,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8824,7 +8823,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8839,7 +8838,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8854,7 +8853,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8871,7 +8870,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8886,7 +8885,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8901,7 +8900,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8918,7 +8917,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -11091,7 +11090,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -11103,7 +11102,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -11336,7 +11335,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11440,7 +11439,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11492,7 +11491,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12953,7 +12952,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -14080,7 +14079,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16093,7 +16092,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -16246,7 +16245,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16429,7 +16428,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16734,7 +16733,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16746,7 +16745,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16856,7 +16855,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16911,7 +16910,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17021,7 +17020,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -17082,7 +17081,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17137,7 +17136,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -17192,7 +17191,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -33833,7 +33832,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33849,7 +33848,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35137,7 +35136,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -35160,7 +35159,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -35183,7 +35182,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -35206,7 +35205,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -35229,7 +35228,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -35252,7 +35251,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -35275,7 +35274,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -35298,7 +35297,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -35321,7 +35320,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -35344,7 +35343,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -35367,7 +35366,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -35390,7 +35389,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -35413,7 +35412,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -35436,7 +35435,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -35459,7 +35458,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -35482,7 +35481,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -35505,7 +35504,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -35528,7 +35527,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -35551,7 +35550,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -35574,7 +35573,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -35597,7 +35596,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -35620,7 +35619,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -35643,7 +35642,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -35666,7 +35665,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -35689,7 +35688,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -35712,7 +35711,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -35735,7 +35734,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -35758,7 +35757,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -35781,7 +35780,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -35804,7 +35803,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -35827,7 +35826,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -35850,7 +35849,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -35873,7 +35872,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -35896,7 +35895,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -35919,7 +35918,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -35942,7 +35941,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -35965,7 +35964,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -35988,7 +35987,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -36011,7 +36010,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -36034,7 +36033,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -36057,7 +36056,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -36080,7 +36079,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -36103,7 +36102,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -36126,7 +36125,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -36149,7 +36148,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -36172,7 +36171,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -36195,7 +36194,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -36340,7 +36339,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36356,7 +36355,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36771,7 +36770,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36787,7 +36786,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36953,7 +36952,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -36976,7 +36975,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -36999,7 +36998,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -37022,7 +37021,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -37045,7 +37044,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -37068,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -37272,7 +37271,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37295,7 +37294,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -37318,7 +37317,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -37394,7 +37393,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37410,7 +37409,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37542,7 +37541,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -37565,7 +37564,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -37588,7 +37587,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -38026,7 +38025,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -38049,7 +38048,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -38072,7 +38071,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -38095,7 +38094,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -38118,7 +38117,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -38141,7 +38140,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -38164,7 +38163,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -38187,7 +38186,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -38210,7 +38209,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -38233,7 +38232,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -38256,7 +38255,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -38368,7 +38367,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -38402,7 +38401,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38418,7 +38417,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38482,7 +38481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -38516,7 +38515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38532,7 +38531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38596,7 +38595,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38630,7 +38629,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38646,7 +38645,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38710,7 +38709,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -38744,7 +38743,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38760,7 +38759,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38824,7 +38823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -38858,7 +38857,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38874,7 +38873,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38938,7 +38937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -38972,7 +38971,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38988,7 +38987,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39086,7 +39085,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -39109,7 +39108,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -39225,7 +39224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -39248,7 +39247,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -39410,7 +39409,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -39433,7 +39432,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -39456,7 +39455,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -39490,7 +39489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39506,7 +39505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39604,7 +39603,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -39627,7 +39626,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -39661,7 +39660,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39677,7 +39676,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39775,7 +39774,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39798,7 +39797,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -39832,7 +39831,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39848,7 +39847,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39980,7 +39979,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -40003,7 +40002,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -40026,7 +40025,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -40060,7 +40059,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40076,7 +40075,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40242,7 +40241,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -40265,7 +40264,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -40288,7 +40287,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -40311,7 +40310,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -40345,7 +40344,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40361,7 +40360,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40527,7 +40526,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -40550,7 +40549,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -40573,7 +40572,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -40596,7 +40595,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -40795,7 +40794,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -40818,7 +40817,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -40841,7 +40840,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -40864,7 +40863,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -40898,7 +40897,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -40914,7 +40913,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41080,7 +41079,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -41103,7 +41102,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -41126,7 +41125,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -41149,7 +41148,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -41345,7 +41344,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -41368,7 +41367,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -41391,7 +41390,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -41425,7 +41424,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41441,7 +41440,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41607,7 +41606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -41630,7 +41629,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -41653,7 +41652,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -41676,7 +41675,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -41710,7 +41709,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41726,7 +41725,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -41824,7 +41823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -41847,7 +41846,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -2,7 +2,7 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -39,7 +39,7 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
@@ -69,7 +69,7 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
@@ -99,7 +99,7 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
@@ -129,7 +129,7 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
@@ -159,7 +159,7 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
@@ -189,7 +189,7 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
@@ -219,7 +219,7 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -257,7 +257,7 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
@@ -287,7 +287,7 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -325,7 +325,7 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
@@ -355,7 +355,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -421,7 +421,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -448,7 +448,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -475,7 +475,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -502,7 +502,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -529,7 +529,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -556,7 +556,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -592,7 +592,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -637,7 +637,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -673,7 +673,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -718,7 +718,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions12 = {
   isTableLike: true,
@@ -757,7 +757,7 @@ const uniqueForeignKeyCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions12,
-  executor: executor_mainPgExecutor
+  executor
 });
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -793,7 +793,7 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -833,7 +833,7 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -878,7 +878,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -923,7 +923,7 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -977,7 +977,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1031,7 +1031,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -1088,7 +1088,7 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1142,7 +1142,7 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1200,7 +1200,7 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1254,7 +1254,7 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
@@ -1316,7 +1316,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1364,7 +1364,7 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const authPayloadCodec = recordCodec({
   name: "authPayload",
@@ -1410,7 +1410,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1541,7 +1541,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1570,7 +1570,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
@@ -1600,7 +1600,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1663,7 +1663,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1748,7 +1748,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1785,7 +1785,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
@@ -1815,7 +1815,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
@@ -1845,7 +1845,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
@@ -1896,7 +1896,7 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const personAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2017,7 +2017,7 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
@@ -2046,7 +2046,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
@@ -2084,7 +2084,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
@@ -2122,7 +2122,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
@@ -2160,7 +2160,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
@@ -2198,7 +2198,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
@@ -2236,7 +2236,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
@@ -2351,7 +2351,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2876,7 +2876,7 @@ const typesCodec = recordCodec({
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2915,70 +2915,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2986,7 +2986,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2994,7 +2994,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3002,7 +3002,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3010,7 +3010,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3018,7 +3018,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3027,7 +3027,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3046,7 +3046,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3074,7 +3074,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3082,7 +3082,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3091,12 +3091,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
   from: personSecretCodec.sqlType,
   codec: personSecretCodec,
-  uniques: uniques13,
+  uniques: person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3111,7 +3111,7 @@ const registryConfig_pgResources_person_secret_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3119,7 +3119,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques15 = [{
+const compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3128,12 +3128,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
   from: compoundKeyCodec.sqlType,
   codec: compoundKeyCodec,
-  uniques: uniques15,
+  uniques: compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3146,7 +3146,7 @@ const registryConfig_pgResources_compound_key_compound_key = {
     tags: {}
   }
 };
-const uniques16 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3154,7 +3154,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const uniques17 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3162,7 +3162,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3170,10 +3170,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3189,12 +3189,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
   from: leftArmCodec.sqlType,
   codec: leftArmCodec,
-  uniques: uniques21,
+  uniques: left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3207,9 +3207,9 @@ const registryConfig_pgResources_left_arm_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
@@ -3229,8 +3229,8 @@ const resourceConfig_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3239,12 +3239,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "issue756",
   identifier: "main.c.issue756",
   from: issue756Codec.sqlType,
   codec: issue756Codec,
-  uniques: uniques23,
+  uniques: issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3257,26 +3257,26 @@ const registryConfig_pgResources_issue756_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3285,12 +3285,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3303,9 +3303,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
@@ -3325,32 +3325,32 @@ const resourceConfig_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3366,12 +3366,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "person",
   identifier: "main.c.person",
   from: personCodec.sqlType,
   codec: personCodec,
-  uniques: uniques27,
+  uniques: personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3384,17 +3384,17 @@ const registryConfig_pgResources_person_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3403,12 +3403,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "types",
   identifier: "main.b.types",
   from: typesCodec.sqlType,
   codec: typesCodec,
-  uniques: uniques28,
+  uniques: typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3423,15 +3423,15 @@ const registryConfig_pgResources_types_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3630,7 +3630,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3683,7 +3683,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3745,16 +3745,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3774,11 +3774,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3799,11 +3799,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3824,11 +3824,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3848,11 +3848,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3873,11 +3873,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3898,11 +3898,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3922,11 +3922,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3946,11 +3946,11 @@ const registry = makeRegistry({
       description: undefined
     },
     no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3970,11 +3970,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3994,11 +3994,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4018,11 +4018,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4042,11 +4042,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4066,11 +4066,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4096,11 +4096,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4126,11 +4126,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4156,11 +4156,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4186,11 +4186,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4215,11 +4215,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4245,11 +4245,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4274,11 +4274,11 @@ const registry = makeRegistry({
       description: undefined
     },
     json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4303,11 +4303,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4332,11 +4332,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4361,11 +4361,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4390,11 +4390,11 @@ const registry = makeRegistry({
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4419,11 +4419,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4453,11 +4453,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4487,11 +4487,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4521,11 +4521,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4555,11 +4555,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4589,11 +4589,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4623,11 +4623,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4657,11 +4657,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4691,11 +4691,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4725,11 +4725,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4759,11 +4759,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4793,11 +4793,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4827,11 +4827,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4861,11 +4861,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4896,11 +4896,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4920,11 +4920,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4944,11 +4944,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4968,11 +4968,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5003,11 +5003,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5027,11 +5027,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5051,11 +5051,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5075,11 +5075,11 @@ const registry = makeRegistry({
       description: undefined
     },
     search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5100,11 +5100,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5139,11 +5139,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5178,11 +5178,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5217,11 +5217,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5256,11 +5256,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5295,11 +5295,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5319,11 +5319,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5348,11 +5348,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5387,11 +5387,11 @@ const registry = makeRegistry({
       description: undefined
     },
     int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5426,11 +5426,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5450,11 +5450,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5479,11 +5479,11 @@ const registry = makeRegistry({
       description: undefined
     },
     guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5508,11 +5508,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5532,11 +5532,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5556,11 +5556,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5580,11 +5580,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5604,7 +5604,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5625,12 +5625,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5644,12 +5644,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5663,12 +5663,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5682,12 +5682,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5701,12 +5701,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5720,12 +5720,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5740,7 +5740,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5766,7 +5766,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5786,12 +5786,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "my_table",
       identifier: "main.c.my_table",
       from: myTableCodec.sqlType,
       codec: myTableCodec,
-      uniques: uniques12,
+      uniques: my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5806,12 +5806,12 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5826,12 +5826,12 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques16,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5845,12 +5845,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques17,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5864,7 +5864,7 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
@@ -5895,12 +5895,12 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
       from: nullTestRecordCodec.sqlType,
       codec: nullTestRecordCodec,
-      uniques: uniques19,
+      uniques: null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5914,11 +5914,11 @@ const registry = makeRegistry({
       }
     },
     edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5946,7 +5946,7 @@ const registry = makeRegistry({
       name: "return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -5965,11 +5965,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -6004,7 +6004,7 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
@@ -6027,7 +6027,7 @@ const registry = makeRegistry({
       name: "authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6049,7 +6049,7 @@ const registry = makeRegistry({
       name: "authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6087,7 +6087,7 @@ const registry = makeRegistry({
       name: "left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6119,7 +6119,7 @@ const registry = makeRegistry({
       name: "issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6141,7 +6141,7 @@ const registry = makeRegistry({
       name: "issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6163,7 +6163,7 @@ const registry = makeRegistry({
       name: "authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6197,7 +6197,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
       from: authPayloadCodec.sqlType,
@@ -6221,7 +6221,7 @@ const registry = makeRegistry({
       name: "authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6255,11 +6255,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6309,11 +6309,11 @@ const registry = makeRegistry({
       description: undefined
     },
     types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6363,11 +6363,11 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6392,11 +6392,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6421,11 +6421,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6450,11 +6450,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6479,11 +6479,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6515,11 +6515,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6551,11 +6551,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6580,11 +6580,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6609,11 +6609,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6648,11 +6648,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6687,11 +6687,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6726,11 +6726,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6769,7 +6769,7 @@ const registry = makeRegistry({
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6791,7 +6791,7 @@ const registry = makeRegistry({
       name: "compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6818,7 +6818,7 @@ const registry = makeRegistry({
       name: "compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6845,7 +6845,7 @@ const registry = makeRegistry({
       name: "compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6872,7 +6872,7 @@ const registry = makeRegistry({
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6899,7 +6899,7 @@ const registry = makeRegistry({
       name: "table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6926,7 +6926,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6959,7 +6959,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6986,7 +6986,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7013,7 +7013,7 @@ const registry = makeRegistry({
       name: "compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7040,7 +7040,7 @@ const registry = makeRegistry({
       name: "compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7067,7 +7067,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7099,7 +7099,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7123,11 +7123,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7156,11 +7156,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7186,11 +7186,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7215,11 +7215,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7250,11 +7250,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7284,11 +7284,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7319,11 +7319,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7348,11 +7348,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7382,11 +7382,11 @@ const registry = makeRegistry({
       description: undefined
     },
     func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7416,11 +7416,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7450,11 +7450,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7484,11 +7484,11 @@ const registry = makeRegistry({
       description: undefined
     },
     person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7526,7 +7526,7 @@ const registry = makeRegistry({
       name: "person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7554,7 +7554,7 @@ const registry = makeRegistry({
       name: "badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7577,7 +7577,7 @@ const registry = makeRegistry({
       name: "func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7599,7 +7599,7 @@ const registry = makeRegistry({
       name: "func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7621,7 +7621,7 @@ const registry = makeRegistry({
       name: "mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7643,7 +7643,7 @@ const registry = makeRegistry({
       name: "mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7665,7 +7665,7 @@ const registry = makeRegistry({
       name: "table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7687,7 +7687,7 @@ const registry = makeRegistry({
       name: "table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7711,7 +7711,7 @@ const registry = makeRegistry({
       name: "table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7733,7 +7733,7 @@ const registry = makeRegistry({
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7761,7 +7761,7 @@ const registry = makeRegistry({
       name: "person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7790,7 +7790,7 @@ const registry = makeRegistry({
       name: "type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7812,7 +7812,7 @@ const registry = makeRegistry({
       name: "type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7834,7 +7834,7 @@ const registry = makeRegistry({
       name: "type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7861,7 +7861,7 @@ const registry = makeRegistry({
       name: "type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7888,7 +7888,7 @@ const registry = makeRegistry({
       name: "person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7915,7 +7915,7 @@ const registry = makeRegistry({
       name: "person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7947,7 +7947,7 @@ const registry = makeRegistry({
       name: "type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -7969,7 +7969,7 @@ const registry = makeRegistry({
       name: "type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -7991,7 +7991,7 @@ const registry = makeRegistry({
       name: "person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -28607,7 +28607,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28623,7 +28623,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        typesUniques[0].attributes.forEach(attributeName => {
           const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31121,7 +31121,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31137,7 +31137,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        personUniques[0].attributes.forEach(attributeName => {
           const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31559,7 +31559,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31575,7 +31575,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32188,7 +32188,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32204,7 +32204,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33249,7 +33249,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33265,7 +33265,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33370,7 +33370,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33386,7 +33386,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33491,7 +33491,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33507,7 +33507,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33612,7 +33612,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33628,7 +33628,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33733,7 +33733,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33749,7 +33749,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33854,7 +33854,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33870,7 +33870,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34393,7 +34393,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34409,7 +34409,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34571,7 +34571,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34587,7 +34587,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34749,7 +34749,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34765,7 +34765,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34984,7 +34984,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35000,7 +35000,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35276,7 +35276,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35292,7 +35292,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35843,7 +35843,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35859,7 +35859,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36384,7 +36384,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36400,7 +36400,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36676,7 +36676,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36692,7 +36692,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -39728,7 +39728,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39815,7 +39815,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40064,7 +40064,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40121,7 +40121,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40378,7 +40378,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40489,7 +40489,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40571,7 +40571,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40638,7 +40638,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40705,7 +40705,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40772,7 +40772,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40839,7 +40839,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40906,7 +40906,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41134,7 +41134,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41208,7 +41208,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41287,7 +41287,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41368,7 +41368,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41459,7 +41459,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41547,7 +41547,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41692,7 +41692,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41830,7 +41830,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41923,7 +41923,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41997,7 +41997,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42060,7 +42060,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42197,7 +42197,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42610,7 +42610,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42676,7 +42676,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42742,7 +42742,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42808,7 +42808,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42874,7 +42874,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42940,7 +42940,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43055,7 +43055,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43128,7 +43128,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43206,7 +43206,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43286,7 +43286,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43377,7 +43377,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43464,7 +43464,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43551,7 +43551,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43638,7 +43638,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43744,7 +43744,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43817,7 +43817,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43923,7 +43923,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44073,7 +44073,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44485,7 +44485,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44536,7 +44536,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44587,7 +44587,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44638,7 +44638,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44689,7 +44689,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44740,7 +44740,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44811,7 +44811,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44862,7 +44862,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44918,7 +44918,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44969,7 +44969,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45031,7 +45031,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45082,7 +45082,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45133,7 +45133,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45184,7 +45184,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45248,7 +45248,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45299,7 +45299,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45355,7 +45355,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45414,7 +45414,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -371,8 +371,8 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", sqlIdent, {
+const guidIdentifier = sql.identifier(...["b", "guid"]);
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -384,7 +384,7 @@ const registryConfig_pgCodecs_guid_guid = domainOfCodec(TYPES.varchar, "guid", s
   },
   notNull: false
 });
-const extensions2 = {
+const intervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -392,13 +392,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_intervalArray_intervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const intervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: intervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const extensions3 = {
+const textArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -406,13 +406,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_textArray_textArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const textArrayCodec = listOfCodec(TYPES.text, {
+  extensions: textArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "textArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -423,7 +423,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -433,17 +433,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -459,22 +521,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -490,22 +552,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -521,84 +583,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -618,7 +618,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -628,17 +628,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -667,7 +667,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -677,17 +677,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -707,7 +707,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -717,17 +717,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -756,7 +756,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -766,17 +766,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -796,7 +796,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -809,17 +809,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -839,7 +839,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -849,17 +849,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_myTable = {
+const myTableIdentifier = sql.identifier(...parts13);
+const myTableCodecSpec = {
   name: "myTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: myTableIdentifier,
+  attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_myTable_myTable = recordCodec(spec_myTable);
-const attributes24 = Object.assign(Object.create(null), {
+const myTableCodec = recordCodec(myTableCodecSpec);
+const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -881,7 +881,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -893,17 +893,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_personSecret = {
+const personSecretIdentifier = sql.identifier(...parts14);
+const personSecretCodecSpec = {
   name: "personSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: personSecretIdentifier,
+  attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_personSecret_personSecret = recordCodec(spec_personSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const personSecretCodec = recordCodec(personSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -932,7 +932,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -942,17 +942,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes26 = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -981,7 +981,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -991,17 +991,17 @@ const extensions18 = {
   tags: Object.create(null)
 };
 const parts16 = ["c", "compound_key"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_compoundKey = {
+const compoundKeyIdentifier = sql.identifier(...parts16);
+const compoundKeyCodecSpec = {
   name: "compoundKey",
-  identifier: sqlIdent16,
-  attributes: attributes26,
+  identifier: compoundKeyIdentifier,
+  attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_compoundKey_compoundKey = recordCodec(spec_compoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1039,7 +1039,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1049,17 +1049,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["a", "similar_table_1"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts17);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent17,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1097,7 +1097,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1107,17 +1107,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_2"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts18);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent18,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -1155,7 +1155,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1168,17 +1168,17 @@ const extensions21 = {
   })
 };
 const parts19 = ["b", "updatable_view"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_updatableView = {
+const updatableViewIdentifier = sql.identifier(...parts19);
+const updatableViewCodecSpec = {
   name: "updatableView",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_,
+  identifier: updatableViewIdentifier,
+  attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_updatableView_updatableView = recordCodec(spec_updatableView);
-const attributes29 = Object.assign(Object.create(null), {
+const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1216,7 +1216,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1226,17 +1226,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_nullTestRecord = {
+const nullTestRecordIdentifier = sql.identifier(...parts20);
+const nullTestRecordCodecSpec = {
   name: "nullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: nullTestRecordIdentifier,
+  attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nullTestRecord_nullTestRecord = recordCodec(spec_nullTestRecord);
-const extensions23 = {
+const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
+const uuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1244,13 +1244,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_uuidArray_uuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const uuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: uuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const edgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1279,7 +1279,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1289,17 +1289,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_edgeCase = {
+const edgeCaseIdentifier = sql.identifier(...parts21);
+const edgeCaseCodecSpec = {
   name: "edgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: edgeCaseIdentifier,
+  attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_edgeCase_edgeCase = recordCodec(spec_edgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1337,7 +1337,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1347,17 +1347,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_leftArm = {
+const leftArmIdentifier = sql.identifier(...parts22);
+const leftArmCodecSpec = {
   name: "leftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: leftArmIdentifier,
+  attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_leftArm_leftArm = recordCodec(spec_leftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const leftArmCodec = recordCodec(leftArmCodecSpec);
+const jwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1404,7 +1404,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1414,17 +1414,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_jwtToken = {
+const jwtTokenIdentifier = sql.identifier(...parts23);
+const jwtTokenCodecSpec = {
   name: "jwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: jwtTokenIdentifier,
+  attributes: jwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_jwtToken_jwtToken = recordCodec(spec_jwtToken);
-const extensions27 = {
+const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1433,13 +1433,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_notNullTimestamp = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sqlIdent24, {
+const notNullTimestampIdentifier = sql.identifier(...parts24);
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const issue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1451,7 +1451,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_notNullTimestamp,
+    codec: notNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1459,7 +1459,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1469,20 +1469,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_issue756 = {
+const issue756Identifier = sql.identifier(...parts25);
+const issue756CodecSpec = {
   name: "issue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: issue756Identifier,
+  attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_issue756_issue756 = recordCodec(spec_issue756);
-const attributes34 = Object.assign(Object.create(null), {
+const issue756Codec = recordCodec(issue756CodecSpec);
+const authPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+    codec: jwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1508,7 +1508,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1520,17 +1520,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_authPayload = {
+const authPayloadIdentifier = sql.identifier(...parts26);
+const authPayloadCodecSpec = {
   name: "authPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: authPayloadIdentifier,
+  attributes: authPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_authPayload_authPayload = recordCodec(spec_authPayload);
-const extensions30 = {
+const authPayloadCodec = recordCodec(authPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1539,16 +1539,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_color = enumCodec({
+const colorCodec = enumCodec({
   name: "color",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1557,16 +1556,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_enumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1575,15 +1574,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_enumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const compoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1604,7 +1603,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1622,7 +1621,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_enumCaps,
+    codec: enumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1631,7 +1630,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_enumWithEmptyString,
+    codec: enumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1657,7 +1656,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1667,17 +1666,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_compoundType = {
+const compoundTypeIdentifier = sql.identifier(...parts30);
+const compoundTypeCodecSpec = {
   name: "compoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: compoundTypeIdentifier,
+  attributes: compoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_compoundType = recordCodec(spec_compoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1688,7 +1687,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1698,7 +1697,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1708,7 +1707,7 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1719,7 +1718,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1729,7 +1728,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1739,7 +1738,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1748,7 +1747,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1757,21 +1756,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1779,7 +1778,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1799,7 +1798,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1809,23 +1808,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1864,7 +1863,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1873,7 +1872,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1881,7 +1880,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1891,17 +1890,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1912,7 +1911,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1920,7 +1919,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1930,7 +1929,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1940,7 +1939,7 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1961,7 +1960,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1971,7 +1970,7 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1992,7 +1991,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2002,7 +2001,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2011,13 +2010,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_email = domainOfCodec(TYPES.text, "email", sqlIdent34, {
+const emailIdentifier = sql.identifier(...parts34);
+const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2026,16 +2025,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_notNullUrl = domainOfCodec(TYPES.varchar, "notNullUrl", sqlIdent35, {
+const notNullUrlIdentifier = sql.identifier(...parts35);
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const wrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_notNullUrl,
+    codec: notNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2043,7 +2042,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2053,17 +2052,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_wrappedUrl = {
+const wrappedUrlIdentifier = sql.identifier(...parts36);
+const wrappedUrlCodecSpec = {
   name: "wrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: wrappedUrlIdentifier,
+  attributes: wrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_wrappedUrl = recordCodec(spec_wrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2086,7 +2085,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2104,7 +2103,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_email,
+    codec: emailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2113,7 +2112,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_wrappedUrl,
+    codec: wrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2168,7 +2167,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2178,20 +2177,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_person = {
+const personIdentifier = sql.identifier(...parts37);
+const personCodecSpec = {
   name: "person",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: personIdentifier,
+  attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_person = recordCodec(spec_person);
-const attributes43 = Object.assign(Object.create(null), {
+const personCodec = recordCodec(personCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2209,7 +2208,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2219,7 +2218,7 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2230,7 +2229,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2238,7 +2237,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2248,7 +2247,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2258,7 +2257,7 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2269,7 +2268,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2277,7 +2276,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2287,7 +2286,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2297,7 +2296,7 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2308,7 +2307,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2316,7 +2315,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2326,7 +2325,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2336,7 +2335,7 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2347,7 +2346,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2355,7 +2354,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2365,7 +2364,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2375,7 +2374,7 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2386,7 +2385,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2394,7 +2393,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_person,
+    codec: personCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2404,7 +2403,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2414,7 +2413,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const colorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2422,13 +2421,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_colorArray = listOfCodec(attributes_c_codec_color, {
-  extensions: extensions43,
+const colorArrayCodec = listOfCodec(colorCodec, {
+  extensions: colorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2437,13 +2436,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2452,13 +2451,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_anotherInt = domainOfCodec(attributes_domain_codec_anInt, "anotherInt", sqlIdent39, {
+const anotherIntIdentifier = sql.identifier(...parts39);
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2467,12 +2466,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_numrange = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2481,12 +2480,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_daterange = rangeOfCodec(TYPES.date, "daterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2495,15 +2494,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2512,7 +2511,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2529,7 +2528,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2539,17 +2538,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_nestedCompoundType = {
+const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const nestedCompoundTypeCodecSpec = {
   name: "nestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: nestedCompoundTypeIdentifier,
+  attributes: nestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_nestedCompoundType = recordCodec(spec_nestedCompoundType);
-const extensions50 = {
+const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2558,13 +2557,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_textArrayDomain = domainOfCodec(registryConfig_pgCodecs_textArray_textArray, "textArrayDomain", sqlIdent44, {
+const textArrayDomainIdentifier = sql.identifier(...parts44);
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2572,7 +2571,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const int8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2580,20 +2579,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_int8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const int8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: int8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_int8ArrayDomain = domainOfCodec(innerCodec_int8Array, "int8ArrayDomain", sqlIdent45, {
+const int8ArrayDomainIdentifier = sql.identifier(...parts45);
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const byteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2601,13 +2600,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_byteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const byteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: byteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const typesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2619,8 +2618,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const typesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2686,7 +2685,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_color,
+    codec: colorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2695,7 +2694,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_colorArray,
+    codec: colorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2704,7 +2703,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2713,7 +2712,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_anotherInt,
+    codec: anotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2722,7 +2721,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_textArray_textArray,
+    codec: textArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2749,7 +2748,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2758,7 +2757,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_numrange,
+    codec: numrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2767,7 +2766,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_daterange,
+    codec: daterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2776,7 +2775,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2839,7 +2838,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+    codec: intervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2857,7 +2856,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2866,7 +2865,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2875,7 +2874,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_compoundType,
+    codec: compoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2884,7 +2883,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_nestedCompoundType,
+    codec: nestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3010,7 +3009,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_textArrayDomain,
+    codec: textArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3019,7 +3018,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_int8ArrayDomain,
+    codec: int8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3037,7 +3036,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_byteaArray,
+    codec: byteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3046,7 +3045,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: typesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3055,7 +3054,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: typesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3063,7 +3062,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3075,17 +3074,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_types = {
+const typesIdentifier = sql.identifier(...parts46);
+const typesCodecSpec = {
   name: "types",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: typesIdentifier,
+  attributes: typesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_types_types = recordCodec(spec_types);
-const extensions55 = {
+const typesCodec = recordCodec(typesCodecSpec);
+const compoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3093,7 +3092,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const jwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3101,7 +3100,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const typesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3109,7 +3108,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const int4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3117,13 +3116,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_int4Array_int4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const int4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: int4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3132,12 +3131,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_floatrange_floatrange = rangeOfCodec(TYPES.float, "floatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3145,13 +3144,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3180,7 +3179,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3190,16 +3189,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3237,7 +3236,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3247,16 +3246,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3303,7 +3302,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3313,16 +3312,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3333,8 +3332,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3346,10 +3345,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3361,10 +3360,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3375,10 +3374,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3390,10 +3389,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3405,10 +3404,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3419,10 +3418,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3433,10 +3432,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3447,10 +3446,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3461,10 +3460,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3475,10 +3474,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3489,10 +3488,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3503,10 +3502,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3518,15 +3517,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3538,15 +3537,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3558,15 +3557,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3578,15 +3577,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3597,15 +3596,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3617,15 +3616,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3636,15 +3635,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3655,15 +3654,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3674,15 +3673,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3693,15 +3692,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3712,15 +3711,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3731,15 +3730,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3750,8 +3749,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3763,7 +3762,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3774,8 +3773,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3787,7 +3786,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3798,8 +3797,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3811,7 +3810,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3822,8 +3821,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3835,7 +3834,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3846,8 +3845,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3859,7 +3858,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3870,8 +3869,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3883,7 +3882,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3894,8 +3893,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3907,7 +3906,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3918,8 +3917,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3931,7 +3930,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3942,8 +3941,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -3955,7 +3954,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3966,8 +3965,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -3979,7 +3978,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3990,8 +3989,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4003,7 +4002,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4014,8 +4013,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4027,7 +4026,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4038,8 +4037,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4051,7 +4050,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4063,8 +4062,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4076,7 +4075,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4087,10 +4086,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4101,10 +4100,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4115,10 +4114,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4130,8 +4129,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4143,7 +4142,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4154,10 +4153,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4168,10 +4167,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4182,10 +4181,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4197,10 +4196,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4211,8 +4210,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4229,7 +4228,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4240,8 +4239,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4258,7 +4257,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4269,8 +4268,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4287,7 +4286,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4298,8 +4297,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4316,7 +4315,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4327,8 +4326,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4345,7 +4344,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4356,10 +4355,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4370,15 +4369,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4389,8 +4388,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4407,7 +4406,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4418,8 +4417,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4436,7 +4435,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4447,10 +4446,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4461,15 +4460,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4480,15 +4479,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_guid_guid
+  codec: guidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4499,10 +4498,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4513,10 +4512,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4527,10 +4526,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4541,10 +4540,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4555,7 +4554,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4572,7 +4571,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4589,7 +4588,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4606,7 +4605,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4623,7 +4622,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4640,7 +4639,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4657,7 +4656,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4671,14 +4670,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4695,7 +4694,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4705,7 +4704,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4714,7 +4713,7 @@ const extensions137 = {
   },
   tags: {
     omit: "create,update,delete,all,order,filter",
-    behavior: extensions14.tags.behavior
+    behavior: extensions12.tags.behavior
   }
 };
 const uniques11 = [{
@@ -4729,14 +4728,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4753,7 +4752,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4776,14 +4775,14 @@ const registryConfig_pgResources_person_secret_person_secret = {
   executor: executor_mainPgExecutor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_personSecret_personSecret.sqlType,
-  codec: registryConfig_pgCodecs_personSecret_personSecret,
+  from: personSecretCodec.sqlType,
+  codec: personSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4800,7 +4799,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4821,14 +4820,14 @@ const registryConfig_pgResources_compound_key_compound_key = {
   executor: executor_mainPgExecutor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_compoundKey_compoundKey.sqlType,
-  codec: registryConfig_pgCodecs_compoundKey_compoundKey,
+  from: compoundKeyCodec.sqlType,
+  codec: compoundKeyCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions141
+  extensions: extensions128
 };
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4845,7 +4844,7 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4862,7 +4861,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4884,7 +4883,7 @@ const uniques18 = [{
     })
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4901,7 +4900,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4912,21 +4911,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_edgeCase_edgeCase
+  codec: edgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_return_table_without_grants = {
   name: "return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4944,7 +4943,7 @@ const options_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4955,13 +4954,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_textArray_textArray
+  codec: textArrayCodec
 }, {
   name: "d",
   required: true,
@@ -4973,7 +4972,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4983,7 +4982,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -5011,20 +5010,20 @@ const registryConfig_pgResources_left_arm_left_arm = {
   executor: executor_mainPgExecutor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_leftArm_leftArm.sqlType,
-  codec: registryConfig_pgCodecs_leftArm_leftArm,
+  from: leftArmCodec.sqlType,
+  codec: leftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_authenticate_fail = {
   name: "authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5042,7 +5041,7 @@ const options_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5058,20 +5057,20 @@ const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_jwtToken_jwtToken.sqlType,
-  codec: registryConfig_pgCodecs_jwtToken_jwtToken,
+  from: jwtTokenCodec.sqlType,
+  codec: jwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_authenticate = {
   name: "authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5104,7 +5103,7 @@ const options_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5125,26 +5124,26 @@ const registryConfig_pgResources_issue756_issue756 = {
   executor: executor_mainPgExecutor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_issue756_issue756.sqlType,
-  codec: registryConfig_pgCodecs_issue756_issue756,
+  from: issue756Codec.sqlType,
+  codec: issue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_left_arm_identity = {
   name: "left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_leftArm_leftArm,
+    codec: leftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5167,12 +5166,12 @@ const options_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_issue756_mutation = {
   name: "issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5191,12 +5190,12 @@ const options_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_issue756_set_mutation = {
   name: "issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5215,12 +5214,12 @@ const options_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_authenticate_many = {
   name: "authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5254,12 +5253,12 @@ const options_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_authenticate_payload = {
   name: "authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5292,7 +5291,7 @@ const options_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5309,14 +5308,14 @@ const resourceConfig_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_authPayload_authPayload.sqlType,
-  codec: registryConfig_pgCodecs_authPayload_authPayload,
+  from: authPayloadCodec.sqlType,
+  codec: authPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5327,8 +5326,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5348,7 +5347,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5358,9 +5357,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5371,8 +5370,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5392,7 +5391,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_int4Array_int4Array
+  codec: int4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5402,9 +5401,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_floatrange_floatrange
+  codec: floatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5415,15 +5414,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_compoundType
+  codec: compoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5434,15 +5433,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5453,15 +5452,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5472,15 +5471,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5493,20 +5492,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5519,20 +5518,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5543,15 +5542,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5562,15 +5561,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5581,13 +5580,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5599,7 +5598,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5610,13 +5609,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5628,7 +5627,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5639,13 +5638,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5657,7 +5656,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5668,8 +5667,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5686,7 +5685,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5707,20 +5706,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_compound_type_set_query = {
   name: "compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5738,7 +5737,7 @@ const options_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5754,26 +5753,26 @@ const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_compoundType.sqlType,
-  codec: attributes_o2_codec_compoundType,
+  from: compoundTypeCodec.sqlType,
+  codec: compoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_compound_type_mutation = {
   name: "compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5791,18 +5790,18 @@ const options_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_compound_type_query = {
   name: "compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5820,18 +5819,18 @@ const options_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_compound_type_set_mutation = {
   name: "compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5849,12 +5848,12 @@ const options_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_table_mutation = {
   name: "table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5878,12 +5877,12 @@ const options_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_table_query = {
   name: "table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5907,18 +5906,18 @@ const options_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5942,18 +5941,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -5971,18 +5970,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6000,18 +5999,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_compound_type_array_mutation = {
   name: "compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6029,18 +6028,18 @@ const options_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_compound_type_array_query = {
   name: "compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6058,23 +6057,23 @@ const options_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_compoundType
+    codec: compoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6092,18 +6091,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6120,7 +6119,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6135,15 +6134,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6155,15 +6154,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6174,15 +6173,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6194,20 +6193,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6218,20 +6217,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6243,20 +6242,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_email
+  codec: emailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6267,15 +6266,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6286,8 +6285,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6299,7 +6298,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6310,8 +6309,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6323,7 +6322,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6334,8 +6333,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6347,7 +6346,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6358,8 +6357,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6371,7 +6370,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6382,13 +6381,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_person
+  codec: personCodec
 }, {
   name: "a",
   required: true,
@@ -6401,18 +6400,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_person_first_post = {
   name: "person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6429,7 +6428,7 @@ const options_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6457,20 +6456,20 @@ const registryConfig_pgResources_person_person = {
   executor: executor_mainPgExecutor,
   name: "person",
   identifier: "main.c.person",
-  from: attributes_person_codec_person.sqlType,
-  codec: attributes_person_codec_person,
+  from: personCodec.sqlType,
+  codec: personCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_badly_behaved_function = {
   name: "badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6490,12 +6489,12 @@ const options_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_func_out_table = {
   name: "func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6514,12 +6513,12 @@ const options_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_func_out_table_setof = {
   name: "func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6538,12 +6537,12 @@ const options_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_mutation_out_table = {
   name: "mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6562,12 +6561,12 @@ const options_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_mutation_out_table_setof = {
   name: "mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6586,12 +6585,12 @@ const options_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_table_set_mutation = {
   name: "table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6610,12 +6609,12 @@ const options_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_table_set_query = {
   name: "table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6636,12 +6635,12 @@ const options_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_table_set_query_plpgsql = {
   name: "table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6660,18 +6659,18 @@ const options_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_person_computed_first_arg_inout = {
   name: "person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6690,18 +6689,18 @@ const options_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_person_friends = {
   name: "person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6719,7 +6718,7 @@ const options_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6727,7 +6726,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6742,20 +6741,20 @@ const registryConfig_pgResources_types_types = {
   executor: executor_mainPgExecutor,
   name: "types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_types_types.sqlType,
-  codec: registryConfig_pgCodecs_types_types,
+  from: typesCodec.sqlType,
+  codec: typesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_type_function_connection = {
   name: "type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6774,12 +6773,12 @@ const options_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_type_function_connection_mutation = {
   name: "type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6798,12 +6797,12 @@ const options_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_type_function = {
   name: "type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6827,12 +6826,12 @@ const options_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_type_function_mutation = {
   name: "type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6856,18 +6855,18 @@ const options_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_person_type_function_connection = {
   name: "person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6885,18 +6884,18 @@ const options_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_person_type_function = {
   name: "person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }, {
     name: "id",
     required: true,
@@ -6919,12 +6918,12 @@ const options_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_type_function_list = {
   name: "type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6943,12 +6942,12 @@ const options_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_type_function_list_mutation = {
   name: "type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6967,18 +6966,18 @@ const options_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_person_type_function_list = {
   name: "person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_person
+    codec: personCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7015,61 +7014,61 @@ const registry = makeRegistry({
     FuncReturnsTableMultiColRecord: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
     MutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
     MutationReturnsTableMultiColRecord: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
-    guid: registryConfig_pgCodecs_guid_guid,
+    guid: guidCodec,
     varchar: TYPES.varchar,
-    intervalArray: registryConfig_pgCodecs_intervalArray_intervalArray,
-    textArray: registryConfig_pgCodecs_textArray_textArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    myTable: registryConfig_pgCodecs_myTable_myTable,
-    personSecret: registryConfig_pgCodecs_personSecret_personSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    compoundKey: registryConfig_pgCodecs_compoundKey_compoundKey,
+    intervalArray: intervalArrayCodec,
+    textArray: textArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    myTable: myTableCodec,
+    personSecret: personSecretCodec,
+    viewTable: viewTableCodec,
+    compoundKey: compoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    updatableView: registryConfig_pgCodecs_updatableView_updatableView,
-    nullTestRecord: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
-    uuidArray: registryConfig_pgCodecs_uuidArray_uuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    updatableView: updatableViewCodec,
+    nullTestRecord: nullTestRecordCodec,
+    uuidArray: uuidArrayCodec,
     uuid: TYPES.uuid,
-    edgeCase: registryConfig_pgCodecs_edgeCase_edgeCase,
+    edgeCase: edgeCaseCodec,
     int2: TYPES.int2,
-    leftArm: registryConfig_pgCodecs_leftArm_leftArm,
+    leftArm: leftArmCodec,
     float8: TYPES.float,
-    jwtToken: registryConfig_pgCodecs_jwtToken_jwtToken,
+    jwtToken: jwtTokenCodec,
     numeric: TYPES.numeric,
-    issue756: registryConfig_pgCodecs_issue756_issue756,
-    notNullTimestamp: attributes_ts_codec_notNullTimestamp,
+    issue756: issue756Codec,
+    notNullTimestamp: notNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    authPayload: registryConfig_pgCodecs_authPayload_authPayload,
+    authPayload: authPayloadCodec,
     FuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
-    compoundType: attributes_o2_codec_compoundType,
-    color: attributes_c_codec_color,
-    enumCaps: attributes_e_codec_enumCaps,
-    enumWithEmptyString: attributes_f_codec_enumWithEmptyString,
+    compoundType: compoundTypeCodec,
+    color: colorCodec,
+    enumCaps: enumCapsCodec,
+    enumWithEmptyString: enumWithEmptyStringCodec,
     MutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
     QueryOutputTwoRowsRecord: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     PersonComputedOutOutRecord: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
     PersonComputedInoutOutRecord: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
     PersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
-    person: attributes_person_codec_person,
-    email: attributes_email_codec_email,
-    wrappedUrl: attributes_site_codec_wrappedUrl,
-    notNullUrl: attributes_url_codec_notNullUrl,
+    person: personCodec,
+    email: emailCodec,
+    wrappedUrl: wrappedUrlCodec,
+    notNullUrl: notNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7080,18 +7079,18 @@ const registry = makeRegistry({
     MutationOutComplexRecord: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
     MutationOutComplexSetofRecord: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
     PersonComputedComplexRecord: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
-    types: registryConfig_pgCodecs_types_types,
-    colorArray: attributes_enum_array_codec_colorArray,
-    anInt: attributes_domain_codec_anInt,
-    anotherInt: attributes_domain2_codec_anotherInt,
-    numrange: attributes_nullable_range_codec_numrange,
-    daterange: attributes_daterange_codec_daterange,
+    types: typesCodec,
+    colorArray: colorArrayCodec,
+    anInt: anIntCodec,
+    anotherInt: anotherIntCodec,
+    numrange: numrangeCodec,
+    daterange: daterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    nestedCompoundType: attributes_nested_compound_type_codec_nestedCompoundType,
+    nestedCompoundType: nestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7101,38 +7100,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    textArrayDomain: attributes_text_array_domain_codec_textArrayDomain,
-    int8ArrayDomain: attributes_int8_array_domain_codec_int8ArrayDomain,
+    textArrayDomain: textArrayDomainCodec,
+    int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    byteaArray: attributes_bytea_array_codec_byteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    byteaArray: byteaArrayCodec,
+    ltree: typesAttributes_ltree_codec_ltree,
+    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    compoundTypeArray: listOfCodec(attributes_o2_codec_compoundType, {
-      extensions: extensions55,
+    compoundTypeArray: listOfCodec(compoundTypeCodec, {
+      extensions: compoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
-    jwtTokenArray: listOfCodec(registryConfig_pgCodecs_jwtToken_jwtToken, {
-      extensions: extensions56,
+    jwtTokenArray: listOfCodec(jwtTokenCodec, {
+      extensions: jwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
-    typesArray: listOfCodec(registryConfig_pgCodecs_types_types, {
-      extensions: extensions57,
+    typesArray: listOfCodec(typesCodec, {
+      extensions: typesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
     }),
-    int4Array: registryConfig_pgCodecs_int4Array_int4Array,
-    floatrange: registryConfig_pgCodecs_floatrange_floatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    int8Array: innerCodec_int8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    int4Array: int4ArrayCodec,
+    floatrange: floatrangeCodec,
+    postArray: postArrayCodec,
+    int8Array: int8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7140,14 +7139,14 @@ const registry = makeRegistry({
       name: "current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     func_out: {
@@ -7160,7 +7159,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     func_out_setof: {
@@ -7173,7 +7172,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     func_out_unnamed: {
@@ -7186,7 +7185,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     mutation_out: {
@@ -7199,7 +7198,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     mutation_out_setof: {
@@ -7212,7 +7211,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     mutation_out_unnamed: {
@@ -7225,7 +7224,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     no_args_mutation: {
@@ -7238,7 +7237,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     no_args_query: {
@@ -7251,7 +7250,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7264,7 +7263,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7277,7 +7276,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7290,7 +7289,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7303,7 +7302,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     func_in_out: {
@@ -7316,7 +7315,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     func_returns_table_one_col: {
@@ -7329,7 +7328,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     mutation_in_out: {
@@ -7342,7 +7341,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     mutation_returns_table_one_col: {
@@ -7355,7 +7354,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7368,7 +7367,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7381,7 +7380,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     json_identity: {
@@ -7394,7 +7393,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     json_identity_mutation: {
@@ -7407,7 +7406,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     jsonb_identity: {
@@ -7420,7 +7419,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     jsonb_identity_mutation: {
@@ -7433,7 +7432,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
@@ -7446,7 +7445,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
@@ -7459,7 +7458,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7472,7 +7471,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7485,7 +7484,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7498,7 +7497,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7511,7 +7510,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7524,7 +7523,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7537,7 +7536,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7550,7 +7549,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7563,7 +7562,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7576,7 +7575,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
@@ -7589,7 +7588,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     mult_2: {
@@ -7602,7 +7601,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     mult_3: {
@@ -7615,7 +7614,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     mult_4: {
@@ -7628,7 +7627,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     func_in_inout: {
@@ -7641,7 +7640,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     func_out_out: {
@@ -7654,7 +7653,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     func_out_out_setof: {
@@ -7667,7 +7666,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     func_out_out_unnamed: {
@@ -7680,7 +7679,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     mutation_in_inout: {
@@ -7693,7 +7692,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     mutation_out_out: {
@@ -7706,7 +7705,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     mutation_out_out_setof: {
@@ -7719,7 +7718,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     mutation_out_out_unnamed: {
@@ -7732,7 +7731,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     search_test_summaries: {
@@ -7745,7 +7744,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7758,7 +7757,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7771,7 +7770,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7784,7 +7783,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7797,7 +7796,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7810,7 +7809,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
@@ -7823,7 +7822,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     func_returns_table_multi_col: {
@@ -7836,7 +7835,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     int_set_mutation: {
@@ -7849,7 +7848,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     int_set_query: {
@@ -7862,7 +7861,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
@@ -7875,7 +7874,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     mutation_returns_table_multi_col: {
@@ -7888,7 +7887,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     guid_fn: {
@@ -7898,10 +7897,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_guid_guid,
+      codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7911,10 +7910,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7924,10 +7923,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7937,10 +7936,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -7950,180 +7949,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
       executor: executor_mainPgExecutor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_myTable_myTable.sqlType,
-      codec: registryConfig_pgCodecs_myTable_myTable,
+      from: myTableCodec.sqlType,
+      codec: myTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions142
+      extensions: extensions129
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_updatableView_updatableView.sqlType,
-      codec: registryConfig_pgCodecs_updatableView_updatableView,
+      from: updatableViewCodec.sqlType,
+      codec: updatableViewCodec,
       uniques: uniques18,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions144
+      extensions: extensions131
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_nullTestRecord_nullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_nullTestRecord_nullTestRecord,
+      from: nullTestRecordCodec.sqlType,
+      codec: nullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8135,7 +8134,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
@@ -8146,22 +8145,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_uuidArray_uuidArray,
+      codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     edge_case: {
       executor: executor_mainPgExecutor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_edgeCase_edgeCase.sqlType,
-      codec: registryConfig_pgCodecs_edgeCase_edgeCase,
+      from: edgeCaseCodec.sqlType,
+      codec: edgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
     authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
@@ -8182,7 +8181,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     types_query: {
@@ -8195,7 +8194,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     compound_type_computed_field: {
@@ -8208,7 +8207,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8221,7 +8220,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8231,10 +8230,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_intervalArray_intervalArray,
+      codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8244,10 +8243,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_textArray_textArray,
+      codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8260,7 +8259,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8273,7 +8272,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     func_out_out_compound_type: {
@@ -8286,7 +8285,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     mutation_out_out_compound_type: {
@@ -8299,7 +8298,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8312,7 +8311,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8325,7 +8324,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8338,7 +8337,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     query_output_two_rows: {
@@ -8351,7 +8350,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8378,7 +8377,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     person_first_name: {
@@ -8391,7 +8390,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     person_computed_out_out: {
@@ -8404,7 +8403,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     person_computed_inout: {
@@ -8417,7 +8416,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     person_computed_inout_out: {
@@ -8430,7 +8429,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     person_exists: {
@@ -8443,7 +8442,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     person_computed_first_arg_inout_out: {
@@ -8456,7 +8455,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     func_out_complex: {
@@ -8469,7 +8468,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     func_out_complex_setof: {
@@ -8482,7 +8481,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     mutation_out_complex: {
@@ -8495,7 +8494,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     mutation_out_complex_setof: {
@@ -8508,7 +8507,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     person_computed_complex: {
@@ -8521,7 +8520,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
@@ -8550,7 +8549,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8565,7 +8564,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8582,7 +8581,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       personByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8597,7 +8596,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8612,7 +8611,7 @@ const registry = makeRegistry({
         }
       },
       typesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_types_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8629,7 +8628,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       compoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8646,7 +8645,7 @@ const registry = makeRegistry({
     }),
     authPayload: Object.assign(Object.create(null), {
       personByMyId: {
-        localCodec: registryConfig_pgCodecs_authPayload_authPayload,
+        localCodec: authPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8663,7 +8662,7 @@ const registry = makeRegistry({
     }),
     types: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8678,7 +8677,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_types_types,
+        localCodec: typesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8695,7 +8694,7 @@ const registry = makeRegistry({
     }),
     compoundKey: Object.assign(Object.create(null), {
       personByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8710,7 +8709,7 @@ const registry = makeRegistry({
         }
       },
       personByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8725,7 +8724,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8740,7 +8739,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_compoundKey_compoundKey,
+        localCodec: compoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8757,7 +8756,7 @@ const registry = makeRegistry({
     }),
     leftArm: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_leftArm_leftArm,
+        localCodec: leftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8774,7 +8773,7 @@ const registry = makeRegistry({
     }),
     person: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8789,7 +8788,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8804,7 +8803,7 @@ const registry = makeRegistry({
         }
       },
       personSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_person_secret_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8821,7 +8820,7 @@ const registry = makeRegistry({
         }
       },
       leftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_left_arm_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8836,7 +8835,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8851,7 +8850,7 @@ const registry = makeRegistry({
         }
       },
       compoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_person,
+        localCodec: personCodec,
         remoteResourceOptions: registryConfig_pgResources_compound_key_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8868,7 +8867,7 @@ const registry = makeRegistry({
     }),
     personSecret: Object.assign(Object.create(null), {
       personByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_personSecret_personSecret,
+        localCodec: personSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_person_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -10695,7 +10694,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -10707,7 +10706,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -10940,7 +10939,7 @@ function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11044,7 +11043,7 @@ const resource_table_queryPgResource = registry.pgResources["table_query"];
 const argDetailsSimple38 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11096,7 +11095,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12395,7 +12394,7 @@ const resource_person_computed_inout_outPgResource = registry.pgResources["perso
 const argDetailsSimple55 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_email,
+  pgCodec: emailCodec,
   required: true,
   fetcher: null
 }];
@@ -13522,7 +13521,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple73 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15535,7 +15534,7 @@ function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_guid_guid,
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
@@ -15688,7 +15687,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_textArray_textArray,
+  pgCodec: textArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -15871,7 +15870,7 @@ function Mutation_authenticate_input_applyPlan(_, $object) {
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_leftArm_leftArm,
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16176,7 +16175,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_int4Array_int4Array,
+  pgCodec: int4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16188,7 +16187,7 @@ const argDetailsSimple114 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_floatrange_floatrange,
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16298,7 +16297,7 @@ function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16353,7 +16352,7 @@ function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16463,7 +16462,7 @@ function Mutation_tableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -16524,7 +16523,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16579,7 +16578,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_compoundType,
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16634,7 +16633,7 @@ function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -31497,7 +31496,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -31513,7 +31512,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_types_types.attributes[attributeName];
+          const attribute = typesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -32801,7 +32800,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
             }
           });
         }
@@ -32824,7 +32823,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -32847,7 +32846,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -32870,7 +32869,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -32893,7 +32892,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -32916,7 +32915,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -32939,7 +32938,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -32962,7 +32961,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
             }
           });
         }
@@ -32985,7 +32984,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
             }
           });
         }
@@ -33008,7 +33007,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
             }
           });
         }
@@ -33031,7 +33030,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -33054,7 +33053,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
             }
           });
         }
@@ -33077,7 +33076,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
             }
           });
         }
@@ -33100,7 +33099,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -33123,7 +33122,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
             }
           });
         }
@@ -33146,7 +33145,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
             }
           });
         }
@@ -33169,7 +33168,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
             }
           });
         }
@@ -33192,7 +33191,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
             }
           });
         }
@@ -33215,7 +33214,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -33238,7 +33237,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -33261,7 +33260,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
             }
           });
         }
@@ -33284,7 +33283,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
             }
           });
         }
@@ -33307,7 +33306,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -33330,7 +33329,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
             }
           });
         }
@@ -33353,7 +33352,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
             }
           });
         }
@@ -33376,7 +33375,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
             }
           });
         }
@@ -33399,7 +33398,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
             }
           });
         }
@@ -33422,7 +33421,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -33445,7 +33444,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -33468,7 +33467,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -33491,7 +33490,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
             }
           });
         }
@@ -33514,7 +33513,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -33537,7 +33536,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
             }
           });
         }
@@ -33560,7 +33559,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -33583,7 +33582,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -33606,7 +33605,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -33629,7 +33628,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -33652,7 +33651,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -33675,7 +33674,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -33698,7 +33697,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -33721,7 +33720,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -33744,7 +33743,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -33767,7 +33766,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33790,7 +33789,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33813,7 +33812,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33836,7 +33835,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -33859,7 +33858,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
             }
           });
         }
@@ -34004,7 +34003,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34020,7 +34019,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_person.attributes[attributeName];
+          const attribute = personCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34435,7 +34434,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34451,7 +34450,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34617,7 +34616,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -34640,7 +34639,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -34663,7 +34662,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -34686,7 +34685,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -34709,7 +34708,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
             }
           });
         }
@@ -34732,7 +34731,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
             }
           });
         }
@@ -34936,7 +34935,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -34959,7 +34958,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34982,7 +34981,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -35050,7 +35049,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35066,7 +35065,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_compoundKey_compoundKey.attributes[attributeName];
+          const attribute = compoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35198,7 +35197,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -35221,7 +35220,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -35244,7 +35243,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -35658,7 +35657,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
             }
           });
         }
@@ -35681,7 +35680,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35704,7 +35703,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
             }
           });
         }
@@ -35727,7 +35726,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
             }
           });
         }
@@ -35750,7 +35749,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
             }
           });
         }
@@ -35773,7 +35772,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
             }
           });
         }
@@ -35796,7 +35795,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
             }
           });
         }
@@ -35819,7 +35818,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35842,7 +35841,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35865,7 +35864,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -35888,7 +35887,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
             }
           });
         }
@@ -36000,7 +35999,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -36034,7 +36033,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36050,7 +36049,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36114,7 +36113,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -36148,7 +36147,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36164,7 +36163,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36228,7 +36227,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -36262,7 +36261,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36278,7 +36277,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36342,7 +36341,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -36376,7 +36375,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36392,7 +36391,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36456,7 +36455,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -36490,7 +36489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36506,7 +36505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36570,7 +36569,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -36604,7 +36603,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36620,7 +36619,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36718,7 +36717,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -36741,7 +36740,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -36857,7 +36856,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -36880,7 +36879,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -37042,7 +37041,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -37065,7 +37064,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -37088,7 +37087,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -37122,7 +37121,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37138,7 +37137,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_myTable_myTable.attributes[attributeName];
+          const attribute = myTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37236,7 +37235,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
             }
           });
         }
@@ -37259,7 +37258,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -37293,7 +37292,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37309,7 +37308,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_personSecret_personSecret.attributes[attributeName];
+          const attribute = personSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37407,7 +37406,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -37430,7 +37429,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -37464,7 +37463,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37480,7 +37479,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37612,7 +37611,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -37635,7 +37634,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -37658,7 +37657,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -37692,7 +37691,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37708,7 +37707,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37874,7 +37873,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -37897,7 +37896,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -37920,7 +37919,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -37943,7 +37942,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -37977,7 +37976,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37993,7 +37992,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38159,7 +38158,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -38182,7 +38181,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -38205,7 +38204,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -38228,7 +38227,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -38427,7 +38426,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -38450,7 +38449,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -38473,7 +38472,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -38496,7 +38495,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -38530,7 +38529,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38546,7 +38545,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_nullTestRecord_nullTestRecord.attributes[attributeName];
+          const attribute = nullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38712,7 +38711,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -38735,7 +38734,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38758,7 +38757,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38781,7 +38780,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38977,7 +38976,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -39000,7 +38999,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -39023,7 +39022,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -39057,7 +39056,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39073,7 +39072,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_leftArm_leftArm.attributes[attributeName];
+          const attribute = leftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39239,7 +39238,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -39262,7 +39261,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -39285,7 +39284,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -39308,7 +39307,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -39342,7 +39341,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39358,7 +39357,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_issue756_issue756.attributes[attributeName];
+          const attribute = issue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39456,7 +39455,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
             }
           });
         }
@@ -39479,7 +39478,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -45,28 +42,27 @@ const registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord = recordCodec({
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = recordCodec({
   name: "FuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -75,29 +71,28 @@ const registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = recordCodec({
   name: "FuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -106,29 +101,28 @@ const registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord = 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = recordCodec({
   name: "MutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -137,29 +131,28 @@ const registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord = recordCodec({
   name: "MutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -168,29 +161,28 @@ const registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord = recordCodec({
   name: "MutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -199,29 +191,28 @@ const registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord = recordCodec({
   name: "SearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -230,37 +221,36 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "FuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -269,29 +259,28 @@ const registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord = recordCodec({
   name: "FuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -300,37 +289,36 @@ const registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMul
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "MutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -339,29 +327,28 @@ const registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutU
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord = recordCodec({
   name: "MutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -371,8 +358,7 @@ const registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturns
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const guidIdentifier = sql.identifier(...["b", "guid"]);
-const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
+const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -384,30 +370,28 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", guidIdentifier, {
   },
   notNull: false
 });
-const intervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const intervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: intervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "intervalArray"
 });
-const textArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const textArrayCodec = listOfCodec(TYPES.text, {
-  extensions: textArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "textArray"
@@ -423,26 +407,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -454,26 +434,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -485,26 +461,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -516,26 +488,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -547,26 +515,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -578,26 +542,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -618,26 +578,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -667,26 +623,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -707,26 +659,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -756,45 +704,21 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
-  executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
   },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions12 = {
   isTableLike: true,
@@ -808,17 +732,33 @@ const extensions12 = {
     behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
   })
 };
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
-  attributes: uniqueForeignKeyAttributes,
+  identifier: sql.identifier("a", "unique_foreign_key"),
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const myTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -839,26 +779,22 @@ const myTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const myTableIdentifier = sql.identifier(...parts13);
-const myTableCodecSpec = {
+const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: myTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: myTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const myTableCodec = recordCodec(myTableCodecSpec);
+});
 const personSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -881,28 +817,24 @@ const personSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const personSecretIdentifier = sql.identifier(...parts14);
-const personSecretCodecSpec = {
+const personSecretCodec = recordCodec({
   name: "personSecret",
-  identifier: personSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: personSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const personSecretCodec = recordCodec(personSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -932,26 +864,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const compoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -981,26 +909,22 @@ const compoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["c", "compound_key"];
-const compoundKeyIdentifier = sql.identifier(...parts16);
-const compoundKeyCodecSpec = {
+const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: compoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: compoundKeyAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const compoundKeyCodec = recordCodec(compoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1039,26 +963,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts17);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1097,26 +1017,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts18);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const updatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -1155,29 +1071,25 @@ const updatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  })
-};
-const parts19 = ["b", "updatable_view"];
-const updatableViewIdentifier = sql.identifier(...parts19);
-const updatableViewCodecSpec = {
+const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: updatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: updatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x",
+      unique: "x|@behavior -single -update -delete"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const updatableViewCodec = recordCodec(updatableViewCodecSpec);
+});
 const nullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1216,36 +1128,31 @@ const nullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const nullTestRecordIdentifier = sql.identifier(...parts20);
-const nullTestRecordCodecSpec = {
+const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: nullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: nullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const nullTestRecordCodec = recordCodec(nullTestRecordCodecSpec);
-const uuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: uuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "uuidArray"
@@ -1279,26 +1186,22 @@ const edgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const edgeCaseIdentifier = sql.identifier(...parts21);
-const edgeCaseCodecSpec = {
+const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: edgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: edgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const edgeCaseCodec = recordCodec(edgeCaseCodecSpec);
+});
 const leftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1337,106 +1240,94 @@ const leftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const leftArmIdentifier = sql.identifier(...parts22);
-const leftArmCodecSpec = {
+const leftArmCodec = recordCodec({
   name: "leftArm",
-  identifier: leftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: leftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const leftArmCodec = recordCodec(leftArmCodecSpec);
-const jwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const jwtTokenIdentifier = sql.identifier(...parts23);
-const jwtTokenCodecSpec = {
+const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: jwtTokenIdentifier,
-  attributes: jwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const jwtTokenCodec = recordCodec(jwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const notNullTimestampIdentifier = sql.identifier(...parts24);
-const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", notNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const issue756Attributes = Object.assign(Object.create(null), {
@@ -1459,245 +1350,220 @@ const issue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const issue756Identifier = sql.identifier(...parts25);
-const issue756CodecSpec = {
+const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: issue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: issue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const issue756Codec = recordCodec(issue756CodecSpec);
-const authPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: jwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const authPayloadIdentifier = sql.identifier(...parts26);
-const authPayloadCodecSpec = {
+const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: authPayloadIdentifier,
-  attributes: authPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: jwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const authPayloadCodec = recordCodec(authPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const colorCodec = enumCodec({
   name: "color",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const enumCapsCodec = enumCodec({
   name: "enumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const enumWithEmptyStringCodec = enumCodec({
   name: "enumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const compoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: enumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: enumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const compoundTypeIdentifier = sql.identifier(...parts30);
-const compoundTypeCodecSpec = {
+const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: compoundTypeIdentifier,
-  attributes: compoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: enumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: enumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const compoundTypeCodec = recordCodec(compoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1706,29 +1572,28 @@ const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTyp
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord = recordCodec({
   name: "MutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1738,88 +1603,77 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1880,56 +1734,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: leftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1938,29 +1787,28 @@ const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord = recordCodec({
   name: "PersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1969,29 +1817,28 @@ const registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord = recordCodec({
   name: "PersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2001,67 +1848,56 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const emailIdentifier = sql.identifier(...parts34);
-const emailCodec = domainOfCodec(TYPES.text, "email", emailIdentifier, {
+const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const notNullUrlIdentifier = sql.identifier(...parts35);
-const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", notNullUrlIdentifier, {
+const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const wrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: notNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const wrappedUrlIdentifier = sql.identifier(...parts36);
-const wrappedUrlCodecSpec = {
+const wrappedUrlCodec = recordCodec({
   name: "wrappedUrl",
-  identifier: wrappedUrlIdentifier,
-  attributes: wrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: notNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const wrappedUrlCodec = recordCodec(wrappedUrlCodecSpec);
+});
 const personAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2167,48 +2003,43 @@ const personAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const personIdentifier = sql.identifier(...parts37);
-const personCodecSpec = {
+const personCodec = recordCodec({
   name: "person",
-  identifier: personIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: personAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const personCodec = recordCodec(personCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2217,37 +2048,36 @@ const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonCompute
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = recordCodec({
   name: "FuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2256,37 +2086,36 @@ const registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord = record
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord = recordCodec({
   name: "FuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2295,37 +2124,36 @@ const registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord = recordCodec({
   name: "MutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2334,37 +2162,36 @@ const registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord = recordCodec({
   name: "MutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2373,37 +2200,36 @@ const registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSe
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: compoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: personCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord = recordCodec({
   name: "PersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: compoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: personCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2413,195 +2239,166 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const colorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const colorArrayCodec = listOfCodec(colorCodec, {
-  extensions: colorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "colorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const anotherIntIdentifier = sql.identifier(...parts39);
-const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", anotherIntIdentifier, {
+const anotherIntCodec = domainOfCodec(anIntCodec, "anotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sqlIdent5, {
+const numrangeCodec = rangeOfCodec(TYPES.numeric, "numrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const nestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const nestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const nestedCompoundTypeCodecSpec = {
+const daterangeCodec = rangeOfCodec(TYPES.date, "daterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const nestedCompoundTypeCodec = recordCodec({
   name: "nestedCompoundType",
-  identifier: nestedCompoundTypeIdentifier,
-  attributes: nestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const nestedCompoundTypeCodec = recordCodec(nestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const textArrayDomainIdentifier = sql.identifier(...parts44);
-const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", textArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const int8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const int8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: int8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const int8ArrayDomainIdentifier = sql.identifier(...parts45);
-const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", int8ArrayDomainIdentifier, {
+const int8ArrayDomainCodec = domainOfCodec(int8ArrayCodec, "int8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const byteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const byteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: byteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "byteaArray"
@@ -3073,1496 +2870,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const typesIdentifier = sql.identifier(...parts46);
-const typesCodecSpec = {
+const typesCodec = recordCodec({
   name: "types",
-  identifier: typesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: typesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const typesCodec = recordCodec(typesCodecSpec);
-const compoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const jwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const typesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const int4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const int4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: int4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "int4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sqlIdent8, {
+const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: guidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4571,15 +2986,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4588,15 +2994,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4605,15 +3002,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4622,15 +3010,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4639,15 +3018,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4656,93 +3026,53 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter",
-    behavior: extensions12.tags.behavior
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter",
+      behavior: extensions12.tags.behavior
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4752,17 +3082,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4780,16 +3099,17 @@ const registryConfig_pgResources_person_secret_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4799,15 +3119,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques15 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4825,16 +3136,15 @@ const registryConfig_pgResources_compound_key_compound_key = {
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions128
-};
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques16 = [{
   isPrimary: true,
@@ -4844,15 +3154,6 @@ const uniques16 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques17 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4861,37 +3162,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x",
-    unique: "x|@behavior -single -update -delete"
-  }
-};
-const uniques18 = [{
-  isPrimary: false,
-  attributes: ["x"],
-  description: undefined,
-  extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
-  }
-}];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4900,97 +3170,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: edgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_return_table_without_grants = {
-  name: "return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: textArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5015,103 +3197,39 @@ const registryConfig_pgResources_left_arm_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_authenticate_fail = {
-  name: "authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
   from: jwtTokenCodec.sqlType,
   codec: jwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_authenticate = {
-  name: "authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5129,571 +3247,35 @@ const registryConfig_pgResources_issue756_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_left_arm_identity = {
-  name: "left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: leftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_issue756_mutation = {
-  name: "issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_issue756_set_mutation = {
-  name: "issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_authenticate_many = {
-  name: "authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_authenticate_payload = {
-  name: "authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "auth_payload",
-  identifier: "main.b.auth_payload",
-  from: authPayloadCodec.sqlType,
-  codec: authPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: int4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: floatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: compoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5711,732 +3293,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_compound_type_set_query = {
-  name: "compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
   executor: executor_mainPgExecutor,
   name: "compound_type",
   identifier: "main.c.compound_type",
   from: compoundTypeCodec.sqlType,
   codec: compoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_compound_type_mutation = {
-  name: "compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_compound_type_query = {
-  name: "compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_compound_type_set_mutation = {
-  name: "compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_table_mutation = {
-  name: "table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_table_query = {
-  name: "table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_compound_type_array_mutation = {
-  name: "compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_compound_type_array_query = {
-  name: "compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: compoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: emailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["queryField -mutationField -typeField", "-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-queryField -mutationField typeField", "-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: personCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_person_first_post = {
-  name: "person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6461,274 +3374,26 @@ const registryConfig_pgResources_person_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_badly_behaved_function = {
-  name: "badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_func_out_table = {
-  name: "func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_func_out_table_setof = {
-  name: "func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_mutation_out_table = {
-  name: "mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_mutation_out_table_setof = {
-  name: "mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_table_set_mutation = {
-  name: "table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_table_set_query = {
-  name: "table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_table_set_query_plpgsql = {
-  name: "table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_person_computed_first_arg_inout = {
-  name: "person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_person_friends = {
-  name: "person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6746,254 +3411,27 @@ const registryConfig_pgResources_types_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_type_function_connection = {
-  name: "type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_type_function_connection_mutation = {
-  name: "type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_type_function = {
-  name: "type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_type_function_mutation = {
-  name: "type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_person_type_function_connection = {
-  name: "person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_person_type_function = {
-  name: "person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_type_function_list = {
-  name: "type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_type_function_list_mutation = {
-  name: "type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-queryField mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_person_type_function_list = {
-  name: "person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: personCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-queryField -mutationField typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7108,19 +3546,40 @@ const registry = makeRegistry({
     "ltree[]": typesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
-      extensions: compoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "compoundTypeArray"
     }),
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
-      extensions: jwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "jwtTokenArray"
     }),
     typesArray: listOfCodec(typesCodec, {
-      extensions: typesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "typesArray"
@@ -7129,9 +3588,165 @@ const registry = makeRegistry({
     floatrange: floatrangeCodec,
     postArray: postArrayCodec,
     int8Array: int8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     current_user_id: {
@@ -7146,813 +3761,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out: {
       executor: executor_mainPgExecutor,
       name: "func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     no_args_query: {
       executor: executor_mainPgExecutor,
       name: "no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_out: {
       executor: executor_mainPgExecutor,
       name: "func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "-queryField -mutationField -typeField"]
+        }
+      },
       description: undefined
     },
     json_identity: {
       executor: executor_mainPgExecutor,
       name: "json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     mult_1: {
       executor: executor_mainPgExecutor,
       name: "mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_2: {
       executor: executor_mainPgExecutor,
       name: "mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_3: {
       executor: executor_mainPgExecutor,
       name: "mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mult_4: {
       executor: executor_mainPgExecutor,
       name: "mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     func_out_out: {
       executor: executor_mainPgExecutor,
       name: "func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutRecord_FuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutOutSetofRecord_FuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutUnnamedRecord_FuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutRecord_MutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutOutSetofRecord_MutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutUnnamedRecord_MutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "+list -connection"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutUnnamedOutOutUnnamedRecord_FuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncReturnsTableMultiColRecord_FuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     int_set_query: {
       executor: executor_mainPgExecutor,
       name: "int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutUnnamedOutOutUnnamedRecord_MutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationReturnsTableMultiColRecord_MutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     guid_fn: {
       executor: executor_mainPgExecutor,
       name: "guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: guidCodec
+      }],
       isUnique: !false,
       codec: guidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -7964,7 +5612,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -7975,7 +5633,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -7986,7 +5652,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -7997,7 +5671,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -8008,7 +5690,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8019,7 +5709,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8030,7 +5728,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8039,10 +5745,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8050,10 +5771,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
@@ -8065,7 +5794,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
@@ -8077,7 +5814,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
@@ -8089,7 +5834,15 @@ const registry = makeRegistry({
       uniques: uniques16,
       isVirtual: false,
       description: undefined,
-      extensions: extensions129
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8100,7 +5853,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8108,10 +5869,30 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: updatableViewCodec.sqlType,
       codec: updatableViewCodec,
-      uniques: uniques18,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["x"],
+        description: undefined,
+        extensions: {
+          tags: Object.assign(Object.create(null), {
+            behavior: "-single -update -delete"
+          })
+        }
+      }],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions131
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x",
+          unique: "x|@behavior -single -update -delete"
+        }
+      }
     },
     null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8122,33 +5903,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: edgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, options_return_table_without_grants),
+    return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_compound_key_compound_key, {
+      name: "return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: textArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: uuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     edge_case: {
@@ -8157,394 +6009,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: edgeCaseCodec.sqlType,
       codec: edgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     left_arm: registryConfig_pgResources_left_arm_left_arm,
-    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_fail),
-    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate),
+    authenticate_fail: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     issue756: registryConfig_pgResources_issue756_issue756,
-    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, options_left_arm_identity),
-    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_mutation),
-    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, options_issue756_set_mutation),
-    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, options_authenticate_many),
-    authenticate_payload: PgResource.functionResourceOptions(resourceConfig_auth_payload, options_authenticate_payload),
+    left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_left_arm_left_arm, {
+      name: "left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: leftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_issue756_issue756, {
+      name: "issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_many: PgResource.functionResourceOptions(resourceConfig_jwt_token, {
+      name: "authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "auth_payload",
+      identifier: "main.b.auth_payload",
+      from: authPayloadCodec.sqlType,
+      codec: authPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     types_mutation: {
       executor: executor_mainPgExecutor,
       name: "types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     types_query: {
       executor: executor_mainPgExecutor,
       name: "types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: int4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: floatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: intervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: textArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
       description: undefined
     },
     func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_query),
-    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_mutation),
-    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_query),
-    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_set_mutation),
-    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_mutation),
-    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_query_compound_type_array),
-    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_mutation),
-    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, options_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: compoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     person_first_name: {
       executor: executor_mainPgExecutor,
       name: "person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
       description: "The first name of the person."
     },
     person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedOutOutRecord_PersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_exists: {
       executor: executor_mainPgExecutor,
       name: "person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: emailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_FuncOutComplexRecord_FuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_FuncOutComplexSetofRecord_FuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_MutationOutComplexRecord_MutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_MutationOutComplexSetofRecord_MutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
-    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_person_first_post),
+    person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     person: registryConfig_pgResources_person_person,
-    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_badly_behaved_function),
-    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table),
-    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_func_out_table_setof),
-    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table),
-    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_mutation_out_table_setof),
-    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_mutation),
-    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query),
-    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_table_set_query_plpgsql),
-    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_computed_first_arg_inout),
-    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, options_person_friends),
+    badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["queryField -mutationField -typeField", "-filter -order", "filter filterBy", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
+    table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_person_person, {
+      name: "person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-queryField -mutationField typeField", "-filter -order", "orderBy order"]
+        }
+      },
+      description: undefined
+    }),
     types: registryConfig_pgResources_types_types,
-    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection),
-    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_connection_mutation),
-    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function),
-    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_mutation),
-    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_connection),
-    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function),
-    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list),
-    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_type_function_list_mutation),
-    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, options_person_type_function_list)
+    type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_types_types, {
+      name: "person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: personCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-queryField -mutationField typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9048,25 +8517,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_funcOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9209,21 +8659,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9274,21 +8709,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9397,21 +8817,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -9902,21 +9307,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10009,12 +9399,6 @@ const makeArgs20 = (args, path = []) => {
   return selectArgs;
 };
 const resource_search_test_summariesPgResource = registry.pgResources["search_test_summaries"];
-function Query_searchTestSummariesList_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_searchTestSummariesList_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10437,21 +9821,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_funcReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10520,21 +9889,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_intSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_intSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_intSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_intSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_intSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -10921,21 +10275,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs35(args);
   return resource_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_compoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_compoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_compoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_compoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_compoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple36 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11264,21 +10603,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs41(args);
   return resource_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple42 = [];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
@@ -11329,21 +10653,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_badlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_badlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_badlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_badlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_badlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11440,21 +10749,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs44(args);
   return resource_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_funcOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_funcOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_funcOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_funcOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_funcOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -11505,21 +10799,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_tableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11588,21 +10867,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_tableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_tableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_tableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -11653,21 +10917,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -11767,385 +11016,10 @@ const makeArgs49 = (args, path = []) => {
 };
 const resource_type_function_listPgResource = registry.pgResources["type_function_list"];
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
-function Query_allUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_edge_casePgResource = registry.pgResources["edge_case"];
-function Query_allEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -12719,21 +11593,6 @@ const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_friendsPgResource.execute(selectArgs);
 };
-function Person_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple61 = [];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
@@ -12814,21 +11673,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function Person_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12928,66 +11772,6 @@ const makeArgs63 = (args, path = []) => {
 };
 const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-function Person_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_compoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_compoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
@@ -13035,24 +11819,6 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13133,21 +11899,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -13571,348 +12322,7 @@ const makeArgs73 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_typesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_typesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_typesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_typesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_typesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function TypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function IntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function IntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function IntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CompoundTypesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CompoundTypesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CompoundTypesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValuesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValuesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValuesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeysConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeysConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeysConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function MyTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function MyTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function MyTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonSecretsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonSecretsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonSecretsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTablesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTablesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTablesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UpdatableViewsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UpdatableViewsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UpdatableViewsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NullTestRecordsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NullTestRecordsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NullTestRecordsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function EdgeCasesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function EdgeCasesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function EdgeCasesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -13959,26 +12369,6 @@ const makeArgs74 = (args, path = []) => {
   return selectArgs;
 };
 const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-function LeftArmsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LeftArmsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LeftArmsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Issue756SConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function Issue756SConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function Issue756SConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
@@ -14025,9 +12415,6 @@ const makeArgs75 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-function Mutation_mutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
@@ -14074,9 +12461,6 @@ const makeArgs76 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-function Mutation_mutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple77 = [];
 const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
@@ -14123,9 +12507,6 @@ const makeArgs77 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-function Mutation_mutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14172,9 +12553,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-function Mutation_noArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14221,9 +12599,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14270,9 +12645,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14325,9 +12697,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-function Mutation_mutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14380,9 +12749,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-function Mutation_mutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14435,9 +12801,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-function Mutation_jsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14490,9 +12853,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-function Mutation_jsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -14545,9 +12905,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
-function Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -14600,9 +12957,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -14661,9 +13015,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14722,9 +13073,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14783,9 +13131,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -14844,9 +13189,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -14905,9 +13247,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -14966,9 +13305,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_1PgResource = registry.pgResources["mult_1"];
-function Mutation_mult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15027,9 +13363,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_2PgResource = registry.pgResources["mult_2"];
-function Mutation_mult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15088,9 +13421,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_3PgResource = registry.pgResources["mult_3"];
-function Mutation_mult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15149,9 +13479,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-function Mutation_mult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15210,9 +13537,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-function Mutation_mutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [];
 const makeArgs97 = (args, path = []) => {
   const selectArgs = [];
@@ -15259,9 +13583,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-function Mutation_mutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [];
 const makeArgs98 = (args, path = []) => {
   const selectArgs = [];
@@ -15308,9 +13629,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-function Mutation_mutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [];
 const makeArgs99 = (args, path = []) => {
   const selectArgs = [];
@@ -15357,9 +13675,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-function Mutation_mutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15424,9 +13739,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-function Mutation_intSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -15473,9 +13785,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-function Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15528,9 +13837,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-function Mutation_mutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -15583,9 +13889,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
-function Mutation_guidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -15632,9 +13935,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -15681,9 +13981,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -15748,9 +14045,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-function Mutation_listBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
@@ -15797,9 +14091,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
-function Mutation_authenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15864,9 +14155,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticatePgResource = registry.pgResources["authenticate"];
-function Mutation_authenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -15919,9 +14207,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
-function Mutation_leftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -15968,9 +14253,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-function Mutation_issue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16017,9 +14299,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-function Mutation_issue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16084,9 +14363,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
-function Mutation_authenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16151,9 +14427,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
-function Mutation_authenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16236,9 +14509,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-function Mutation_typesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16291,9 +14561,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-function Mutation_mutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16346,9 +14613,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
-function Mutation_compoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16401,9 +14665,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
-function Mutation_compoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -16456,9 +14717,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-function Mutation_tableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -16517,9 +14775,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16572,9 +14827,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16627,9 +14879,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
-function Mutation_compoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -16682,9 +14931,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16743,9 +14989,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-function Mutation_mutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16804,9 +15047,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-function Mutation_mutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
@@ -16853,9 +15093,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-function Mutation_mutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
@@ -16902,9 +15139,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-function Mutation_mutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
@@ -16951,9 +15185,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-function Mutation_tableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
@@ -17000,9 +15231,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
-function Mutation_typeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17055,9 +15283,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
-function Mutation_typeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17104,1629 +15329,7 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_type_function_list_mutationPgResource = registry.pgResources["type_function_list_mutation"];
-function Mutation_typeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteMyTableById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNullTestRecordById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteIssue756ById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteTypeById_input_applyPlan(_, $object) {
-  return $object;
-}
-function MutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function NoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function NoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function NoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult1Payload_queryPlan() {
-  return rootValue();
-}
-function Mult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult2Payload_queryPlan() {
-  return rootValue();
-}
-function Mult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult3Payload_queryPlan() {
-  return rootValue();
-}
-function Mult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Mult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Mult4Payload_queryPlan() {
-  return rootValue();
-}
-function Mult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function IntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function IntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function IntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function MutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function GuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function GuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function GuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function LeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function LeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function LeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Issue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Issue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function Issue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function AuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function AuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function AuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
-function AuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function MutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function TypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function TypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function TypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function CreateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateMyTableInput_myTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonSecretInput_personSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCompoundKeyInput_compoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUpdatableViewPayload_updatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUpdatableViewInput_updatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNullTestRecordInput_nullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateEdgeCasePayload_edgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateEdgeCaseInput_edgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLeftArmInput_leftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function CreateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateIssue756Input_issue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function CreateTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTypeInput_type_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateMyTableByIdInput_myTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateIssue756ByIdInput_issue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByEmailInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function UpdateTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateTypeByIdInput_typePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteMyTablePayload_myTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteMyTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonSecretPayload_personSecretPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCompoundKeyPayload_compoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNullTestRecordPayload_nullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNullTestRecordByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLeftArmPayload_leftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLeftArmByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteIssue756Payload_issue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteIssue756ByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteTypePayload_typePlan($object) {
-  return $object.get("result");
-}
-function DeleteTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteTypeByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query {
   """
@@ -27701,7 +24304,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputById: {
       plan(_$root, args) {
         return resource_inputsPgResource.get({
@@ -27935,27 +24540,40 @@ export const plans = {
       return resource_func_outPgResource.execute(selectArgs);
     },
     funcOutSetof: {
-      plan: Query_funcOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -27975,23 +24593,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28003,23 +24631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28041,23 +24679,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28141,23 +24789,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28173,11 +24831,15 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_searchTestSummariesList_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         }
       }
     },
@@ -28249,23 +24911,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28280,23 +24952,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_intSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28354,23 +25036,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_compoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28430,23 +25122,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28458,23 +25160,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_badlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28490,23 +25202,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_funcOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28518,23 +25240,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28562,23 +25294,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_tableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28590,23 +25332,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28630,23 +25382,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28673,23 +25435,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28716,23 +25488,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28759,23 +25541,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28802,23 +25594,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28845,23 +25647,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28888,23 +25700,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28931,23 +25753,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -28974,23 +25806,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29017,23 +25859,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29060,23 +25912,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29103,23 +25965,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29146,23 +26018,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29189,23 +26071,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29232,23 +26124,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29275,23 +26177,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29318,23 +26230,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29361,23 +26283,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29404,23 +26336,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29447,23 +26389,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29490,23 +26442,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29533,23 +26495,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29576,23 +26548,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29619,23 +26601,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29751,23 +26743,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30165,23 +27167,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30202,23 +27214,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30344,23 +27366,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30390,23 +27422,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30446,23 +27488,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30492,23 +27544,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_compoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30676,12 +27738,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -30693,23 +27767,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -31054,23 +28138,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_typesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31098,9 +28192,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -31116,8 +28217,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -31258,9 +28363,16 @@ export const plans = {
   },
   TypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: TypesConnection_nodesPlan,
-    edges: TypesConnection_edgesPlan,
-    pageInfo: TypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33920,9 +31032,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34381,9 +31500,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34773,9 +31899,16 @@ export const plans = {
   },
   ForeignKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeysConnection_nodesPlan,
-    edges: ForeignKeysConnection_edgesPlan,
-    pageInfo: ForeignKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35026,9 +32159,16 @@ export const plans = {
   },
   CompoundKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundKeysConnection_nodesPlan,
-    edges: CompoundKeysConnection_edgesPlan,
-    pageInfo: CompoundKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35329,9 +32469,16 @@ export const plans = {
   },
   FuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutSetofConnection_nodesPlan,
-    edges: FuncOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35347,9 +32494,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35365,9 +32519,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35383,9 +32544,16 @@ export const plans = {
   },
   FuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableOneColConnection_nodesPlan,
-    edges: FuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35410,9 +32578,16 @@ export const plans = {
   },
   FuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutOutSetofConnection_nodesPlan,
-    edges: FuncOutOutSetofConnection_edgesPlan,
-    pageInfo: FuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35467,9 +32642,16 @@ export const plans = {
   },
   FuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncReturnsTableMultiColConnection_nodesPlan,
-    edges: FuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: FuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35494,9 +32676,16 @@ export const plans = {
   },
   IntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: IntSetQueryConnection_nodesPlan,
-    edges: IntSetQueryConnection_edgesPlan,
-    pageInfo: IntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35559,9 +32748,16 @@ export const plans = {
   },
   CompoundTypesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CompoundTypesConnection_nodesPlan,
-    edges: CompoundTypesConnection_edgesPlan,
-    pageInfo: CompoundTypesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35601,9 +32797,16 @@ export const plans = {
   },
   FuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: FuncOutComplexSetofConnection_nodesPlan,
-    edges: FuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: FuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35922,9 +33125,16 @@ export const plans = {
   },
   NonUpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewsConnection_nodesPlan,
-    edges: NonUpdatableViewsConnection_edgesPlan,
-    pageInfo: NonUpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36010,9 +33220,16 @@ export const plans = {
   },
   InputsConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputsConnection_nodesPlan,
-    edges: InputsConnection_edgesPlan,
-    pageInfo: InputsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36124,9 +33341,16 @@ export const plans = {
   },
   PatchesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchesConnection_nodesPlan,
-    edges: PatchesConnection_edgesPlan,
-    pageInfo: PatchesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36238,9 +33462,16 @@ export const plans = {
   },
   ReservedsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedsConnection_nodesPlan,
-    edges: ReservedsConnection_edgesPlan,
-    pageInfo: ReservedsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36352,9 +33583,16 @@ export const plans = {
   },
   ReservedPatchRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordsConnection_nodesPlan,
-    edges: ReservedPatchRecordsConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36466,9 +33704,16 @@ export const plans = {
   },
   ReservedInputRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordsConnection_nodesPlan,
-    edges: ReservedInputRecordsConnection_edgesPlan,
-    pageInfo: ReservedInputRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36580,9 +33825,16 @@ export const plans = {
   },
   DefaultValuesConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValuesConnection_nodesPlan,
-    edges: DefaultValuesConnection_edgesPlan,
-    pageInfo: DefaultValuesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36751,9 +34003,16 @@ export const plans = {
   },
   NoPrimaryKeysConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeysConnection_nodesPlan,
-    edges: NoPrimaryKeysConnection_edgesPlan,
-    pageInfo: NoPrimaryKeysConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36890,9 +34149,16 @@ export const plans = {
   },
   TestviewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewsConnection_nodesPlan,
-    edges: TestviewsConnection_edgesPlan,
-    pageInfo: TestviewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37098,9 +34364,16 @@ export const plans = {
   },
   MyTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: MyTablesConnection_nodesPlan,
-    edges: MyTablesConnection_edgesPlan,
-    pageInfo: MyTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37269,9 +34542,16 @@ export const plans = {
   },
   PersonSecretsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonSecretsConnection_nodesPlan,
-    edges: PersonSecretsConnection_edgesPlan,
-    pageInfo: PersonSecretsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37440,9 +34720,16 @@ export const plans = {
   },
   ViewTablesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTablesConnection_nodesPlan,
-    edges: ViewTablesConnection_edgesPlan,
-    pageInfo: ViewTablesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37668,9 +34955,16 @@ export const plans = {
   },
   SimilarTable1SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1SConnection_nodesPlan,
-    edges: SimilarTable1SConnection_edgesPlan,
-    pageInfo: SimilarTable1SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37953,9 +35247,16 @@ export const plans = {
   },
   SimilarTable2SConnection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2SConnection_nodesPlan,
-    edges: SimilarTable2SConnection_edgesPlan,
-    pageInfo: SimilarTable2SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38238,9 +35539,16 @@ export const plans = {
   },
   UpdatableViewsConnection: {
     __assertStep: ConnectionStep,
-    nodes: UpdatableViewsConnection_nodesPlan,
-    edges: UpdatableViewsConnection_edgesPlan,
-    pageInfo: UpdatableViewsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38506,9 +35814,16 @@ export const plans = {
   },
   NullTestRecordsConnection: {
     __assertStep: ConnectionStep,
-    nodes: NullTestRecordsConnection_nodesPlan,
-    edges: NullTestRecordsConnection_edgesPlan,
-    pageInfo: NullTestRecordsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38791,9 +36106,16 @@ export const plans = {
   },
   EdgeCasesConnection: {
     __assertStep: ConnectionStep,
-    nodes: EdgeCasesConnection_nodesPlan,
-    edges: EdgeCasesConnection_edgesPlan,
-    pageInfo: EdgeCasesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39033,9 +36355,16 @@ export const plans = {
   },
   LeftArmsConnection: {
     __assertStep: ConnectionStep,
-    nodes: LeftArmsConnection_nodesPlan,
-    edges: LeftArmsConnection_edgesPlan,
-    pageInfo: LeftArmsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39318,9 +36647,16 @@ export const plans = {
   },
   Issue756SConnection: {
     __assertStep: ConnectionStep,
-    nodes: Issue756SConnection_nodesPlan,
-    edges: Issue756SConnection_edgesPlan,
-    pageInfo: Issue756SConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39500,7 +36836,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39515,7 +36853,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39530,7 +36870,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39545,7 +36887,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_noArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39560,7 +36904,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39575,7 +36921,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39590,7 +36938,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39605,7 +36955,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39620,7 +36972,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39635,7 +36989,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39650,7 +37006,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39665,7 +37023,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_jsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39680,7 +37040,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39695,7 +37057,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39710,7 +37074,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39725,7 +37091,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39740,7 +37108,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39755,7 +37125,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39770,7 +37142,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39785,7 +37159,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39800,7 +37176,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39815,7 +37193,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39830,7 +37210,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39845,7 +37227,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39860,7 +37244,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39875,7 +37261,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_intSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39890,7 +37278,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39905,7 +37295,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39920,7 +37312,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_guidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39935,7 +37329,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39950,7 +37346,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39965,7 +37363,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_listBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39980,7 +37380,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39995,7 +37397,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40010,7 +37414,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_leftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40025,7 +37431,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40040,7 +37448,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_issue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40055,7 +37465,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40070,7 +37482,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_authenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40085,7 +37499,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40100,7 +37516,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40115,7 +37533,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40130,7 +37550,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40145,7 +37567,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40160,7 +37584,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40175,7 +37601,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40190,7 +37618,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_compoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40205,7 +37635,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40220,7 +37652,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40235,7 +37669,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40250,7 +37686,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40265,7 +37703,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40280,7 +37720,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_tableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40295,7 +37737,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40310,7 +37754,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40325,7 +37771,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_typeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40340,7 +37788,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40355,7 +37805,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40370,7 +37822,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40385,7 +37839,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40400,7 +37856,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40415,7 +37873,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40430,7 +37890,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40445,7 +37907,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40460,7 +37924,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40475,7 +37941,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40490,7 +37958,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40505,7 +37975,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40520,7 +37992,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40535,7 +38009,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40550,7 +38026,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40565,7 +38043,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40580,7 +38060,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40595,7 +38077,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40610,7 +38094,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40625,7 +38111,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40640,7 +38128,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40655,7 +38145,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40670,7 +38162,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40686,7 +38180,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40702,7 +38198,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40718,7 +38216,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40734,7 +38234,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40750,7 +38252,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40766,7 +38270,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40782,7 +38288,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40798,7 +38306,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40814,7 +38324,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40830,7 +38342,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40847,7 +38361,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40863,7 +38379,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40879,7 +38397,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40895,7 +38415,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40911,7 +38433,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40927,7 +38451,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40943,7 +38469,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40959,7 +38487,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40975,7 +38505,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40991,7 +38523,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41007,7 +38541,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41023,7 +38559,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41039,7 +38577,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41055,7 +38595,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41071,7 +38613,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41087,7 +38631,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41103,7 +38649,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41119,7 +38667,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41135,7 +38685,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteMyTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41151,7 +38703,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41167,7 +38721,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41184,7 +38740,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41200,7 +38758,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41216,7 +38776,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41232,7 +38794,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNullTestRecordById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41248,7 +38812,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41264,7 +38830,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41280,7 +38848,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteIssue756ById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41296,7 +38866,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41312,7 +38884,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41328,7 +38902,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41344,193 +38920,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteTypeById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   MutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     os($object) {
       return $object.get("result");
     },
-    query: MutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   NoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: NoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: NoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   NoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: NoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     o($object) {
       return $object.get("result");
     },
-    query: MutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInOutInput: {
     clientMutationId: {
-      applyPlan: MutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   MutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     col1S($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   JsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   JsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   JsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: JsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     json($object) {
       return $object.get("result");
     },
-    query: JsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: JsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41538,15 +39194,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41554,15 +39216,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41570,15 +39238,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41586,15 +39260,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41602,15 +39282,21 @@ export const plans = {
   },
   Mult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult1Input: {
     clientMutationId: {
-      applyPlan: Mult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41618,15 +39304,21 @@ export const plans = {
   },
   Mult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult2Input: {
     clientMutationId: {
-      applyPlan: Mult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41634,15 +39326,21 @@ export const plans = {
   },
   Mult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult3Input: {
     clientMutationId: {
-      applyPlan: Mult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41650,15 +39348,21 @@ export const plans = {
   },
   Mult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: Mult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integer($object) {
       return $object.get("result");
     },
-    query: Mult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Mult4Input: {
     clientMutationId: {
-      applyPlan: Mult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41666,15 +39370,21 @@ export const plans = {
   },
   MutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     ino($object) {
       return $object.get("result");
     },
-    query: MutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationInInoutInput: {
     clientMutationId: {
-      applyPlan: MutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -41682,11 +39392,15 @@ export const plans = {
   },
   MutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41699,17 +39413,23 @@ export const plans = {
   },
   MutationOutOutInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41722,17 +39442,23 @@ export const plans = {
   },
   MutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41745,21 +39471,29 @@ export const plans = {
   },
   MutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   IntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: IntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     integers($object) {
       return $object.get("result");
     },
-    query: IntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   IntSetMutationInput: {
     clientMutationId: {
-      applyPlan: IntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -41768,11 +39502,15 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41788,17 +39526,23 @@ export const plans = {
   },
   MutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: MutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41811,65 +39555,91 @@ export const plans = {
   },
   MutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: MutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   GuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: GuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     guid($object) {
       return $object.get("result");
     },
-    query: GuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   GuidFnInput: {
     clientMutationId: {
-      applyPlan: GuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     intervals($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     strings($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     uuids($object) {
       return $object.get("result");
     },
-    query: ListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   ListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: ListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -41878,11 +39648,15 @@ export const plans = {
   },
   AuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   JwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -41904,21 +39678,29 @@ export const plans = {
   },
   AuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: AuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtToken($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateInput: {
     clientMutationId: {
-      applyPlan: AuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41927,11 +39709,15 @@ export const plans = {
   },
   LeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: LeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     leftArm($object) {
       return $object.get("result");
     },
-    query: LeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41971,7 +39757,9 @@ export const plans = {
   },
   LeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: LeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -42008,11 +39796,15 @@ export const plans = {
   },
   Issue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756($object) {
       return $object.get("result");
     },
-    query: Issue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42047,35 +39839,49 @@ export const plans = {
   },
   Issue756MutationInput: {
     clientMutationId: {
-      applyPlan: Issue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   Issue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Issue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     issue756S($object) {
       return $object.get("result");
     },
-    query: Issue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Issue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: Issue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   AuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     jwtTokens($object) {
       return $object.get("result");
     },
-    query: AuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   AuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: AuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42084,11 +39890,15 @@ export const plans = {
   },
   AuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: AuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     authPayload($object) {
       return $object.get("result");
     },
-    query: AuthenticatePayloadPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personById($record) {
       return resource_personPgResource.get({
         id: $record.get("result").get("id")
@@ -42120,7 +39930,9 @@ export const plans = {
   },
   AuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: AuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42129,15 +39941,21 @@ export const plans = {
   },
   TypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     boolean($object) {
       return $object.get("result");
     },
-    query: TypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypesMutationInput: {
     clientMutationId: {
-      applyPlan: TypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42149,11 +39967,15 @@ export const plans = {
   },
   MutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42172,48 +39994,66 @@ export const plans = {
   },
   MutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: MutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   CompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundType($object) {
       return $object.get("result");
     },
-    query: CompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: TableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42253,18 +40093,24 @@ export const plans = {
   },
   TableMutationInput: {
     clientMutationId: {
-      applyPlan: TableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     post($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42304,7 +40150,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -42356,56 +40204,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     compoundTypes($object) {
       return $object.get("result");
     },
-    query: CompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: CompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     posts($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42433,7 +40303,9 @@ export const plans = {
   },
   MutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42441,11 +40313,15 @@ export const plans = {
   },
   MutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     results($object) {
       return $object.get("result");
     },
-    query: MutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42473,7 +40349,9 @@ export const plans = {
   },
   MutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42481,11 +40359,15 @@ export const plans = {
   },
   MutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     person($object) {
       return $object.get("result");
     },
-    query: MutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42520,59 +40402,83 @@ export const plans = {
   },
   MutationOutTableInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: MutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: MutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     people($object) {
       return $object.get("result");
     },
-    query: TableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TableSetMutationInput: {
     clientMutationId: {
-      applyPlan: TableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   TypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     type($object) {
       return $object.get("result");
     },
-    query: TypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42617,30 +40523,44 @@ export const plans = {
   },
   TypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   TypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: TypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     types($object) {
       return $object.get("result");
     },
-    query: TypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   TypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: TypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42675,11 +40595,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42694,9 +40619,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42731,11 +40662,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42750,9 +40686,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42787,11 +40729,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42806,9 +40753,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42843,11 +40796,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42862,9 +40820,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42899,11 +40863,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42918,9 +40887,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42955,11 +40930,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42981,9 +40961,15 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyByCompoundKey1AndCompoundKey2($record) {
       return resource_compound_keyPgResource.get({
         person_id_1: $record.get("result").get("compound_key_1"),
@@ -42998,11 +40984,16 @@ export const plans = {
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43031,17 +41022,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43063,17 +41065,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43102,9 +41115,15 @@ export const plans = {
   },
   CreateMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateMyTablePayload_clientMutationIdPlan,
-    myTable: CreateMyTablePayload_myTablePlan,
-    query: CreateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43139,11 +41158,16 @@ export const plans = {
   },
   CreateMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     myTable: {
-      applyPlan: CreateMyTableInput_myTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43165,9 +41189,15 @@ export const plans = {
   },
   CreatePersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: CreatePersonSecretPayload_personSecretPlan,
-    query: CreatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43207,11 +41237,16 @@ export const plans = {
   },
   CreatePersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreatePersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     personSecret: {
-      applyPlan: CreatePersonSecretInput_personSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43233,9 +41268,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43270,11 +41311,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43303,9 +41349,15 @@ export const plans = {
   },
   CreateCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: CreateCompoundKeyPayload_compoundKeyPlan,
-    query: CreateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43350,11 +41402,16 @@ export const plans = {
   },
   CreateCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     compoundKey: {
-      applyPlan: CreateCompoundKeyInput_compoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43383,9 +41440,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43420,11 +41483,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43460,9 +41528,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43497,11 +41571,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43537,17 +41616,28 @@ export const plans = {
   },
   CreateUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUpdatableViewPayload_clientMutationIdPlan,
-    updatableView: CreateUpdatableViewPayload_updatableViewPlan,
-    query: CreateUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    updatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     updatableView: {
-      applyPlan: CreateUpdatableViewInput_updatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43583,9 +41673,15 @@ export const plans = {
   },
   CreateNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: CreateNullTestRecordPayload_nullTestRecordPlan,
-    query: CreateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43620,11 +41716,16 @@ export const plans = {
   },
   CreateNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     nullTestRecord: {
-      applyPlan: CreateNullTestRecordInput_nullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43660,17 +41761,28 @@ export const plans = {
   },
   CreateEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateEdgeCasePayload_clientMutationIdPlan,
-    edgeCase: CreateEdgeCasePayload_edgeCasePlan,
-    query: CreateEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    edgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     edgeCase: {
-      applyPlan: CreateEdgeCaseInput_edgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43699,9 +41811,15 @@ export const plans = {
   },
   CreateLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLeftArmPayload_clientMutationIdPlan,
-    leftArm: CreateLeftArmPayload_leftArmPlan,
-    query: CreateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43741,11 +41859,16 @@ export const plans = {
   },
   CreateLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: {
-      applyPlan: CreateLeftArmInput_leftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43781,9 +41904,15 @@ export const plans = {
   },
   CreateIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateIssue756Payload_clientMutationIdPlan,
-    issue756: CreateIssue756Payload_issue756Plan,
-    query: CreateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43818,11 +41947,16 @@ export const plans = {
   },
   CreateIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     issue756: {
-      applyPlan: CreateIssue756Input_issue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43844,9 +41978,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43886,19 +42026,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43933,11 +42084,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -44022,9 +42178,15 @@ export const plans = {
   },
   CreateTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTypePayload_clientMutationIdPlan,
-    type: CreateTypePayload_typePlan,
-    query: CreateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44069,11 +42231,16 @@ export const plans = {
   },
   CreateTypeInput: {
     clientMutationId: {
-      applyPlan: CreateTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     type: {
-      applyPlan: CreateTypeInput_type_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -44424,9 +42591,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44461,11 +42634,16 @@ export const plans = {
   },
   UpdateInputByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -44479,9 +42657,15 @@ export const plans = {
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44516,11 +42700,16 @@ export const plans = {
   },
   UpdatePatchByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -44534,9 +42723,15 @@ export const plans = {
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44571,11 +42766,16 @@ export const plans = {
   },
   UpdateReservedByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -44589,9 +42789,15 @@ export const plans = {
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44626,11 +42832,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -44644,9 +42855,15 @@ export const plans = {
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44681,11 +42898,16 @@ export const plans = {
   },
   UpdateReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -44699,9 +42921,15 @@ export const plans = {
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44736,11 +42964,16 @@ export const plans = {
   },
   UpdateDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -44761,17 +42994,28 @@ export const plans = {
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -44792,9 +43036,15 @@ export const plans = {
   },
   UpdateMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateMyTablePayload_clientMutationIdPlan,
-    myTable: UpdateMyTablePayload_myTablePlan,
-    query: UpdateMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44829,11 +43079,16 @@ export const plans = {
   },
   UpdateMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     myTablePatch: {
-      applyPlan: UpdateMyTableByIdInput_myTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   MyTablePatch: {
@@ -44854,9 +43109,15 @@ export const plans = {
   },
   UpdatePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonSecretPayload_clientMutationIdPlan,
-    personSecret: UpdatePersonSecretPayload_personSecretPlan,
-    query: UpdatePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44896,11 +43157,16 @@ export const plans = {
   },
   UpdatePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personSecretPatch: {
-      applyPlan: UpdatePersonSecretByPersonIdInput_personSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonSecretPatch: {
@@ -44921,9 +43187,15 @@ export const plans = {
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44958,11 +43230,16 @@ export const plans = {
   },
   UpdateViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -44990,9 +43267,15 @@ export const plans = {
   },
   UpdateCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: UpdateCompoundKeyPayload_compoundKeyPlan,
-    query: UpdateCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45037,12 +43320,17 @@ export const plans = {
   },
   UpdateCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     compoundKeyPatch: {
-      applyPlan: UpdateCompoundKeyByPersonId1AndPersonId2Input_compoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CompoundKeyPatch: {
@@ -45070,9 +43358,15 @@ export const plans = {
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45107,11 +43401,16 @@ export const plans = {
   },
   UpdateSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -45146,9 +43445,15 @@ export const plans = {
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45183,11 +43488,16 @@ export const plans = {
   },
   UpdateSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -45222,9 +43532,15 @@ export const plans = {
   },
   UpdateNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: UpdateNullTestRecordPayload_nullTestRecordPlan,
-    query: UpdateNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45259,11 +43575,16 @@ export const plans = {
   },
   UpdateNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     nullTestRecordPatch: {
-      applyPlan: UpdateNullTestRecordByIdInput_nullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NullTestRecordPatch: {
@@ -45298,9 +43619,15 @@ export const plans = {
   },
   UpdateLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLeftArmPayload_clientMutationIdPlan,
-    leftArm: UpdateLeftArmPayload_leftArmPlan,
-    query: UpdateLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45340,11 +43667,16 @@ export const plans = {
   },
   UpdateLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LeftArmPatch: {
@@ -45379,18 +43711,29 @@ export const plans = {
   },
   UpdateLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     leftArmPatch: {
-      applyPlan: UpdateLeftArmByPersonIdInput_leftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateIssue756Payload_clientMutationIdPlan,
-    issue756: UpdateIssue756Payload_issue756Plan,
-    query: UpdateIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45425,11 +43768,16 @@ export const plans = {
   },
   UpdateIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     issue756Patch: {
-      applyPlan: UpdateIssue756ByIdInput_issue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   Issue756Patch: {
@@ -45450,9 +43798,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45492,11 +43846,16 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -45545,9 +43904,15 @@ export const plans = {
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45582,11 +43947,16 @@ export const plans = {
   },
   UpdatePersonByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -45670,18 +44040,29 @@ export const plans = {
   },
   UpdatePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByEmailInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateTypePayload_clientMutationIdPlan,
-    type: UpdateTypePayload_typePlan,
-    query: UpdateTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45726,11 +44107,16 @@ export const plans = {
   },
   UpdateTypeByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     typePatch: {
-      applyPlan: UpdateTypeByIdInput_typePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   TypePatch: {
@@ -46080,9 +44466,15 @@ export const plans = {
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
-    query: DeleteInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46117,15 +44509,23 @@ export const plans = {
   },
   DeleteInputByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
-    query: DeletePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46160,15 +44560,23 @@ export const plans = {
   },
   DeletePatchByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
-    query: DeleteReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46203,15 +44611,23 @@ export const plans = {
   },
   DeleteReservedByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46246,15 +44662,23 @@ export const plans = {
   },
   DeleteReservedPatchRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46289,15 +44713,23 @@ export const plans = {
   },
   DeleteReservedInputRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
-    query: DeleteDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46332,27 +44764,43 @@ export const plans = {
   },
   DeleteDefaultValueByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteMyTablePayload_clientMutationIdPlan,
-    myTable: DeleteMyTablePayload_myTablePlan,
-    query: DeleteMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    myTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     myTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46387,15 +44835,23 @@ export const plans = {
   },
   DeleteMyTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteMyTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonSecretPayload_clientMutationIdPlan,
-    personSecret: DeletePersonSecretPayload_personSecretPlan,
-    query: DeletePersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    personSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46435,15 +44891,23 @@ export const plans = {
   },
   DeletePersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
-    query: DeleteViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46478,15 +44942,23 @@ export const plans = {
   },
   DeleteViewTableByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCompoundKeyPayload_clientMutationIdPlan,
-    compoundKey: DeleteCompoundKeyPayload_compoundKeyPlan,
-    query: DeleteCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    compoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     compoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46531,16 +45003,24 @@ export const plans = {
   },
   DeleteCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
-    query: DeleteSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46575,15 +45055,23 @@ export const plans = {
   },
   DeleteSimilarTable1ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
-    query: DeleteSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46618,15 +45106,23 @@ export const plans = {
   },
   DeleteSimilarTable2ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNullTestRecordPayload_clientMutationIdPlan,
-    nullTestRecord: DeleteNullTestRecordPayload_nullTestRecordPlan,
-    query: DeleteNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    nullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     nullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46661,15 +45157,23 @@ export const plans = {
   },
   DeleteNullTestRecordByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNullTestRecordByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLeftArmPayload_clientMutationIdPlan,
-    leftArm: DeleteLeftArmPayload_leftArmPlan,
-    query: DeleteLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    leftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     leftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46709,21 +45213,31 @@ export const plans = {
   },
   DeleteLeftArmByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteIssue756Payload_clientMutationIdPlan,
-    issue756: DeleteIssue756Payload_issue756Plan,
-    query: DeleteIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    issue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     issue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46758,15 +45272,23 @@ export const plans = {
   },
   DeleteIssue756ByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteIssue756ByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
-    query: DeletePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46806,15 +45328,23 @@ export const plans = {
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
-    query: DeletePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46849,21 +45379,31 @@ export const plans = {
   },
   DeletePersonByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeletePersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteTypePayload_clientMutationIdPlan,
-    type: DeleteTypePayload_typePlan,
-    query: DeleteTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    type($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     typeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46908,7 +45448,9 @@ export const plans = {
   },
   DeleteTypeByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteTypeByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -2,26 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -44,35 +24,32 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
-const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
-  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
-const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions2 = {
   isTableLike: true,
@@ -86,36 +63,32 @@ const extensions2 = {
     behavior: ["-*"]
   })
 };
-const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
-const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
-  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
-};
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
-const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions3 = {
   isTableLike: true,
@@ -129,36 +102,32 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
-const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
-  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
-const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions4 = {
   isTableLike: true,
@@ -172,17 +141,33 @@ const extensions4 = {
     behavior: ["-*"]
   })
 };
-const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
-const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
-  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
+  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+});
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
@@ -203,28 +188,24 @@ const organizationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization"
-  })
-};
-const parts5 = ["polymorphic", "organizations"];
-const organizationsIdentifier = sql.identifier(...parts5);
-const organizationsCodecSpec = {
+const organizationsCodec = recordCodec({
   name: "organizations",
-  identifier: organizationsIdentifier,
+  identifier: sql.identifier("polymorphic", "organizations"),
   attributes: organizationsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const organizationsCodec = recordCodec(organizationsCodecSpec);
+});
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -271,36 +252,13 @@ const extensions6 = {
     }
   })
 };
-const parts6 = ["polymorphic", "people"];
-const peopleIdentifier = sql.identifier(...parts6);
-const peopleCodecSpec = {
+const peopleCodec = recordCodec({
   name: "people",
-  identifier: peopleIdentifier,
+  identifier: sql.identifier("polymorphic", "people"),
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
-};
-const peopleCodec = recordCodec(peopleCodecSpec);
-const prioritiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
 const extensions7 = {
   isTableLike: true,
@@ -314,32 +272,46 @@ const extensions7 = {
     behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
   })
 };
-const parts7 = ["polymorphic", "priorities"];
-const prioritiesIdentifier = sql.identifier(...parts7);
-const prioritiesCodecSpec = {
+const prioritiesCodec = recordCodec({
   name: "priorities",
-  identifier: prioritiesIdentifier,
-  attributes: prioritiesAttributes,
+  identifier: sql.identifier("polymorphic", "priorities"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
-};
-const prioritiesCodec = recordCodec(prioritiesCodecSpec);
-const extensions8 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "item_type"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["polymorphic", "item_type"];
+});
 const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sql.identifier(...parts8),
+  identifier: sql.identifier("polymorphic", "item_type"),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
-  extensions: extensions8
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "item_type"
+    },
+    tags: Object.create(null)
+  }
 });
 const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
@@ -471,27 +443,23 @@ const relationalChecklistsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts9 = ["polymorphic", "relational_checklists"];
-const relationalChecklistsIdentifier = sql.identifier(...parts9);
-const relationalChecklistsCodecSpec = {
+const relationalChecklistsCodec = recordCodec({
   name: "relationalChecklists",
-  identifier: relationalChecklistsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklists"),
   attributes: relationalChecklistsAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+});
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -512,26 +480,22 @@ const relationalItemRelationCompositePksAttributes = Object.assign(Object.create
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
-const relationalItemRelationCompositePksCodecSpec = {
+const relationalItemRelationCompositePksCodec = recordCodec({
   name: "relationalItemRelationCompositePks",
-  identifier: relationalItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
   attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+});
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
@@ -662,27 +626,23 @@ const relationalTopicsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts11 = ["polymorphic", "relational_topics"];
-const relationalTopicsIdentifier = sql.identifier(...parts11);
-const relationalTopicsCodecSpec = {
+const relationalTopicsCodec = recordCodec({
   name: "relationalTopics",
-  identifier: relationalTopicsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_topics"),
   attributes: relationalTopicsAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+});
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -703,26 +663,22 @@ const singleTableItemRelationCompositePksAttributes = Object.assign(Object.creat
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
-const singleTableItemRelationCompositePksCodecSpec = {
+const singleTableItemRelationCompositePksCodec = recordCodec({
   name: "singleTableItemRelationCompositePks",
-  identifier: singleTableItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
   attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+});
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
@@ -862,27 +818,23 @@ const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts13 = ["polymorphic", "relational_checklist_items"];
-const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
-const relationalChecklistItemsCodecSpec = {
+const relationalChecklistItemsCodec = recordCodec({
   name: "relationalChecklistItems",
-  identifier: relationalChecklistItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
   attributes: relationalChecklistItemsAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+});
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
@@ -1022,27 +974,23 @@ const relationalDividersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts14 = ["polymorphic", "relational_dividers"];
-const relationalDividersIdentifier = sql.identifier(...parts14);
-const relationalDividersCodecSpec = {
+const relationalDividersCodec = recordCodec({
   name: "relationalDividers",
-  identifier: relationalDividersIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_dividers"),
   attributes: relationalDividersAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+});
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1072,26 +1020,22 @@ const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["polymorphic", "relational_item_relations"];
-const relationalItemRelationsIdentifier = sql.identifier(...parts15);
-const relationalItemRelationsCodecSpec = {
+const relationalItemRelationsCodec = recordCodec({
   name: "relationalItemRelations",
-  identifier: relationalItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relations"),
   attributes: relationalItemRelationsAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+});
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1121,26 +1065,22 @@ const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["polymorphic", "single_table_item_relations"];
-const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
-const singleTableItemRelationsCodecSpec = {
+const singleTableItemRelationsCodec = recordCodec({
   name: "singleTableItemRelations",
-  identifier: singleTableItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
   attributes: singleTableItemRelationsAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+});
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1204,17 +1144,14 @@ const extensions17 = {
     }
   })
 };
-const parts17 = ["polymorphic", "log_entries"];
-const logEntriesIdentifier = sql.identifier(...parts17);
-const logEntriesCodecSpec = {
+const logEntriesCodec = recordCodec({
   name: "logEntries",
-  identifier: logEntriesIdentifier,
+  identifier: sql.identifier("polymorphic", "log_entries"),
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
-};
-const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+});
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
@@ -1363,27 +1300,23 @@ const relationalPostsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts18 = ["polymorphic", "relational_posts"];
-const relationalPostsIdentifier = sql.identifier(...parts18);
-const relationalPostsCodecSpec = {
+const relationalPostsCodec = recordCodec({
   name: "relationalPosts",
-  identifier: relationalPostsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_posts"),
   attributes: relationalPostsAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+});
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1459,17 +1392,14 @@ const extensions19 = {
     }
   })
 };
-const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
-const firstPartyVulnerabilitiesCodecSpec = {
+const firstPartyVulnerabilitiesCodec = recordCodec({
   name: "firstPartyVulnerabilities",
-  identifier: firstPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
-};
-const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+});
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1545,17 +1475,14 @@ const extensions20 = {
     }
   })
 };
-const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
-const thirdPartyVulnerabilitiesCodecSpec = {
+const thirdPartyVulnerabilitiesCodec = recordCodec({
   name: "thirdPartyVulnerabilities",
-  identifier: thirdPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
-};
-const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+});
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1649,17 +1576,14 @@ const extensions21 = {
     }
   })
 };
-const parts21 = ["polymorphic", "aws_applications"];
-const awsApplicationsIdentifier = sql.identifier(...parts21);
-const awsApplicationsCodecSpec = {
+const awsApplicationsCodec = recordCodec({
   name: "awsApplications",
-  identifier: awsApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "aws_applications"),
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
-};
-const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+});
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1753,17 +1677,14 @@ const extensions22 = {
     }
   })
 };
-const parts22 = ["polymorphic", "gcp_applications"];
-const gcpApplicationsIdentifier = sql.identifier(...parts22);
-const gcpApplicationsCodecSpec = {
+const gcpApplicationsCodec = recordCodec({
   name: "gcpApplications",
-  identifier: gcpApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "gcp_applications"),
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+});
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1938,17 +1859,14 @@ const extensions23 = {
     }
   })
 };
-const parts23 = ["polymorphic", "single_table_items"];
-const singleTableItemsIdentifier = sql.identifier(...parts23);
-const singleTableItemsCodecSpec = {
+const singleTableItemsCodec = recordCodec({
   name: "singleTableItems",
-  identifier: singleTableItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_items"),
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
-};
-const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+});
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2053,17 +1971,14 @@ const extensions24 = {
     type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
   })
 };
-const parts24 = ["polymorphic", "relational_items"];
-const relationalItemsIdentifier = sql.identifier(...parts24);
-const relationalItemsCodecSpec = {
+const relationalItemsCodec = recordCodec({
   name: "relationalItems",
-  identifier: relationalItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_items"),
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
-};
-const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+});
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2097,54 +2012,6 @@ const ApplicationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Application",
-    behavior: "node",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts25 = ["polymorphic", "applications"];
-const ApplicationIdentifier = sql.identifier(...parts25);
-const ApplicationCodecSpec = {
-  name: "Application",
-  identifier: ApplicationIdentifier,
-  attributes: ApplicationAttributes,
-  description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
 const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2180,54 +2047,6 @@ const VulnerabilityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Vulnerability",
-    behavior: "node",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts26 = ["polymorphic", "vulnerabilities"];
-const VulnerabilityIdentifier = sql.identifier(...parts26);
-const VulnerabilityCodecSpec = {
-  name: "Vulnerability",
-  identifier: VulnerabilityIdentifier,
-  attributes: VulnerabilityAttributes,
-  description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
 const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2248,41 +2067,6 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions27 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "zero_implementation"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "ZeroImplementation",
-    behavior: "node"
-  })
-};
-const parts27 = ["polymorphic", "zero_implementation"];
-const ZeroImplementationIdentifier = sql.identifier(...parts27);
-const ZeroImplementationCodecSpec = {
-  name: "ZeroImplementation",
-  identifier: ZeroImplementationIdentifier,
-  attributes: ZeroImplementationAttributes,
-  description: undefined,
-  extensions: extensions27,
-  executor: executor_mainPgExecutor
-};
-const extensions28 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "aws_application_first_party_vulnerabilities",
@@ -2299,110 +2083,104 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions28
-};
-const extensions29 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions2.tags.behavior
-  }
-};
-const uniques2 = [{
-  isPrimary: true,
-  attributes: ["aws_application_id", "third_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
   from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques2,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["aws_application_id", "third_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions29
-};
-const extensions30 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["gcp_application_id", "first_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions2.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
   from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["gcp_application_id", "first_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions30
-};
-const extensions31 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true,
-    behavior: extensions4.tags.behavior
-  }
-};
-const uniques4 = [{
-  isPrimary: true,
-  attributes: ["gcp_application_id", "third_party_vulnerability_id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
   executor: executor_mainPgExecutor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
   from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques4,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["gcp_application_id", "third_party_vulnerability_id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions31
-};
-const extensions32 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true,
+      behavior: extensions4.tags.behavior
+    }
   }
 };
 const uniques5 = [{
@@ -2429,19 +2207,16 @@ const registryConfig_pgResources_organizations_organizations = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions32
-};
-const extensions33 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: extensions6.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization"
+    }
   }
 };
 const uniques6 = [{
@@ -2468,47 +2243,48 @@ const registryConfig_pgResources_people_people = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions33
-};
-const extensions34 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
-  },
-  tags: {
-    omit: "create,update,delete,filter,order",
-    behavior: extensions7.tags.behavior
-  }
-};
-const uniques7 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: extensions6.tags.refVia
+    }
   }
-}];
+};
 const registryConfig_pgResources_priorities_priorities = {
   executor: executor_mainPgExecutor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
   from: prioritiesCodec.sqlType,
   codec: prioritiesCodec,
-  uniques: uniques7,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions34
-};
-const extensions35 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: {
+      omit: "create,update,delete,filter,order",
+      behavior: extensions7.tags.behavior
+    }
+  }
 };
 const uniques8 = [{
   isPrimary: true,
@@ -2527,16 +2303,15 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions35
-};
-const extensions36 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: {}
+  }
 };
 const uniques9 = [{
   isPrimary: true,
@@ -2555,16 +2330,15 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions36
-};
-const extensions37 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques10 = [{
   isPrimary: true,
@@ -2583,16 +2357,15 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
-  extensions: extensions37
-};
-const extensions38 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: {}
+  }
 };
 const uniques11 = [{
   isPrimary: true,
@@ -2611,16 +2384,15 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions38
-};
-const extensions39 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -2639,16 +2411,15 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
-  extensions: extensions39
-};
-const extensions40 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: {}
+  }
 };
 const uniques13 = [{
   isPrimary: true,
@@ -2667,16 +2438,15 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
-  extensions: extensions40
-};
-const extensions41 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: {}
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -2702,16 +2472,15 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
-  extensions: extensions41
-};
-const extensions42 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: {}
+  }
 };
 const uniques15 = [{
   isPrimary: true,
@@ -2737,18 +2506,14 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions42
-};
-const extensions43 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: extensions17.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: {}
   }
 };
 const uniques16 = [{
@@ -2768,16 +2533,18 @@ const registryConfig_pgResources_log_entries_log_entries = {
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
-  extensions: extensions43
-};
-const extensions44 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: extensions17.tags.refVia
+    }
+  }
 };
 const uniques17 = [{
   isPrimary: true,
@@ -2796,19 +2563,14 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
-  extensions: extensions44
-};
-const extensions45 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions19.tags.ref,
-    refVia: extensions19.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: {}
   }
 };
 const uniques18 = [{
@@ -2828,19 +2590,18 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
-  extensions: extensions45
-};
-const extensions46 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions20.tags.ref,
-    refVia: extensions20.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions19.tags.ref,
+      refVia: extensions19.tags.refVia
+    }
   }
 };
 const uniques19 = [{
@@ -2860,19 +2621,18 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
-  extensions: extensions46
-};
-const extensions47 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions21.tags.ref,
-    refVia: extensions21.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions20.tags.ref,
+      refVia: extensions20.tags.refVia
+    }
   }
 };
 const uniques20 = [{
@@ -2892,19 +2652,18 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
-  extensions: extensions47
-};
-const extensions48 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions22.tags.ref,
-    refVia: extensions22.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions21.tags.ref,
+      refVia: extensions21.tags.refVia
+    }
   }
 };
 const uniques21 = [{
@@ -2924,34 +2683,21 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
-  extensions: extensions48
-};
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "custom_delete_relational_item"
-  },
-  tags: {
-    arg0variant: "nodeId",
-    behavior: ["-queryField mutationField -typeField", "-filter -order"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions22.tags.ref,
+      refVia: extensions22.tags.refVia
+    }
   }
 };
-const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent2 = sql.identifier(...parts28);
-const extensions50 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: {
-    interface: "mode:single type:type",
-    type: extensions23.tags.type,
-    ref: extensions23.tags.ref
-  }
-};
+const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
 const uniques22 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -2969,74 +2715,22 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
-  extensions: extensions50
-};
-const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent3 = sql.identifier(...parts29);
-const options_all_single_tables = {
-  name: "all_single_tables",
-  identifier: "main.polymorphic.all_single_tables()",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "polymorphic",
-      name: "all_single_tables"
+      name: "single_table_items"
     },
     tags: {
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
+      interface: "mode:single type:type",
+      type: extensions23.tags.type,
+      ref: extensions23.tags.ref
     }
-  },
-  description: undefined
-};
-const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent4 = sql.identifier(...parts30);
-const options_get_single_table_topic_by_id = {
-  name: "get_single_table_topic_by_id",
-  identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
-  from(...args) {
-    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "polymorphic",
-      name: "get_single_table_topic_by_id"
-    },
-    tags: {
-      returnType: "SingleTableTopic",
-      behavior: ["queryField -mutationField -typeField", "-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions51 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: {
-    interface: "mode:relational",
-    type: extensions24.tags.type
   }
 };
+const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
+const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3054,7 +2748,18 @@ const registryConfig_pgResources_relational_items_relational_items = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions51
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: {
+      interface: "mode:relational",
+      type: extensions24.tags.type
+    }
+  }
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
@@ -3090,9 +2795,116 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(ApplicationCodecSpec),
-    Vulnerability: recordCodec(VulnerabilityCodecSpec),
-    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
+    Application: recordCodec({
+      name: "Application",
+      identifier: sql.identifier("polymorphic", "applications"),
+      attributes: ApplicationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "applications"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Application",
+          behavior: "node",
+          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          vulnerabilities: {
+            singular: false,
+            graphqlType: "Vulnerability",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owner: {
+            singular: true,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    Vulnerability: recordCodec({
+      name: "Vulnerability",
+      identifier: sql.identifier("polymorphic", "vulnerabilities"),
+      attributes: VulnerabilityAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "vulnerabilities"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Vulnerability",
+          behavior: "node",
+          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          applications: {
+            singular: false,
+            graphqlType: "Application",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owners: {
+            singular: false,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    ZeroImplementation: recordCodec({
+      name: "ZeroImplementation",
+      identifier: sql.identifier("polymorphic", "zero_implementation"),
+      attributes: ZeroImplementationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "zero_implementation"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "ZeroImplementation",
+          behavior: "node"
+        })
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3136,12 +2948,70 @@ const registryConfig = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "custom_delete_relational_item"
+        },
+        tags: {
+          arg0variant: "nodeId",
+          behavior: ["-queryField mutationField -typeField", "-filter -order"]
+        }
+      },
       description: undefined
     },
     single_table_items: registryConfig_pgResources_single_table_items_single_table_items,
-    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_all_single_tables),
-    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_get_single_table_topic_by_id),
+    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "all_single_tables",
+      identifier: "main.polymorphic.all_single_tables()",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "all_single_tables"
+        },
+        tags: {
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "get_single_table_topic_by_id",
+      identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "get_single_table_topic_by_id"
+        },
+        tags: {
+          returnType: "SingleTableTopic",
+          behavior: ["queryField -mutationField -typeField", "-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     relational_items: registryConfig_pgResources_relational_items_relational_items
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -4216,21 +4086,6 @@ const registryConfig = {
 const registry = makeRegistry(registryConfig);
 const otherSource_peoplePgResource = registry.pgResources["people"];
 const otherSource_single_table_itemsPgResource = registry.pgResources["single_table_items"];
-function SingleTableTopic_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -4250,146 +4105,11 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   });
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
-function SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_log_entriesPgResource = registry.pgResources["log_entries"];
-function Person_logEntriesByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_logEntriesByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_logEntriesByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_logEntriesByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_logEntriesByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_singleTableItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_relational_itemsPgResource = registry.pgResources["relational_items"];
-function Person_relationalItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_relationalItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_aws_applicationsPgResource = registry.pgResources["aws_applications"];
-function Person_awsApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_awsApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_gcp_applicationsPgResource = registry.pgResources["gcp_applications"];
-function Person_gcpApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_gcpApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication",
@@ -4426,31 +4146,6 @@ const resourceByTypeName = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Person_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function LogEntriesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LogEntriesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LogEntriesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const otherSource_organizationsPgResource = registry.pgResources["organizations"];
 const attributes = {};
 const members2 = [{
@@ -4489,61 +4184,6 @@ const resourceByTypeName2 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function Organization_logEntriesByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_logEntriesByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function AwsApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AwsApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AwsApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const members_0_resource_aws_application_first_party_vulnerabilitiesPgResource = registry.pgResources["aws_application_first_party_vulnerabilities"];
 const members_1_resource_aws_application_third_party_vulnerabilitiesPgResource = registry.pgResources["aws_application_third_party_vulnerabilities"];
 const members3 = [{
@@ -4600,21 +4240,6 @@ const resourceByTypeName3 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function AwsApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function AwsApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function AwsApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
@@ -4652,52 +4277,6 @@ const resourceByTypeName4 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function VulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function VulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function VulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function PersonOrOrganizationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonOrOrganizationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonOrOrganizationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function GcpApplicationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GcpApplicationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GcpApplicationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const members_0_resource_gcp_application_first_party_vulnerabilitiesPgResource = registry.pgResources["gcp_application_first_party_vulnerabilities"];
 const members_1_resource_gcp_application_third_party_vulnerabilitiesPgResource = registry.pgResources["gcp_application_third_party_vulnerabilities"];
 const members5 = [{
@@ -4752,21 +4331,6 @@ const resourceByTypeName5 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function GcpApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function GcpApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function GcpApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes3 = {};
 const members6 = [{
   resource: otherSource_peoplePgResource,
@@ -4804,782 +4368,14 @@ const resourceByTypeName6 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function SingleTableItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemRelationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemRelationCompositePksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationCompositePksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationCompositePksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SingleTableItemRelationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SingleTableItemRelationCompositePksConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationCompositePksConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationCompositePksConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const otherSource_prioritiesPgResource = registry.pgResources["priorities"];
-function SingleTablePost_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_topics_relational_topicsPgResource = registry.pgResources["relational_topics"];
-function RelationalTopic_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_posts_relational_postsPgResource = registry.pgResources["relational_posts"];
 const relational_dividers_relational_dividersPgResource = registry.pgResources["relational_dividers"];
 const relational_checklists_relational_checklistsPgResource = registry.pgResources["relational_checklists"];
 const relational_checklist_items_relational_checklist_itemsPgResource = registry.pgResources["relational_checklist_items"];
 const relational_item_relations_relational_item_relationsPgResource = registry.pgResources["relational_item_relations"];
-function RelationalTopic_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_item_relation_composite_pks_relational_item_relation_composite_pksPgResource = registry.pgResources["relational_item_relation_composite_pks"];
-function RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_queryPlan() {
-  return rootValue();
-}
 const argDetailsSimple = [];
 const makeArgs = (args, path = []) => {
   const selectArgs = [];
@@ -5630,25 +4426,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs(args);
   return resource_all_single_tablesPgResource.execute(selectArgs);
 };
-function Query_allSingleTablesPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_allSingleTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple2 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -5712,21 +4489,6 @@ const resourceByTypeName7 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function Query_allVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members8 = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication"
@@ -5738,323 +4500,8 @@ const resourceByTypeName8 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Query_allApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members9 = [];
 const resourceByTypeName9 = Object.create(null);
-function Query_allZeroImplementations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allZeroImplementations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allZeroImplementations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allZeroImplementations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allZeroImplementations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allOrganizations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOrganizations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOrganizations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOrganizations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOrganizations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPriorities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPriorities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPriorities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPriorities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPriorities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklists_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklists_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklists_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklists_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklists_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalTopics_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalTopics_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalTopics_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalTopics_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalTopics_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklistItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklistItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklistItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklistItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklistItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalDividers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalDividers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalDividers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalDividers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalDividers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLogEntries_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLogEntries_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLogEntries_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLogEntries_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLogEntries_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allAwsApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAwsApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAwsApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAwsApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAwsApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allGcpApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGcpApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGcpApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGcpApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGcpApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members10 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "AwsApplication",
@@ -6107,21 +4554,6 @@ const resourceByTypeName10 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function FirstPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function FirstPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function FirstPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes4 = {};
 const members11 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
@@ -6305,21 +4737,6 @@ const resourceByTypeName12 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function ThirdPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function ThirdPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes5 = {};
 const members13 = [{
   resource: members_1_resource_aws_application_third_party_vulnerabilitiesPgResource,
@@ -6451,763 +4868,6 @@ const resourceByTypeName13 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function ZeroImplementationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ZeroImplementationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ZeroImplementationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function OrganizationsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OrganizationsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OrganizationsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PeopleConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PeopleConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PeopleConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PrioritiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PrioritiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PrioritiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalTopicsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalTopicsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalTopicsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistItemsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistItemsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistItemsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalDividersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalDividersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalDividersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalPostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalPostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalPostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FirstPartyVulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FirstPartyVulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FirstPartyVulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ThirdPartyVulnerabilitiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ThirdPartyVulnerabilitiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ThirdPartyVulnerabilitiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createOrganization_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLogEntry_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createAwsApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createGcpApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLogEntryById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFirstPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateThirdPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAwsApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGcpApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLogEntryById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFirstPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteThirdPartyVulnerabilityById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAwsApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGcpApplicationById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function CreateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOrganizationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOrganizationInput_organization_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationInput_relationalItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function CreateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLogEntryInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLogEntryInput_logEntry_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAwsApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAwsApplicationInput_awsApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGcpApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGcpApplicationInput_gcpApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function UpdateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByNameInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByPersonIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByUsernameInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function UpdateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLogEntryByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLogEntryByIdInput_logEntryPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFirstPartyVulnerabilityByIdInput_firstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateThirdPartyVulnerabilityByIdInput_thirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAwsApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationByIdInput_awsApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGcpApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationByIdInput_gcpApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function DeleteOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function DeleteLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLogEntryByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAwsApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGcpApplicationByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`type SingleTableTopic implements SingleTableItem {
   id: Int!
   type: ItemType!
@@ -14524,23 +12184,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14570,23 +12240,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14616,23 +12296,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14662,23 +12352,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14708,23 +12408,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14768,23 +12478,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14814,23 +12534,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14860,23 +12590,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14906,23 +12646,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -14952,23 +12702,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15019,23 +12779,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15065,9 +12835,16 @@ export const plans = {
   },
   LogEntriesConnection: {
     __assertStep: ConnectionStep,
-    nodes: LogEntriesConnection_nodesPlan,
-    edges: LogEntriesConnection_edgesPlan,
-    pageInfo: LogEntriesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -15142,23 +12919,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15188,23 +12975,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15234,23 +13031,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15540,9 +13347,16 @@ export const plans = {
   },
   AwsApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: AwsApplicationsConnection_nodesPlan,
-    edges: AwsApplicationsConnection_edgesPlan,
-    pageInfo: AwsApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -15608,23 +13422,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -15681,18 +13505,32 @@ export const plans = {
   },
   VulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: VulnerabilitiesConnection_nodesPlan,
-    edges: VulnerabilitiesConnection_edgesPlan,
-    pageInfo: VulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   ApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ApplicationsConnection_nodesPlan,
-    edges: ApplicationsConnection_edgesPlan,
-    pageInfo: ApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -15708,8 +13546,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -15719,9 +13561,16 @@ export const plans = {
   },
   PersonOrOrganizationConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonOrOrganizationConnection_nodesPlan,
-    edges: PersonOrOrganizationConnection_edgesPlan,
-    pageInfo: PersonOrOrganizationConnection_pageInfoPlan
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    }
   },
   PersonOrOrganizationEdge: {
     __assertStep: assertEdgeCapableStep,
@@ -16311,9 +14160,16 @@ export const plans = {
   },
   GcpApplicationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: GcpApplicationsConnection_nodesPlan,
-    edges: GcpApplicationsConnection_edgesPlan,
-    pageInfo: GcpApplicationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -16379,23 +14235,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16851,9 +14717,16 @@ export const plans = {
   },
   SingleTableItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemsConnection_nodesPlan,
-    edges: SingleTableItemsConnection_edgesPlan,
-    pageInfo: SingleTableItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17478,18 +15351,32 @@ export const plans = {
   },
   RelationalItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemsConnection_nodesPlan,
-    edges: RelationalItemsConnection_edgesPlan,
-    pageInfo: RelationalItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   RelationalItemRelationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationsConnection_nodesPlan,
-    edges: RelationalItemRelationsConnection_edgesPlan,
-    pageInfo: RelationalItemRelationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17527,9 +15414,16 @@ export const plans = {
   },
   RelationalItemRelationCompositePksConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationCompositePksConnection_nodesPlan,
-    edges: RelationalItemRelationCompositePksConnection_edgesPlan,
-    pageInfo: RelationalItemRelationCompositePksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18360,9 +16254,16 @@ export const plans = {
   },
   SingleTableItemRelationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationsConnection_nodesPlan,
-    edges: SingleTableItemRelationsConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18400,9 +16301,16 @@ export const plans = {
   },
   SingleTableItemRelationCompositePksConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationCompositePksConnection_nodesPlan,
-    edges: SingleTableItemRelationCompositePksConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationCompositePksConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18867,23 +16775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18913,23 +16831,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18959,23 +16887,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19005,23 +16943,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19051,23 +16999,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19111,23 +17069,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19206,23 +17174,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19252,23 +17230,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19298,23 +17286,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19344,23 +17342,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19390,23 +17398,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19487,23 +17505,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19533,23 +17561,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19579,23 +17617,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19625,23 +17673,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19671,23 +17729,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19784,23 +17852,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19830,23 +17908,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19876,23 +17964,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19922,23 +18020,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -19968,23 +18076,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20055,23 +18173,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20151,23 +18279,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20275,23 +18413,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20329,23 +18477,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20383,23 +18541,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20437,23 +18605,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -20938,23 +19116,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21062,23 +19250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21116,23 +19314,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21170,23 +19378,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21224,23 +19442,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21359,23 +19587,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21483,23 +19721,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21537,23 +19785,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21591,23 +19849,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21645,23 +19913,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21777,23 +20055,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21901,23 +20189,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -21955,23 +20253,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22009,23 +20317,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22063,23 +20381,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22198,23 +20526,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22322,23 +20660,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22376,23 +20724,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22430,23 +20788,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22484,23 +20852,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22525,7 +20903,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     organizationByOrganizationId: {
       plan(_$root, args) {
         return otherSource_organizationsPgResource.get({
@@ -22745,27 +21125,40 @@ export const plans = {
       }
     },
     allSingleTables: {
-      plan: Query_allSingleTablesPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -22791,23 +21184,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22847,23 +21250,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22903,23 +21316,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22946,23 +21369,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22989,23 +21422,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23032,23 +21475,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -23059,23 +21512,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23102,23 +21565,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23145,23 +21618,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23188,23 +21671,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23231,23 +21724,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23274,23 +21777,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23317,23 +21830,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23360,23 +21883,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23403,23 +21936,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23446,23 +21989,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23489,23 +22042,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23532,23 +22095,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23575,23 +22148,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23618,23 +22201,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23661,23 +22254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23704,23 +22307,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23786,23 +22399,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23902,23 +22525,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23975,9 +22608,16 @@ export const plans = {
   },
   ZeroImplementationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: ZeroImplementationsConnection_nodesPlan,
-    edges: ZeroImplementationsConnection_edgesPlan,
-    pageInfo: ZeroImplementationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -24114,9 +22754,16 @@ export const plans = {
   },
   OrganizationsConnection: {
     __assertStep: ConnectionStep,
-    nodes: OrganizationsConnection_nodesPlan,
-    edges: OrganizationsConnection_edgesPlan,
-    pageInfo: OrganizationsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -24285,9 +22932,16 @@ export const plans = {
   },
   PeopleConnection: {
     __assertStep: ConnectionStep,
-    nodes: PeopleConnection_nodesPlan,
-    edges: PeopleConnection_edgesPlan,
-    pageInfo: PeopleConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -24456,9 +23110,16 @@ export const plans = {
   },
   PrioritiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PrioritiesConnection_nodesPlan,
-    edges: PrioritiesConnection_edgesPlan,
-    pageInfo: PrioritiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -24474,9 +23135,16 @@ export const plans = {
   },
   RelationalChecklistsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistsConnection_nodesPlan,
-    edges: RelationalChecklistsConnection_edgesPlan,
-    pageInfo: RelationalChecklistsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -25158,9 +23826,16 @@ export const plans = {
   },
   RelationalTopicsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalTopicsConnection_nodesPlan,
-    edges: RelationalTopicsConnection_edgesPlan,
-    pageInfo: RelationalTopicsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -25842,9 +24517,16 @@ export const plans = {
   },
   RelationalChecklistItemsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistItemsConnection_nodesPlan,
-    edges: RelationalChecklistItemsConnection_edgesPlan,
-    pageInfo: RelationalChecklistItemsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -26583,9 +25265,16 @@ export const plans = {
   },
   RelationalDividersConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalDividersConnection_nodesPlan,
-    edges: RelationalDividersConnection_edgesPlan,
-    pageInfo: RelationalDividersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27324,9 +26013,16 @@ export const plans = {
   },
   RelationalPostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalPostsConnection_nodesPlan,
-    edges: RelationalPostsConnection_edgesPlan,
-    pageInfo: RelationalPostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28122,9 +26818,16 @@ export const plans = {
   },
   FirstPartyVulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: FirstPartyVulnerabilitiesConnection_nodesPlan,
-    edges: FirstPartyVulnerabilitiesConnection_edgesPlan,
-    pageInfo: FirstPartyVulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28407,9 +27110,16 @@ export const plans = {
   },
   ThirdPartyVulnerabilitiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: ThirdPartyVulnerabilitiesConnection_nodesPlan,
-    edges: ThirdPartyVulnerabilitiesConnection_edgesPlan,
-    pageInfo: ThirdPartyVulnerabilitiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28703,7 +27413,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOrganization_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28718,7 +27430,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28733,7 +27447,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28748,7 +27464,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28763,7 +27481,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28778,7 +27498,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28793,7 +27515,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLogEntry_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28808,7 +27532,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28823,7 +27549,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28838,7 +27566,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAwsApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28853,7 +27583,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGcpApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28869,7 +27601,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28885,7 +27619,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28901,7 +27637,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28917,7 +27655,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28934,7 +27674,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28951,7 +27693,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28967,7 +27711,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -28984,7 +27730,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29000,7 +27748,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29017,7 +27767,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29033,7 +27785,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLogEntryById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29049,7 +27803,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFirstPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29065,7 +27821,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateThirdPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29081,7 +27839,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29097,7 +27857,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29113,7 +27875,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29129,7 +27893,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29145,7 +27911,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29161,7 +27929,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29178,7 +27948,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29195,7 +27967,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29211,7 +27985,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29228,7 +28004,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29244,7 +28022,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29261,7 +28041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29277,7 +28059,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLogEntryById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29293,7 +28077,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFirstPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29309,7 +28095,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteThirdPartyVulnerabilityById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29325,7 +28113,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -29341,16 +28131,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplicationById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateOrganizationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOrganizationPayload_clientMutationIdPlan,
-    organization: CreateOrganizationPayload_organizationPlan,
-    query: CreateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29385,11 +28183,16 @@ export const plans = {
   },
   CreateOrganizationInput: {
     clientMutationId: {
-      applyPlan: CreateOrganizationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     organization: {
-      applyPlan: CreateOrganizationInput_organization_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29411,9 +28214,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29448,11 +28257,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29474,9 +28288,15 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: CreateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29521,11 +28341,16 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelationCompositePk: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29547,9 +28372,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: CreateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29594,11 +28425,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelationCompositePk: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29620,9 +28456,15 @@ export const plans = {
   },
   CreateRelationalItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: CreateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: CreateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29667,11 +28509,16 @@ export const plans = {
   },
   CreateRelationalItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelation: {
-      applyPlan: CreateRelationalItemRelationInput_relationalItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29700,9 +28547,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: CreateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: CreateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29747,11 +28600,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelation: {
-      applyPlan: CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29780,9 +28638,15 @@ export const plans = {
   },
   CreateLogEntryPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLogEntryPayload_clientMutationIdPlan,
-    logEntry: CreateLogEntryPayload_logEntryPlan,
-    query: CreateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29827,11 +28691,16 @@ export const plans = {
   },
   CreateLogEntryInput: {
     clientMutationId: {
-      applyPlan: CreateLogEntryInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     logEntry: {
-      applyPlan: CreateLogEntryInput_logEntry_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29867,9 +28736,15 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: CreateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29904,11 +28779,16 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     firstPartyVulnerability: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -29944,9 +28824,15 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: CreateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -29981,11 +28867,16 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     thirdPartyVulnerability: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -30021,9 +28912,15 @@ export const plans = {
   },
   CreateAwsApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: CreateAwsApplicationPayload_awsApplicationPlan,
-    query: CreateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30068,11 +28965,16 @@ export const plans = {
   },
   CreateAwsApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateAwsApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     awsApplication: {
-      applyPlan: CreateAwsApplicationInput_awsApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -30122,9 +29024,15 @@ export const plans = {
   },
   CreateGcpApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: CreateGcpApplicationPayload_gcpApplicationPlan,
-    query: CreateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30169,11 +29077,16 @@ export const plans = {
   },
   CreateGcpApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateGcpApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     gcpApplication: {
-      applyPlan: CreateGcpApplicationInput_gcpApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -30223,9 +29136,15 @@ export const plans = {
   },
   UpdateOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOrganizationPayload_clientMutationIdPlan,
-    organization: UpdateOrganizationPayload_organizationPlan,
-    query: UpdateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30260,11 +29179,16 @@ export const plans = {
   },
   UpdateOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OrganizationPatch: {
@@ -30285,18 +29209,29 @@ export const plans = {
   },
   UpdateOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByNameInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30331,11 +29266,16 @@ export const plans = {
   },
   UpdatePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByPersonIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -30356,18 +29296,29 @@ export const plans = {
   },
   UpdatePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByUsernameInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: UpdateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30412,12 +29363,17 @@ export const plans = {
   },
   UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationCompositePkPatch: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationCompositePkPatch: {
@@ -30438,9 +29394,15 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: UpdateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30485,12 +29447,17 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationCompositePkPatch: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationCompositePkPatch: {
@@ -30511,9 +29478,15 @@ export const plans = {
   },
   UpdateRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: UpdateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: UpdateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30558,11 +29531,16 @@ export const plans = {
   },
   UpdateRelationalItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationPatch: {
@@ -30590,19 +29568,30 @@ export const plans = {
   },
   UpdateRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: UpdateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30647,11 +29636,16 @@ export const plans = {
   },
   UpdateSingleTableItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationPatch: {
@@ -30679,19 +29673,30 @@ export const plans = {
   },
   UpdateSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLogEntryPayload_clientMutationIdPlan,
-    logEntry: UpdateLogEntryPayload_logEntryPlan,
-    query: UpdateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30736,11 +29741,16 @@ export const plans = {
   },
   UpdateLogEntryByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLogEntryByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     logEntryPatch: {
-      applyPlan: UpdateLogEntryByIdInput_logEntryPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LogEntryPatch: {
@@ -30775,9 +29785,15 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: UpdateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30812,11 +29828,16 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     firstPartyVulnerabilityPatch: {
-      applyPlan: UpdateFirstPartyVulnerabilityByIdInput_firstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FirstPartyVulnerabilityPatch: {
@@ -30851,9 +29872,15 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: UpdateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30888,11 +29915,16 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     thirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateThirdPartyVulnerabilityByIdInput_thirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ThirdPartyVulnerabilityPatch: {
@@ -30927,9 +29959,15 @@ export const plans = {
   },
   UpdateAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: UpdateAwsApplicationPayload_awsApplicationPlan,
-    query: UpdateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -30974,11 +30012,16 @@ export const plans = {
   },
   UpdateAwsApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     awsApplicationPatch: {
-      applyPlan: UpdateAwsApplicationByIdInput_awsApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AwsApplicationPatch: {
@@ -31027,9 +30070,15 @@ export const plans = {
   },
   UpdateGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: UpdateGcpApplicationPayload_gcpApplicationPlan,
-    query: UpdateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31074,11 +30123,16 @@ export const plans = {
   },
   UpdateGcpApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     gcpApplicationPatch: {
-      applyPlan: UpdateGcpApplicationByIdInput_gcpApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GcpApplicationPatch: {
@@ -31127,9 +30181,15 @@ export const plans = {
   },
   DeleteOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOrganizationPayload_clientMutationIdPlan,
-    organization: DeleteOrganizationPayload_organizationPlan,
-    query: DeleteOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31164,21 +30224,31 @@ export const plans = {
   },
   DeleteOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined
   },
   DeleteOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
-    query: DeletePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31213,21 +30283,31 @@ export const plans = {
   },
   DeletePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeletePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined
   },
   DeleteRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: DeleteRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31272,16 +30352,24 @@ export const plans = {
   },
   DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: DeleteSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31326,16 +30414,24 @@ export const plans = {
   },
   DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: DeleteRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: DeleteRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31380,22 +30476,32 @@ export const plans = {
   },
   DeleteRelationalItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: DeleteSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31440,22 +30546,32 @@ export const plans = {
   },
   DeleteSingleTableItemRelationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLogEntryPayload_clientMutationIdPlan,
-    logEntry: DeleteLogEntryPayload_logEntryPlan,
-    query: DeleteLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31500,15 +30616,23 @@ export const plans = {
   },
   DeleteLogEntryByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLogEntryByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: DeleteFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31543,15 +30667,23 @@ export const plans = {
   },
   DeleteFirstPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteFirstPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: DeleteThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31586,15 +30718,23 @@ export const plans = {
   },
   DeleteThirdPartyVulnerabilityByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteThirdPartyVulnerabilityByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: DeleteAwsApplicationPayload_awsApplicationPlan,
-    query: DeleteAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31639,15 +30779,23 @@ export const plans = {
   },
   DeleteAwsApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: DeleteGcpApplicationPayload_gcpApplicationPlan,
-    query: DeleteGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -31692,7 +30840,9 @@ export const plans = {
   },
   DeleteGcpApplicationByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -2,6 +2,26 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
+const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
+  aws_application_id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  },
+  first_party_vulnerability_id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -24,35 +44,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_awsApplicationFirstPartyVulnerabilities = {
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
+const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]),
-  attributes: Object.assign(Object.create(null), {
-    aws_application_id: {
-      description: undefined,
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    },
-    first_party_vulnerability_id: {
-      description: undefined,
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
-const attributes2 = Object.assign(Object.create(null), {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
+const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -85,17 +87,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_awsApplicationThirdPartyVulnerabilities = {
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
+const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
-const attributes3 = Object.assign(Object.create(null), {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
+const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -128,17 +130,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_gcpApplicationFirstPartyVulnerabilities = {
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
+const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
-const attributes4 = Object.assign(Object.create(null), {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
+const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -171,17 +173,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_gcpApplicationThirdPartyVulnerabilities = {
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
+const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
     codec: TYPES.int,
@@ -213,17 +215,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["polymorphic", "organizations"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_organizations = {
+const organizationsIdentifier = sql.identifier(...parts5);
+const organizationsCodecSpec = {
   name: "organizations",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: organizationsIdentifier,
+  attributes: organizationsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_organizations_organizations = recordCodec(spec_organizations);
-const attributes5 = Object.assign(Object.create(null), {
+const organizationsCodec = recordCodec(organizationsCodecSpec);
+const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -270,17 +272,17 @@ const extensions6 = {
   })
 };
 const parts6 = ["polymorphic", "people"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_people = {
+const peopleIdentifier = sql.identifier(...parts6);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes6 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const prioritiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -313,16 +315,16 @@ const extensions7 = {
   })
 };
 const parts7 = ["polymorphic", "priorities"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_priorities = {
+const prioritiesIdentifier = sql.identifier(...parts7);
+const prioritiesCodecSpec = {
   name: "priorities",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: prioritiesIdentifier,
+  attributes: prioritiesAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_priorities_priorities = recordCodec(spec_priorities);
+const prioritiesCodec = recordCodec(prioritiesCodecSpec);
 const extensions8 = {
   pg: {
     serviceName: "main",
@@ -332,15 +334,14 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["polymorphic", "item_type"];
-const sqlIdent8 = sql.identifier(...parts8);
-const attributes_type_codec_itemType = enumCodec({
+const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sqlIdent8,
+  identifier: sql.identifier(...parts8),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
   extensions: extensions8
 });
-const attributes7 = Object.assign(Object.create(null), {
+const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -371,7 +372,7 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemId",
@@ -481,17 +482,17 @@ const extensions9 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts9 = ["polymorphic", "relational_checklists"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_relationalChecklists = {
+const relationalChecklistsIdentifier = sql.identifier(...parts9);
+const relationalChecklistsCodecSpec = {
   name: "relationalChecklists",
-  identifier: sqlIdent9,
-  attributes: attributes7,
+  identifier: relationalChecklistsIdentifier,
+  attributes: relationalChecklistsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklists_relationalChecklists = recordCodec(spec_relationalChecklists);
-const attributes8 = Object.assign(Object.create(null), {
+const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -521,17 +522,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_relationalItemRelationCompositePks = {
+const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
+const relationalItemRelationCompositePksCodecSpec = {
   name: "relationalItemRelationCompositePks",
-  identifier: sqlIdent10,
-  attributes: attributes8,
+  identifier: relationalItemRelationCompositePksIdentifier,
+  attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks = recordCodec(spec_relationalItemRelationCompositePks);
-const attributes9 = Object.assign(Object.create(null), {
+const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -558,18 +559,18 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyTopicItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -580,7 +581,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -591,7 +592,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -602,7 +603,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -613,7 +614,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -624,7 +625,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -635,7 +636,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -646,7 +647,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -657,7 +658,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -672,17 +673,17 @@ const extensions11 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts11 = ["polymorphic", "relational_topics"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_relationalTopics = {
+const relationalTopicsIdentifier = sql.identifier(...parts11);
+const relationalTopicsCodecSpec = {
   name: "relationalTopics",
-  identifier: sqlIdent11,
-  attributes: attributes9,
+  identifier: relationalTopicsIdentifier,
+  attributes: relationalTopicsAttributes,
   description: undefined,
   extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalTopics_relationalTopics = recordCodec(spec_relationalTopics);
-const attributes10 = Object.assign(Object.create(null), {
+const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -712,17 +713,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_singleTableItemRelationCompositePks = {
+const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
+const singleTableItemRelationCompositePksCodecSpec = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sqlIdent12,
-  attributes: attributes10,
+  identifier: singleTableItemRelationCompositePksIdentifier,
+  attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks = recordCodec(spec_singleTableItemRelationCompositePks);
-const attributes11 = Object.assign(Object.create(null), {
+const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -758,18 +759,18 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -780,7 +781,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -791,7 +792,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -802,7 +803,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -813,7 +814,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -824,7 +825,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -835,7 +836,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -846,7 +847,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -857,7 +858,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -872,17 +873,17 @@ const extensions13 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts13 = ["polymorphic", "relational_checklist_items"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_relationalChecklistItems = {
+const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
+const relationalChecklistItemsCodecSpec = {
   name: "relationalChecklistItems",
-  identifier: sqlIdent13,
-  attributes: attributes11,
+  identifier: relationalChecklistItemsIdentifier,
+  attributes: relationalChecklistItemsAttributes,
   description: undefined,
   extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems = recordCodec(spec_relationalChecklistItems);
-const attributes12 = Object.assign(Object.create(null), {
+const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -918,18 +919,18 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyDividerItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -940,7 +941,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -951,7 +952,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -962,7 +963,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -973,7 +974,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -984,7 +985,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -995,7 +996,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1006,7 +1007,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1017,7 +1018,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1032,17 +1033,17 @@ const extensions14 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts14 = ["polymorphic", "relational_dividers"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_relationalDividers = {
+const relationalDividersIdentifier = sql.identifier(...parts14);
+const relationalDividersCodecSpec = {
   name: "relationalDividers",
-  identifier: sqlIdent14,
-  attributes: attributes12,
+  identifier: relationalDividersIdentifier,
+  attributes: relationalDividersAttributes,
   description: undefined,
   extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalDividers_relationalDividers = recordCodec(spec_relationalDividers);
-const attributes13 = Object.assign(Object.create(null), {
+const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1081,17 +1082,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts15 = ["polymorphic", "relational_item_relations"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_relationalItemRelations = {
+const relationalItemRelationsIdentifier = sql.identifier(...parts15);
+const relationalItemRelationsCodecSpec = {
   name: "relationalItemRelations",
-  identifier: sqlIdent15,
-  attributes: attributes13,
+  identifier: relationalItemRelationsIdentifier,
+  attributes: relationalItemRelationsAttributes,
   description: undefined,
   extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations = recordCodec(spec_relationalItemRelations);
-const attributes14 = Object.assign(Object.create(null), {
+const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1130,17 +1131,17 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts16 = ["polymorphic", "single_table_item_relations"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_singleTableItemRelations = {
+const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
+const singleTableItemRelationsCodecSpec = {
   name: "singleTableItemRelations",
-  identifier: sqlIdent16,
-  attributes: attributes14,
+  identifier: singleTableItemRelationsIdentifier,
+  attributes: singleTableItemRelationsAttributes,
   description: undefined,
   extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations = recordCodec(spec_singleTableItemRelations);
-const attributes15 = Object.assign(Object.create(null), {
+const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1204,17 +1205,17 @@ const extensions17 = {
   })
 };
 const parts17 = ["polymorphic", "log_entries"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_logEntries = {
+const logEntriesIdentifier = sql.identifier(...parts17);
+const logEntriesCodecSpec = {
   name: "logEntries",
-  identifier: sqlIdent17,
-  attributes: attributes15,
+  identifier: logEntriesIdentifier,
+  attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_logEntries_logEntries = recordCodec(spec_logEntries);
-const attributes16 = Object.assign(Object.create(null), {
+const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -1259,18 +1260,18 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyPostItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1281,7 +1282,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1292,7 +1293,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -1303,7 +1304,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -1314,7 +1315,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -1325,7 +1326,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -1336,7 +1337,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1347,7 +1348,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1358,7 +1359,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1373,17 +1374,17 @@ const extensions18 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts18 = ["polymorphic", "relational_posts"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_relationalPosts = {
+const relationalPostsIdentifier = sql.identifier(...parts18);
+const relationalPostsCodecSpec = {
   name: "relationalPosts",
-  identifier: sqlIdent18,
-  attributes: attributes16,
+  identifier: relationalPostsIdentifier,
+  attributes: relationalPostsAttributes,
   description: undefined,
   extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalPosts_relationalPosts = recordCodec(spec_relationalPosts);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1459,17 +1460,17 @@ const extensions19 = {
   })
 };
 const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_firstPartyVulnerabilities = {
+const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
+const firstPartyVulnerabilitiesCodecSpec = {
   name: "firstPartyVulnerabilities",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_2,
+  identifier: firstPartyVulnerabilitiesIdentifier,
+  attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities = recordCodec(spec_firstPartyVulnerabilities);
-const attributes_object_Object_3 = Object.assign(Object.create(null), {
+const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1545,17 +1546,17 @@ const extensions20 = {
   })
 };
 const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_thirdPartyVulnerabilities = {
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
+const thirdPartyVulnerabilitiesCodecSpec = {
   name: "thirdPartyVulnerabilities",
-  identifier: sqlIdent20,
-  attributes: attributes_object_Object_3,
+  identifier: thirdPartyVulnerabilitiesIdentifier,
+  attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities = recordCodec(spec_thirdPartyVulnerabilities);
-const attributes_object_Object_4 = Object.assign(Object.create(null), {
+const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1649,17 +1650,17 @@ const extensions21 = {
   })
 };
 const parts21 = ["polymorphic", "aws_applications"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_awsApplications = {
+const awsApplicationsIdentifier = sql.identifier(...parts21);
+const awsApplicationsCodecSpec = {
   name: "awsApplications",
-  identifier: sqlIdent21,
-  attributes: attributes_object_Object_4,
+  identifier: awsApplicationsIdentifier,
+  attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplications_awsApplications = recordCodec(spec_awsApplications);
-const attributes_object_Object_5 = Object.assign(Object.create(null), {
+const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1753,17 +1754,17 @@ const extensions22 = {
   })
 };
 const parts22 = ["polymorphic", "gcp_applications"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_gcpApplications = {
+const gcpApplicationsIdentifier = sql.identifier(...parts22);
+const gcpApplicationsCodecSpec = {
   name: "gcpApplications",
-  identifier: sqlIdent22,
-  attributes: attributes_object_Object_5,
+  identifier: gcpApplicationsIdentifier,
+  attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplications_gcpApplications = recordCodec(spec_gcpApplications);
-const attributes17 = Object.assign(Object.create(null), {
+const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1775,7 +1776,7 @@ const attributes17 = Object.assign(Object.create(null), {
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1938,33 +1939,33 @@ const extensions23 = {
   })
 };
 const parts23 = ["polymorphic", "single_table_items"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_singleTableItems = {
+const singleTableItemsIdentifier = sql.identifier(...parts23);
+const singleTableItemsCodecSpec = {
   name: "singleTableItems",
-  identifier: sqlIdent23,
-  attributes: attributes17,
+  identifier: singleTableItemsIdentifier,
+  attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItems_singleTableItems = recordCodec(spec_singleTableItems);
-const attributes18 = Object.assign(Object.create(null), {
+const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1973,7 +1974,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1982,7 +1983,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -1991,7 +1992,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: false,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -2000,7 +2001,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -2009,7 +2010,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -2018,7 +2019,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -2027,7 +2028,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -2036,7 +2037,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -2053,17 +2054,17 @@ const extensions24 = {
   })
 };
 const parts24 = ["polymorphic", "relational_items"];
-const sqlIdent24 = sql.identifier(...parts24);
-const spec_relationalItems = {
+const relationalItemsIdentifier = sql.identifier(...parts24);
+const relationalItemsCodecSpec = {
   name: "relationalItems",
-  identifier: sqlIdent24,
-  attributes: attributes18,
+  identifier: relationalItemsIdentifier,
+  attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItems_relationalItems = recordCodec(spec_relationalItems);
-const attributes_object_Object_6 = Object.assign(Object.create(null), {
+const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2135,16 +2136,16 @@ const extensions25 = {
   })
 };
 const parts25 = ["polymorphic", "applications"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_Application = {
+const ApplicationIdentifier = sql.identifier(...parts25);
+const ApplicationCodecSpec = {
   name: "Application",
-  identifier: sqlIdent25,
-  attributes: attributes_object_Object_6,
+  identifier: ApplicationIdentifier,
+  attributes: ApplicationAttributes,
   description: undefined,
   extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_7 = Object.assign(Object.create(null), {
+const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2218,16 +2219,16 @@ const extensions26 = {
   })
 };
 const parts26 = ["polymorphic", "vulnerabilities"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_Vulnerability = {
+const VulnerabilityIdentifier = sql.identifier(...parts26);
+const VulnerabilityCodecSpec = {
   name: "Vulnerability",
-  identifier: sqlIdent26,
-  attributes: attributes_object_Object_7,
+  identifier: VulnerabilityIdentifier,
+  attributes: VulnerabilityAttributes,
   description: undefined,
   extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_8 = Object.assign(Object.create(null), {
+const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2261,11 +2262,11 @@ const extensions27 = {
   })
 };
 const parts27 = ["polymorphic", "zero_implementation"];
-const sqlIdent27 = sql.identifier(...parts27);
-const spec_ZeroImplementation = {
+const ZeroImplementationIdentifier = sql.identifier(...parts27);
+const ZeroImplementationCodecSpec = {
   name: "ZeroImplementation",
-  identifier: sqlIdent27,
-  attributes: attributes_object_Object_8,
+  identifier: ZeroImplementationIdentifier,
+  attributes: ZeroImplementationAttributes,
   description: undefined,
   extensions: extensions27,
   executor: executor_mainPgExecutor
@@ -2286,8 +2287,8 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["aws_application_id", "first_party_vulnerability_id"],
@@ -2324,8 +2325,8 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -2355,8 +2356,8 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -2386,8 +2387,8 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -2423,8 +2424,8 @@ const registryConfig_pgResources_organizations_organizations = {
   executor: executor_mainPgExecutor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: registryConfig_pgCodecs_organizations_organizations.sqlType,
-  codec: registryConfig_pgCodecs_organizations_organizations,
+  from: organizationsCodec.sqlType,
+  codec: organizationsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -2462,8 +2463,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -2493,8 +2494,8 @@ const registryConfig_pgResources_priorities_priorities = {
   executor: executor_mainPgExecutor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: registryConfig_pgCodecs_priorities_priorities.sqlType,
-  codec: registryConfig_pgCodecs_priorities_priorities,
+  from: prioritiesCodec.sqlType,
+  codec: prioritiesCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -2521,8 +2522,8 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   executor: executor_mainPgExecutor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: registryConfig_pgCodecs_relationalChecklists_relationalChecklists.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+  from: relationalChecklistsCodec.sqlType,
+  codec: relationalChecklistsCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -2549,8 +2550,8 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   executor: executor_mainPgExecutor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+  from: relationalItemRelationCompositePksCodec.sqlType,
+  codec: relationalItemRelationCompositePksCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -2577,8 +2578,8 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   executor: executor_mainPgExecutor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: registryConfig_pgCodecs_relationalTopics_relationalTopics.sqlType,
-  codec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+  from: relationalTopicsCodec.sqlType,
+  codec: relationalTopicsCodec,
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
@@ -2605,8 +2606,8 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   executor: executor_mainPgExecutor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+  from: singleTableItemRelationCompositePksCodec.sqlType,
+  codec: singleTableItemRelationCompositePksCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
@@ -2633,8 +2634,8 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   executor: executor_mainPgExecutor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+  from: relationalChecklistItemsCodec.sqlType,
+  codec: relationalChecklistItemsCodec,
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
@@ -2661,8 +2662,8 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   executor: executor_mainPgExecutor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: registryConfig_pgCodecs_relationalDividers_relationalDividers.sqlType,
-  codec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+  from: relationalDividersCodec.sqlType,
+  codec: relationalDividersCodec,
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
@@ -2696,8 +2697,8 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   executor: executor_mainPgExecutor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+  from: relationalItemRelationsCodec.sqlType,
+  codec: relationalItemRelationsCodec,
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
@@ -2731,8 +2732,8 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   executor: executor_mainPgExecutor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+  from: singleTableItemRelationsCodec.sqlType,
+  codec: singleTableItemRelationsCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
@@ -2762,8 +2763,8 @@ const registryConfig_pgResources_log_entries_log_entries = {
   executor: executor_mainPgExecutor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: registryConfig_pgCodecs_logEntries_logEntries.sqlType,
-  codec: registryConfig_pgCodecs_logEntries_logEntries,
+  from: logEntriesCodec.sqlType,
+  codec: logEntriesCodec,
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
@@ -2790,8 +2791,8 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   executor: executor_mainPgExecutor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: registryConfig_pgCodecs_relationalPosts_relationalPosts.sqlType,
-  codec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+  from: relationalPostsCodec.sqlType,
+  codec: relationalPostsCodec,
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
@@ -2822,8 +2823,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   executor: executor_mainPgExecutor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+  from: firstPartyVulnerabilitiesCodec.sqlType,
+  codec: firstPartyVulnerabilitiesCodec,
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
@@ -2854,8 +2855,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   executor: executor_mainPgExecutor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  codec: thirdPartyVulnerabilitiesCodec,
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
@@ -2886,8 +2887,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   executor: executor_mainPgExecutor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: registryConfig_pgCodecs_awsApplications_awsApplications.sqlType,
-  codec: registryConfig_pgCodecs_awsApplications_awsApplications,
+  from: awsApplicationsCodec.sqlType,
+  codec: awsApplicationsCodec,
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
@@ -2918,8 +2919,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   executor: executor_mainPgExecutor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: registryConfig_pgCodecs_gcpApplications_gcpApplications.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+  from: gcpApplicationsCodec.sqlType,
+  codec: gcpApplicationsCodec,
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
@@ -2937,7 +2938,7 @@ const extensions49 = {
   }
 };
 const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent28 = sql.identifier(...parts28);
+const sqlIdent2 = sql.identifier(...parts28);
 const extensions50 = {
   description: undefined,
   pg: {
@@ -2963,20 +2964,20 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   executor: executor_mainPgExecutor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: registryConfig_pgCodecs_singleTableItems_singleTableItems.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+  from: singleTableItemsCodec.sqlType,
+  codec: singleTableItemsCodec,
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
   extensions: extensions50
 };
 const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent29 = sql.identifier(...parts29);
+const sqlIdent3 = sql.identifier(...parts29);
 const options_all_single_tables = {
   name: "all_single_tables",
   identifier: "main.polymorphic.all_single_tables()",
   from(...args) {
-    return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -2995,12 +2996,12 @@ const options_all_single_tables = {
   description: undefined
 };
 const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent30 = sql.identifier(...parts30);
+const sqlIdent4 = sql.identifier(...parts30);
 const options_get_single_table_topic_by_id = {
   name: "get_single_table_topic_by_id",
   identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
   from(...args) {
-    return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3048,8 +3049,8 @@ const registryConfig_pgResources_relational_items_relational_items = {
   executor: executor_mainPgExecutor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: registryConfig_pgCodecs_relationalItems_relationalItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+  from: relationalItemsCodec.sqlType,
+  codec: relationalItemsCodec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
@@ -3057,41 +3058,41 @@ const registryConfig_pgResources_relational_items_relational_items = {
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
-    awsApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+    awsApplicationFirstPartyVulnerabilities: awsApplicationFirstPartyVulnerabilitiesCodec,
     int4: TYPES.int,
-    awsApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
-    gcpApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
-    gcpApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
-    organizations: registryConfig_pgCodecs_organizations_organizations,
+    awsApplicationThirdPartyVulnerabilities: awsApplicationThirdPartyVulnerabilitiesCodec,
+    gcpApplicationFirstPartyVulnerabilities: gcpApplicationFirstPartyVulnerabilitiesCodec,
+    gcpApplicationThirdPartyVulnerabilities: gcpApplicationThirdPartyVulnerabilitiesCodec,
+    organizations: organizationsCodec,
     text: TYPES.text,
-    people: registryConfig_pgCodecs_people_people,
-    priorities: registryConfig_pgCodecs_priorities_priorities,
-    relationalChecklists: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
-    relationalItemRelationCompositePks: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
-    relationalTopics: registryConfig_pgCodecs_relationalTopics_relationalTopics,
-    singleTableItemRelationCompositePks: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
-    relationalChecklistItems: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
-    relationalDividers: registryConfig_pgCodecs_relationalDividers_relationalDividers,
-    relationalItemRelations: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
-    singleTableItemRelations: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
-    logEntries: registryConfig_pgCodecs_logEntries_logEntries,
-    relationalPosts: registryConfig_pgCodecs_relationalPosts_relationalPosts,
-    firstPartyVulnerabilities: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+    people: peopleCodec,
+    priorities: prioritiesCodec,
+    relationalChecklists: relationalChecklistsCodec,
+    relationalItemRelationCompositePks: relationalItemRelationCompositePksCodec,
+    relationalTopics: relationalTopicsCodec,
+    singleTableItemRelationCompositePks: singleTableItemRelationCompositePksCodec,
+    relationalChecklistItems: relationalChecklistItemsCodec,
+    relationalDividers: relationalDividersCodec,
+    relationalItemRelations: relationalItemRelationsCodec,
+    singleTableItemRelations: singleTableItemRelationsCodec,
+    logEntries: logEntriesCodec,
+    relationalPosts: relationalPostsCodec,
+    firstPartyVulnerabilities: firstPartyVulnerabilitiesCodec,
     float8: TYPES.float,
-    thirdPartyVulnerabilities: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
-    awsApplications: registryConfig_pgCodecs_awsApplications_awsApplications,
+    thirdPartyVulnerabilities: thirdPartyVulnerabilitiesCodec,
+    awsApplications: awsApplicationsCodec,
     timestamptz: TYPES.timestamptz,
-    gcpApplications: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+    gcpApplications: gcpApplicationsCodec,
     bool: TYPES.boolean,
-    singleTableItems: registryConfig_pgCodecs_singleTableItems_singleTableItems,
-    itemType: attributes_type_codec_itemType,
+    singleTableItems: singleTableItemsCodec,
+    itemType: itemTypeCodec,
     int8: TYPES.bigint,
-    relationalItems: registryConfig_pgCodecs_relationalItems_relationalItems,
+    relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(spec_Application),
-    Vulnerability: recordCodec(spec_Vulnerability),
-    ZeroImplementation: recordCodec(spec_ZeroImplementation)
+    Application: recordCodec(ApplicationCodecSpec),
+    Vulnerability: recordCodec(VulnerabilityCodecSpec),
+    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3120,13 +3121,13 @@ const registryConfig = {
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
         required: true,
         notNull: false,
-        codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        codec: relationalItemsCodec,
         extensions: {
           variant: "nodeId"
         }
@@ -3146,7 +3147,7 @@ const registryConfig = {
   pgRelations: Object.assign(Object.create(null), {
     awsApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3161,7 +3162,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3178,7 +3179,7 @@ const registryConfig = {
     }),
     awsApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3193,7 +3194,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3210,7 +3211,7 @@ const registryConfig = {
     }),
     awsApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3225,7 +3226,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3240,7 +3241,7 @@ const registryConfig = {
         }
       },
       awsApplicationFirstPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3255,7 +3256,7 @@ const registryConfig = {
         }
       },
       awsApplicationThirdPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3272,7 +3273,7 @@ const registryConfig = {
     }),
     firstPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3287,7 +3288,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3304,7 +3305,7 @@ const registryConfig = {
     }),
     gcpApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3319,7 +3320,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3336,7 +3337,7 @@ const registryConfig = {
     }),
     gcpApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3351,7 +3352,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3368,7 +3369,7 @@ const registryConfig = {
     }),
     gcpApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3383,7 +3384,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3398,7 +3399,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3413,7 +3414,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3430,7 +3431,7 @@ const registryConfig = {
     }),
     logEntries: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3445,7 +3446,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3462,7 +3463,7 @@ const registryConfig = {
     }),
     organizations: Object.assign(Object.create(null), {
       logEntriesByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3477,7 +3478,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3492,7 +3493,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3509,7 +3510,7 @@ const registryConfig = {
     }),
     people: Object.assign(Object.create(null), {
       logEntriesByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3524,7 +3525,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3539,7 +3540,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3554,7 +3555,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3569,7 +3570,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3586,7 +3587,7 @@ const registryConfig = {
     }),
     priorities: Object.assign(Object.create(null), {
       singleTableItemsByTheirPriorityId: {
-        localCodec: registryConfig_pgCodecs_priorities_priorities,
+        localCodec: prioritiesCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3603,7 +3604,7 @@ const registryConfig = {
     }),
     relationalChecklistItems: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+        localCodec: relationalChecklistItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_item_id"],
@@ -3620,7 +3621,7 @@ const registryConfig = {
     }),
     relationalChecklists: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+        localCodec: relationalChecklistsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_id"],
@@ -3637,7 +3638,7 @@ const registryConfig = {
     }),
     relationalDividers: Object.assign(Object.create(null), {
       relationalItemsByMyDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+        localCodec: relationalDividersCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["divider_item_id"],
@@ -3654,7 +3655,7 @@ const registryConfig = {
     }),
     relationalItemRelationCompositePks: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3669,7 +3670,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3686,7 +3687,7 @@ const registryConfig = {
     }),
     relationalItemRelations: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3701,7 +3702,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3718,7 +3719,7 @@ const registryConfig = {
     }),
     relationalItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -3733,7 +3734,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3748,7 +3749,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -3763,7 +3764,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3778,7 +3779,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByTheirTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3793,7 +3794,7 @@ const registryConfig = {
         }
       },
       relationalPostsByTheirPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_posts_relational_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3808,7 +3809,7 @@ const registryConfig = {
         }
       },
       relationalDividersByTheirDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_dividers_relational_dividers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3823,7 +3824,7 @@ const registryConfig = {
         }
       },
       relationalChecklistsByTheirChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklists_relational_checklists,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3838,7 +3839,7 @@ const registryConfig = {
         }
       },
       relationalChecklistItemsByTheirChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklist_items_relational_checklist_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3853,7 +3854,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3868,7 +3869,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3883,7 +3884,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3898,7 +3899,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3915,7 +3916,7 @@ const registryConfig = {
     }),
     relationalPosts: Object.assign(Object.create(null), {
       relationalItemsByMyPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+        localCodec: relationalPostsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_item_id"],
@@ -3932,7 +3933,7 @@ const registryConfig = {
     }),
     relationalTopics: Object.assign(Object.create(null), {
       relationalItemsByMyTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3947,7 +3948,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3964,7 +3965,7 @@ const registryConfig = {
     }),
     singleTableItemRelationCompositePks: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3979,7 +3980,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3996,7 +3997,7 @@ const registryConfig = {
     }),
     singleTableItemRelations: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -4011,7 +4012,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4028,7 +4029,7 @@ const registryConfig = {
     }),
     singleTableItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -4043,7 +4044,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4058,7 +4059,7 @@ const registryConfig = {
         }
       },
       prioritiesByMyPriorityId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_priorities_priorities,
         localCodecPolymorphicTypes: ["POST", "CHECKLIST_ITEM"],
         localAttributes: ["priority_id"],
@@ -4073,7 +4074,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -4088,7 +4089,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4103,7 +4104,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4118,7 +4119,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4133,7 +4134,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4148,7 +4149,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4163,7 +4164,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4180,7 +4181,7 @@ const registryConfig = {
     }),
     thirdPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4195,7 +4196,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4451,7 +4452,7 @@ function LogEntriesConnection_pageInfoPlan($connection) {
   return $connection.pageInfo();
 }
 const otherSource_organizationsPgResource = registry.pgResources["organizations"];
-const attributes19 = {};
+const attributes = {};
 const members2 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4614,7 +4615,7 @@ function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes20 = {};
+const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4766,7 +4767,7 @@ function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes21 = {};
+const attributes3 = {};
 const members6 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -6121,7 +6122,7 @@ function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes22 = {};
+const attributes4 = {};
 const members11 = [{
   resource: members_0_resource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -6319,7 +6320,7 @@ function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes23 = {};
+const attributes5 = {};
 const members13 = [{
   resource: members_1_resource_aws_application_third_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -15002,7 +15003,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -15109,7 +15110,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes19,
+        attributes,
         resourceByTypeName: resourceByTypeName2,
         members: members2,
         name: "author"
@@ -15277,7 +15278,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15293,7 +15294,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15459,7 +15460,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
             }
           });
         }
@@ -15482,7 +15483,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
             }
           });
         }
@@ -15505,7 +15506,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -15528,7 +15529,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
             }
           });
         }
@@ -15591,7 +15592,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -15664,7 +15665,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes20,
+        attributes: attributes2,
         resourceByTypeName: resourceByTypeName4,
         members: members4,
         name: "owner"
@@ -15863,7 +15864,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
             }
           });
         }
@@ -15886,7 +15887,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
             }
           });
         }
@@ -15909,7 +15910,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -15934,7 +15935,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -15950,7 +15951,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16184,7 +16185,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -16207,7 +16208,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -16230,7 +16231,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -16253,7 +16254,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -16276,7 +16277,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -16299,7 +16300,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
             }
           });
         }
@@ -16362,7 +16363,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "vulnerabilities"
@@ -16435,7 +16436,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes21,
+        attributes: attributes3,
         resourceByTypeName: resourceByTypeName6,
         members: members6,
         name: "owner"
@@ -16465,7 +16466,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16481,7 +16482,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16715,7 +16716,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -16738,7 +16739,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -16761,7 +16762,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -16784,7 +16785,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -16807,7 +16808,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -16830,7 +16831,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
             }
           });
         }
@@ -16873,7 +16874,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -16889,7 +16890,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17259,7 +17260,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -17282,7 +17283,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -17305,7 +17306,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -17328,7 +17329,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -17351,7 +17352,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -17374,7 +17375,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -17397,7 +17398,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -17420,7 +17421,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -17443,7 +17444,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -17466,7 +17467,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -17577,7 +17578,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17593,7 +17594,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17963,7 +17964,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -17986,7 +17987,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -18009,7 +18010,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -18032,7 +18033,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -18055,7 +18056,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -18078,7 +18079,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -18101,7 +18102,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -18124,7 +18125,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -18147,7 +18148,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -18170,7 +18171,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -18302,7 +18303,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
             }
           });
         }
@@ -18325,7 +18326,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
             }
           });
         }
@@ -18348,7 +18349,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -18441,7 +18442,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18457,7 +18458,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18589,7 +18590,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -18612,7 +18613,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -18635,7 +18636,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -18651,7 +18652,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18667,7 +18668,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18765,7 +18766,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -18788,7 +18789,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -20480,7 +20481,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20496,7 +20497,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20628,7 +20629,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -20651,7 +20652,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20674,7 +20675,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -20690,7 +20691,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20706,7 +20707,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20804,7 +20805,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20827,7 +20828,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -22780,7 +22781,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "Vulnerability"
@@ -22836,7 +22837,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName8,
           members: members8,
           name: "Application"
@@ -22892,7 +22893,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_8,
+          attributes: ZeroImplementationAttributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "ZeroImplementation"
@@ -23769,7 +23770,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName10,
           members: members10,
           name: "applications"
@@ -23842,7 +23843,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes22,
+        attributes: attributes4,
         resourceByTypeName: resourceByTypeName11,
         members: members11,
         name: "owners"
@@ -23885,7 +23886,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "applications"
@@ -23958,7 +23959,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes23,
+        attributes: attributes5,
         resourceByTypeName: resourceByTypeName13,
         members: members13,
         name: "owners"
@@ -24079,7 +24080,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
             }
           });
         }
@@ -24102,7 +24103,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
             }
           });
         }
@@ -24136,7 +24137,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24152,7 +24153,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24250,7 +24251,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -24273,7 +24274,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
             }
           });
         }
@@ -24307,7 +24308,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24323,7 +24324,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24421,7 +24422,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
             }
           });
         }
@@ -24444,7 +24445,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
             }
           });
         }
@@ -24496,7 +24497,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24512,7 +24513,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24916,7 +24917,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
             }
           });
         }
@@ -24939,7 +24940,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
             }
           });
         }
@@ -24962,7 +24963,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
             }
           });
         }
@@ -24985,7 +24986,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -25008,7 +25009,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -25031,7 +25032,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -25054,7 +25055,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
             }
           });
         }
@@ -25077,7 +25078,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -25100,7 +25101,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -25123,7 +25124,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -25146,7 +25147,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -25180,7 +25181,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -25196,7 +25197,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -25600,7 +25601,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
             }
           });
         }
@@ -25623,7 +25624,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
             }
           });
         }
@@ -25646,7 +25647,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
             }
           });
         }
@@ -25669,7 +25670,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -25692,7 +25693,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -25715,7 +25716,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -25738,7 +25739,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
             }
           });
         }
@@ -25761,7 +25762,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -25784,7 +25785,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -25807,7 +25808,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -25830,7 +25831,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -25864,7 +25865,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -25880,7 +25881,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26318,7 +26319,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
             }
           });
         }
@@ -26341,7 +26342,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
             }
           });
         }
@@ -26364,7 +26365,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -26387,7 +26388,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -26410,7 +26411,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -26433,7 +26434,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -26456,7 +26457,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -26479,7 +26480,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -26502,7 +26503,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -26525,7 +26526,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -26548,7 +26549,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -26571,7 +26572,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -26605,7 +26606,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -26621,7 +26622,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27059,7 +27060,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
             }
           });
         }
@@ -27082,7 +27083,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
             }
           });
         }
@@ -27105,7 +27106,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
             }
           });
         }
@@ -27128,7 +27129,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
             }
           });
         }
@@ -27151,7 +27152,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -27174,7 +27175,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27197,7 +27198,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
             }
           });
         }
@@ -27220,7 +27221,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
             }
           });
         }
@@ -27243,7 +27244,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
             }
           });
         }
@@ -27266,7 +27267,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -27289,7 +27290,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -27312,7 +27313,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -27346,7 +27347,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27362,7 +27363,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27834,7 +27835,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
             }
           });
         }
@@ -27857,7 +27858,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
             }
           });
         }
@@ -27880,7 +27881,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
             }
           });
         }
@@ -27903,7 +27904,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
             }
           });
         }
@@ -27926,7 +27927,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
             }
           });
         }
@@ -27949,7 +27950,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -27972,7 +27973,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27995,7 +27996,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -28018,7 +28019,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
             }
           });
         }
@@ -28041,7 +28042,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -28064,7 +28065,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -28087,7 +28088,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28110,7 +28111,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -28144,7 +28145,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28160,7 +28161,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28326,7 +28327,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -28349,7 +28350,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -28372,7 +28373,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -28395,7 +28396,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
             }
           });
         }
@@ -28429,7 +28430,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28445,7 +28446,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28611,7 +28612,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -28634,7 +28635,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -28657,7 +28658,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -28680,7 +28681,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -2,7 +2,7 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -49,7 +49,7 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions2 = {
   isTableLike: true,
@@ -88,7 +88,7 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions2,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -127,7 +127,7 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions4 = {
   isTableLike: true,
@@ -166,7 +166,7 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions4,
-  executor: executor_mainPgExecutor
+  executor
 });
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
@@ -204,7 +204,7 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -258,7 +258,7 @@ const peopleCodec = recordCodec({
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions7 = {
   isTableLike: true,
@@ -297,7 +297,7 @@ const prioritiesCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions7,
-  executor: executor_mainPgExecutor
+  executor
 });
 const itemTypeCodec = enumCodec({
   name: "itemType",
@@ -458,7 +458,7 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -494,7 +494,7 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
@@ -641,7 +641,7 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -677,7 +677,7 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
@@ -833,7 +833,7 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
@@ -989,7 +989,7 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1034,7 +1034,7 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1079,7 +1079,7 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1150,7 +1150,7 @@ const logEntriesCodec = recordCodec({
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
@@ -1315,7 +1315,7 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1398,7 +1398,7 @@ const firstPartyVulnerabilitiesCodec = recordCodec({
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
-  executor: executor_mainPgExecutor
+  executor
 });
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1481,7 +1481,7 @@ const thirdPartyVulnerabilitiesCodec = recordCodec({
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
-  executor: executor_mainPgExecutor
+  executor
 });
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1582,7 +1582,7 @@ const awsApplicationsCodec = recordCodec({
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
-  executor: executor_mainPgExecutor
+  executor
 });
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1683,7 +1683,7 @@ const gcpApplicationsCodec = recordCodec({
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1865,7 +1865,7 @@ const singleTableItemsCodec = recordCodec({
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1977,7 +1977,7 @@ const relationalItemsCodec = recordCodec({
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
-  executor: executor_mainPgExecutor
+  executor
 });
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2068,7 +2068,7 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   }
 });
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
   from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
@@ -2097,7 +2097,7 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
   from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
@@ -2126,7 +2126,7 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
   from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
@@ -2155,7 +2155,7 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   }
 };
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
   from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
@@ -2183,7 +2183,7 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
     }
   }
 };
-const uniques5 = [{
+const organizationsUniques = [{
   isPrimary: true,
   attributes: ["organization_id"],
   description: undefined,
@@ -2199,12 +2199,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
   from: organizationsCodec.sqlType,
   codec: organizationsCodec,
-  uniques: uniques5,
+  uniques: organizationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2219,7 +2219,7 @@ const registryConfig_pgResources_organizations_organizations = {
     }
   }
 };
-const uniques6 = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2235,12 +2235,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.polymorphic.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques: uniques6,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2258,7 +2258,7 @@ const registryConfig_pgResources_people_people = {
   }
 };
 const registryConfig_pgResources_priorities_priorities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
   from: prioritiesCodec.sqlType,
@@ -2286,7 +2286,7 @@ const registryConfig_pgResources_priorities_priorities = {
     }
   }
 };
-const uniques8 = [{
+const relational_checklistsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_id"],
   description: undefined,
@@ -2295,12 +2295,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
   from: relationalChecklistsCodec.sqlType,
   codec: relationalChecklistsCodec,
-  uniques: uniques8,
+  uniques: relational_checklistsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2313,7 +2313,7 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
     tags: {}
   }
 };
-const uniques9 = [{
+const relational_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2322,12 +2322,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
   from: relationalItemRelationCompositePksCodec.sqlType,
   codec: relationalItemRelationCompositePksCodec,
-  uniques: uniques9,
+  uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2340,7 +2340,7 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
     tags: {}
   }
 };
-const uniques10 = [{
+const relational_topicsUniques = [{
   isPrimary: true,
   attributes: ["topic_item_id"],
   description: undefined,
@@ -2349,12 +2349,12 @@ const uniques10 = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
   from: relationalTopicsCodec.sqlType,
   codec: relationalTopicsCodec,
-  uniques: uniques10,
+  uniques: relational_topicsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2367,7 +2367,7 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
     tags: {}
   }
 };
-const uniques11 = [{
+const single_table_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2376,12 +2376,12 @@ const uniques11 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
   from: singleTableItemRelationCompositePksCodec.sqlType,
   codec: singleTableItemRelationCompositePksCodec,
-  uniques: uniques11,
+  uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2394,7 +2394,7 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
     tags: {}
   }
 };
-const uniques12 = [{
+const relational_checklist_itemsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_item_id"],
   description: undefined,
@@ -2403,12 +2403,12 @@ const uniques12 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
   from: relationalChecklistItemsCodec.sqlType,
   codec: relationalChecklistItemsCodec,
-  uniques: uniques12,
+  uniques: relational_checklist_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2421,7 +2421,7 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
     tags: {}
   }
 };
-const uniques13 = [{
+const relational_dividersUniques = [{
   isPrimary: true,
   attributes: ["divider_item_id"],
   description: undefined,
@@ -2430,12 +2430,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
   from: relationalDividersCodec.sqlType,
   codec: relationalDividersCodec,
-  uniques: uniques13,
+  uniques: relational_dividersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2448,7 +2448,7 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
     tags: {}
   }
 };
-const uniques14 = [{
+const relational_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2464,12 +2464,12 @@ const uniques14 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
   from: relationalItemRelationsCodec.sqlType,
   codec: relationalItemRelationsCodec,
-  uniques: uniques14,
+  uniques: relational_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2482,7 +2482,7 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
     tags: {}
   }
 };
-const uniques15 = [{
+const single_table_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2498,12 +2498,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
   from: singleTableItemRelationsCodec.sqlType,
   codec: singleTableItemRelationsCodec,
-  uniques: uniques15,
+  uniques: single_table_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2516,7 +2516,7 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
     tags: {}
   }
 };
-const uniques16 = [{
+const log_entriesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2525,12 +2525,12 @@ const uniques16 = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
   from: logEntriesCodec.sqlType,
   codec: logEntriesCodec,
-  uniques: uniques16,
+  uniques: log_entriesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2546,7 +2546,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     }
   }
 };
-const uniques17 = [{
+const relational_postsUniques = [{
   isPrimary: true,
   attributes: ["post_item_id"],
   description: undefined,
@@ -2555,12 +2555,12 @@ const uniques17 = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
   from: relationalPostsCodec.sqlType,
   codec: relationalPostsCodec,
-  uniques: uniques17,
+  uniques: relational_postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2573,7 +2573,7 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
     tags: {}
   }
 };
-const uniques18 = [{
+const first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2582,12 +2582,12 @@ const uniques18 = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
   from: firstPartyVulnerabilitiesCodec.sqlType,
   codec: firstPartyVulnerabilitiesCodec,
-  uniques: uniques18,
+  uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2604,7 +2604,7 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     }
   }
 };
-const uniques19 = [{
+const third_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2613,12 +2613,12 @@ const uniques19 = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
   from: thirdPartyVulnerabilitiesCodec.sqlType,
   codec: thirdPartyVulnerabilitiesCodec,
-  uniques: uniques19,
+  uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2635,7 +2635,7 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     }
   }
 };
-const uniques20 = [{
+const aws_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2644,12 +2644,12 @@ const uniques20 = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
   from: awsApplicationsCodec.sqlType,
   codec: awsApplicationsCodec,
-  uniques: uniques20,
+  uniques: aws_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2666,7 +2666,7 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     }
   }
 };
-const uniques21 = [{
+const gcp_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2675,12 +2675,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
   from: gcpApplicationsCodec.sqlType,
   codec: gcpApplicationsCodec,
-  uniques: uniques21,
+  uniques: gcp_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2697,8 +2697,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     }
   }
 };
-const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
-const uniques22 = [{
+const custom_delete_relational_itemFunctionIdentifer = sql.identifier("polymorphic", "custom_delete_relational_item");
+const single_table_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2707,12 +2707,12 @@ const uniques22 = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
   from: singleTableItemsCodec.sqlType,
   codec: singleTableItemsCodec,
-  uniques: uniques22,
+  uniques: single_table_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2729,9 +2729,9 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     }
   }
 };
-const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
-const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
-const uniques23 = [{
+const all_single_tablesFunctionIdentifer = sql.identifier("polymorphic", "all_single_tables");
+const get_single_table_topic_by_idFunctionIdentifer = sql.identifier("polymorphic", "get_single_table_topic_by_id");
+const relational_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2740,12 +2740,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
   from: relationalItemsCodec.sqlType,
   codec: relationalItemsCodec,
-  uniques: uniques23,
+  uniques: relational_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2838,7 +2838,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     Vulnerability: recordCodec({
       name: "Vulnerability",
@@ -2883,7 +2883,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     ZeroImplementation: recordCodec({
       name: "ZeroImplementation",
@@ -2903,7 +2903,7 @@ const registryConfig = {
           behavior: "node"
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -2929,11 +2929,11 @@ const registryConfig = {
     aws_applications: registryConfig_pgResources_aws_applications_aws_applications,
     gcp_applications: registryConfig_pgResources_gcp_applications_gcp_applications,
     custom_delete_relational_item: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${custom_delete_relational_itemFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
@@ -2966,7 +2966,7 @@ const registryConfig = {
       name: "all_single_tables",
       identifier: "main.polymorphic.all_single_tables()",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${all_single_tablesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -2988,7 +2988,7 @@ const registryConfig = {
       name: "get_single_table_topic_by_id",
       identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${get_single_table_topic_by_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -13084,7 +13084,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -13100,7 +13100,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -13783,7 +13783,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -13799,7 +13799,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14331,7 +14331,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14347,7 +14347,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14746,7 +14746,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14762,7 +14762,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15471,7 +15471,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15487,7 +15487,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16349,7 +16349,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16365,7 +16365,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16559,7 +16559,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16575,7 +16575,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18658,7 +18658,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18674,7 +18674,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18868,7 +18868,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18884,7 +18884,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -22783,7 +22783,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -22799,7 +22799,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -22961,7 +22961,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -22977,7 +22977,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -23164,7 +23164,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -23180,7 +23180,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -23855,7 +23855,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -23871,7 +23871,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -24546,7 +24546,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -24562,7 +24562,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25294,7 +25294,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25310,7 +25310,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26042,7 +26042,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26058,7 +26058,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26847,7 +26847,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26863,7 +26863,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27139,7 +27139,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27155,7 +27155,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28159,7 +28159,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28233,7 +28233,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28307,7 +28307,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28391,7 +28391,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28475,7 +28475,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28566,7 +28566,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28657,7 +28657,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28755,7 +28755,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28843,7 +28843,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -28931,7 +28931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29043,7 +29043,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29155,7 +29155,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29242,7 +29242,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29329,7 +29329,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29413,7 +29413,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29497,7 +29497,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29602,7 +29602,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29707,7 +29707,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29804,7 +29804,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29891,7 +29891,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -29978,7 +29978,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30089,7 +30089,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30200,7 +30200,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30259,7 +30259,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30318,7 +30318,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30380,7 +30380,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30442,7 +30442,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30512,7 +30512,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30582,7 +30582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30643,7 +30643,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30694,7 +30694,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30745,7 +30745,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -30806,7 +30806,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,48 +100,24 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    primaryKey: "id"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      primaryKey: "id"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -166,17 +132,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -197,30 +179,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view (id)"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view (id)"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -241,28 +219,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -292,26 +266,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -341,26 +311,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -442,17 +408,14 @@ const extensions8 = {
     foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -500,41 +463,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -551,18 +497,18 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    primaryKey: "id"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
 };
 const uniques2 = [{
@@ -582,51 +528,47 @@ const registryConfig_pgResources_posts_posts = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: {
+      name: "posts",
+      primaryKey: "id"
+    }
   }
-}];
+};
 const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view (id)"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -646,17 +588,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view (id)"
+    }
   }
 };
 const uniques5 = [{
@@ -683,16 +626,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +655,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,19 +682,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    primaryKey: "street_id,property_id",
-    foreignKey: extensions8.tags.foreignKey,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -771,17 +709,18 @@ const registryConfig_pgResources_houses_houses = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: {
+      primaryKey: "street_id,property_id",
+      foreignKey: extensions8.tags.foreignKey,
+      behavior: ["-insert", "-update", "-delete"]
+    }
   }
 };
 const uniques9 = [{
@@ -801,7 +740,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -1407,21 +1356,6 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Building);
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1440,785 +1374,54 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Post_offersByPostId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_offersByPostId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_offersByPostId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_offersByPostId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_offersByPostId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_housesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_housesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_housesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_housesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_housesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_housesByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_housesByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_housesByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_housesByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_housesByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Building_housesByBuildingId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_housesByBuildingId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_housesByBuildingId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_housesByBuildingId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_housesByBuildingId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4564,7 +3767,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4731,23 +3936,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4774,23 +3989,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4817,23 +4042,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4860,23 +4095,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4903,23 +4148,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4946,23 +4201,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4989,23 +4254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5045,23 +4320,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5084,9 +4369,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5120,8 +4412,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5304,23 +4600,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5350,23 +4656,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5396,23 +4712,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5442,23 +4768,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5481,9 +4817,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5518,23 +4861,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5564,23 +4917,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5610,23 +4973,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5649,9 +5022,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5778,23 +5158,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5817,9 +5207,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6492,9 +5889,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7053,9 +6457,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7167,9 +6578,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7349,7 +6767,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7364,7 +6784,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7379,7 +6801,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7394,7 +6818,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7409,7 +6835,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7424,7 +6852,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7438,7 +6868,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7454,7 +6886,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7468,7 +6902,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7484,7 +6920,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7498,7 +6936,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7514,7 +6954,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7530,7 +6972,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7544,7 +6988,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7560,7 +7006,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7574,7 +7022,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7591,7 +7041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7605,7 +7057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7621,7 +7075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7635,7 +7091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7651,7 +7109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7665,7 +7125,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7681,7 +7143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7695,7 +7159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7711,7 +7177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7727,7 +7195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7741,7 +7211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7757,7 +7229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7771,7 +7245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7788,7 +7264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7802,7 +7280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7818,16 +7298,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7862,11 +7350,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7881,9 +7374,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7923,11 +7422,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7949,9 +7453,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7986,11 +7496,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8012,9 +7527,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8054,11 +7575,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8087,9 +7613,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8134,11 +7666,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8167,9 +7704,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8214,11 +7757,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8261,9 +7809,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8298,11 +7852,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8316,18 +7875,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8367,11 +7937,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -8392,18 +7967,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8438,11 +8024,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8463,27 +8054,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8523,11 +8130,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8555,18 +8167,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8611,11 +8234,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8643,19 +8271,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8700,11 +8339,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8746,23 +8390,34 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8797,26 +8452,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8856,26 +8521,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8910,32 +8585,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8975,26 +8662,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9039,27 +8736,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9104,13 +8811,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -121,17 +123,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -165,17 +167,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +211,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -441,17 +443,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -510,16 +512,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -537,8 +539,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -575,8 +577,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -607,8 +609,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -639,8 +641,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,8 +734,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -764,8 +766,8 @@ const registryConfig_pgResources_houses_houses = {
   executor: executor_mainPgExecutor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: registryConfig_pgCodecs_houses_houses.sqlType,
-  codec: registryConfig_pgCodecs_houses_houses,
+  from: housesCodec.sqlType,
+  codec: housesCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -794,8 +796,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -803,20 +805,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -832,7 +834,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -847,7 +849,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -865,7 +867,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirBuildingId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -882,7 +884,7 @@ const registry = makeRegistry({
     }),
     houses: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -897,7 +899,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByMyBuildingId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["building_id"],
@@ -912,7 +914,7 @@ const registry = makeRegistry({
         }
       },
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -927,7 +929,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertyByMyStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id", "property_id"],
@@ -944,7 +946,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -961,7 +963,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postsByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -995,7 +997,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1012,7 +1014,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -1027,7 +1029,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1042,7 +1044,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1057,7 +1059,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1074,7 +1076,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1089,7 +1091,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1104,7 +1106,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id", "prop_id"],
@@ -1121,7 +1123,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1136,7 +1138,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1151,7 +1153,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -1169,7 +1171,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5134,7 +5136,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5150,7 +5152,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5248,7 +5250,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -5271,7 +5273,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -5838,7 +5840,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5854,7 +5856,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6122,7 +6124,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -6145,7 +6147,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -6168,7 +6170,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -6191,7 +6193,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6214,7 +6216,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -6237,7 +6239,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6260,7 +6262,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }
@@ -6285,7 +6287,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6301,7 +6303,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6433,7 +6435,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -6456,7 +6458,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -6479,7 +6481,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -6513,7 +6515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6529,7 +6531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6729,7 +6731,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -6752,7 +6754,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6775,7 +6777,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -6798,7 +6800,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -6821,7 +6823,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -6846,7 +6848,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6862,7 +6864,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6994,7 +6996,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -7017,7 +7019,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -7040,7 +7042,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -7074,7 +7076,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7090,7 +7092,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7154,7 +7156,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -7188,7 +7190,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7204,7 +7206,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7302,7 +7304,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -7325,7 +7327,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -117,7 +117,7 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -157,7 +157,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -197,7 +197,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view (id)"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -280,7 +280,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -325,7 +325,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -414,7 +414,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -479,10 +479,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -511,7 +511,7 @@ const registryConfig_pgResources_post_table_post_table = {
     }
   }
 };
-const uniques2 = [{
+const postsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -542,7 +542,7 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -571,7 +571,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -580,12 +580,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -602,7 +602,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -618,12 +618,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -638,7 +638,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -647,12 +647,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,7 +665,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -674,12 +674,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -692,7 +692,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -701,12 +701,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
   from: housesCodec.sqlType,
   codec: housesCodec,
-  uniques: uniques8,
+  uniques: housesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -723,7 +723,7 @@ const registryConfig_pgResources_houses_houses = {
     }
   }
 };
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -732,12 +732,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -4431,7 +4431,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4447,7 +4447,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5236,7 +5236,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5252,7 +5252,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5683,7 +5683,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5699,7 +5699,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5918,7 +5918,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5934,7 +5934,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6251,7 +6251,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6267,7 +6267,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6486,7 +6486,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6502,7 +6502,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6607,7 +6607,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6623,7 +6623,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7326,7 +7326,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7393,7 +7393,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7472,7 +7472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7546,7 +7546,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7632,7 +7632,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7723,7 +7723,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7828,7 +7828,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7908,7 +7908,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8000,7 +8000,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8101,7 +8101,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8200,7 +8200,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8305,7 +8305,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8428,7 +8428,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8492,7 +8492,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8561,7 +8561,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8633,7 +8633,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8702,7 +8702,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8777,7 +8777,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,48 +100,24 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    primaryKey: "id"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      primaryKey: "id"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -166,17 +132,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -197,30 +179,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -241,28 +219,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -292,26 +266,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -341,26 +311,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -442,17 +408,14 @@ const extensions8 = {
     foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -500,41 +463,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -551,42 +497,21 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    primaryKey: "id"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
 };
 const uniques2 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -600,22 +525,28 @@ const registryConfig_pgResources_offer_table_offer_table = {
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -635,17 +566,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post"
+    }
   }
 };
 const uniques5 = [{
@@ -672,16 +604,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -700,16 +633,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -728,19 +660,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    primaryKey: "street_id,property_id",
-    foreignKey: extensions8.tags.foreignKey,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -760,17 +687,18 @@ const registryConfig_pgResources_houses_houses = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: {
+      primaryKey: "street_id,property_id",
+      foreignKey: extensions8.tags.foreignKey,
+      behavior: ["-insert", "-update", "-delete"]
+    }
   }
 };
 const uniques9 = [{
@@ -790,7 +718,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -820,7 +758,18 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
-      extensions: extensions11
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "smart_comment_relations",
+          name: "post_view"
+        },
+        tags: {
+          name: "posts",
+          primaryKey: "id"
+        }
+      }
     },
     offer_table: registryConfig_pgResources_offer_table_offer_table,
     offers: registryConfig_pgResources_offers_offers,
@@ -1404,21 +1353,6 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Building);
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1437,770 +1371,54 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_housesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_housesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_housesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_housesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_housesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_housesByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_housesByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_housesByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_housesByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_housesByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Building_housesByBuildingId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_housesByBuildingId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_housesByBuildingId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_housesByBuildingId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_housesByBuildingId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4505,7 +3723,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4672,23 +3892,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4715,23 +3945,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4758,23 +3998,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4801,23 +4051,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4844,23 +4104,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4887,23 +4157,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4930,23 +4210,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5012,23 +4302,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5058,23 +4358,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5104,23 +4414,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5150,23 +4470,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5189,9 +4519,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5226,23 +4563,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5272,23 +4619,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5318,23 +4675,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5357,9 +4724,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5486,23 +4860,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5525,9 +4909,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5543,8 +4934,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -6211,9 +5606,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6772,9 +6174,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6886,9 +6295,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7057,9 +6473,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7239,7 +6662,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7254,7 +6679,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7269,7 +6696,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7284,7 +6713,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7299,7 +6730,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7314,7 +6747,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7328,7 +6763,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7344,7 +6781,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7358,7 +6797,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7374,7 +6815,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7388,7 +6831,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7404,7 +6849,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7420,7 +6867,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7434,7 +6883,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7450,7 +6901,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7464,7 +6917,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7481,7 +6936,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7495,7 +6952,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7511,7 +6970,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7525,7 +6986,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7541,7 +7004,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7555,7 +7020,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7571,7 +7038,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7585,7 +7054,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7601,7 +7072,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7617,7 +7090,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7631,7 +7106,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7647,7 +7124,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7661,7 +7140,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7678,7 +7159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7692,7 +7175,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7708,16 +7193,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7752,11 +7245,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7771,9 +7269,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7808,11 +7312,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7834,9 +7343,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7871,11 +7386,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7897,9 +7417,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7939,11 +7465,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7972,9 +7503,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8019,11 +7556,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8052,9 +7594,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8099,11 +7647,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8146,9 +7699,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8183,11 +7742,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8201,18 +7765,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8247,11 +7822,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -8272,18 +7852,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8318,11 +7909,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8343,27 +7939,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8403,11 +8015,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8435,18 +8052,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8491,11 +8119,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8523,19 +8156,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8580,11 +8224,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8626,23 +8275,34 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8677,26 +8337,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8731,26 +8401,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8785,32 +8465,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8850,26 +8542,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8914,27 +8616,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8979,13 +8691,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -121,17 +123,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -165,17 +167,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +211,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -441,17 +443,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -510,16 +512,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -537,8 +539,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -596,8 +598,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -628,8 +630,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -665,8 +667,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -693,8 +695,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -721,8 +723,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -753,8 +755,8 @@ const registryConfig_pgResources_houses_houses = {
   executor: executor_mainPgExecutor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: registryConfig_pgCodecs_houses_houses.sqlType,
-  codec: registryConfig_pgCodecs_houses_houses,
+  from: housesCodec.sqlType,
+  codec: housesCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -783,8 +785,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -792,20 +794,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -813,8 +815,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "posts",
       identifier: "main.smart_comment_relations.post_view",
-      from: registryConfig_pgCodecs_posts_posts.sqlType,
-      codec: registryConfig_pgCodecs_posts_posts,
+      from: postsCodec.sqlType,
+      codec: postsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: undefined,
@@ -831,7 +833,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -846,7 +848,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -864,7 +866,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirBuildingId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -881,7 +883,7 @@ const registry = makeRegistry({
     }),
     houses: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -896,7 +898,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByMyBuildingId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["building_id"],
@@ -911,7 +913,7 @@ const registry = makeRegistry({
         }
       },
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -926,7 +928,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertyByMyStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id", "property_id"],
@@ -943,7 +945,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -960,7 +962,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -977,7 +979,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -992,7 +994,7 @@ const registry = makeRegistry({
         }
       },
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1009,7 +1011,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -1024,7 +1026,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1039,7 +1041,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1054,7 +1056,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1071,7 +1073,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1086,7 +1088,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1101,7 +1103,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id", "prop_id"],
@@ -1118,7 +1120,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1133,7 +1135,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1148,7 +1150,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -1166,7 +1168,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5557,7 +5559,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5573,7 +5575,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5841,7 +5843,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -5864,7 +5866,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5887,7 +5889,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -5910,7 +5912,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -5933,7 +5935,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -5956,7 +5958,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -5979,7 +5981,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }
@@ -6004,7 +6006,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6020,7 +6022,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6152,7 +6154,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -6175,7 +6177,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -6198,7 +6200,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -6232,7 +6234,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6248,7 +6250,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6448,7 +6450,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -6471,7 +6473,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6494,7 +6496,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -6517,7 +6519,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -6540,7 +6542,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -6565,7 +6567,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6581,7 +6583,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6713,7 +6715,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -6736,7 +6738,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6759,7 +6761,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6793,7 +6795,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6809,7 +6811,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6873,7 +6875,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -6907,7 +6909,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6923,7 +6925,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7021,7 +7023,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -7044,7 +7046,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -7078,7 +7080,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7094,7 +7096,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7192,7 +7194,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -7215,7 +7217,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -117,7 +117,7 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -157,7 +157,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -197,7 +197,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -280,7 +280,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -325,7 +325,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -414,7 +414,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -479,10 +479,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -511,7 +511,7 @@ const registryConfig_pgResources_post_table_post_table = {
     }
   }
 };
-const uniques2 = [{
+const postsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,7 +520,7 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -549,7 +549,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -558,12 +558,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -580,7 +580,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -596,12 +596,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -616,7 +616,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -625,12 +625,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -643,7 +643,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -652,12 +652,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -670,7 +670,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -679,12 +679,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
   from: housesCodec.sqlType,
   codec: housesCodec,
-  uniques: uniques8,
+  uniques: housesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -701,7 +701,7 @@ const registryConfig_pgResources_houses_houses = {
     }
   }
 };
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -710,12 +710,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -750,12 +750,12 @@ const registry = makeRegistry({
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
     posts: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "posts",
       identifier: "main.smart_comment_relations.post_view",
       from: postsCodec.sqlType,
       codec: postsCodec,
-      uniques: uniques2,
+      uniques: postsUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -4953,7 +4953,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4969,7 +4969,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5400,7 +5400,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5416,7 +5416,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5635,7 +5635,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5651,7 +5651,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5968,7 +5968,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5984,7 +5984,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6203,7 +6203,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6219,7 +6219,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6324,7 +6324,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6340,7 +6340,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6502,7 +6502,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6518,7 +6518,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7221,7 +7221,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7288,7 +7288,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7362,7 +7362,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7436,7 +7436,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7522,7 +7522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7613,7 +7613,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7718,7 +7718,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7798,7 +7798,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7885,7 +7885,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7986,7 +7986,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8085,7 +8085,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8190,7 +8190,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8313,7 +8313,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8377,7 +8377,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8441,7 +8441,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8513,7 +8513,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8582,7 +8582,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8657,7 +8657,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,48 +100,24 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    primaryKey: "id"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      primaryKey: "id"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -166,17 +132,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -197,30 +179,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -241,28 +219,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -292,26 +266,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -341,26 +311,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -442,17 +408,14 @@ const extensions8 = {
     foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -500,41 +463,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -551,18 +497,18 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    primaryKey: "id"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
 };
 const uniques2 = [{
@@ -582,51 +528,47 @@ const registryConfig_pgResources_posts_posts = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: {
+      name: "posts",
+      primaryKey: "id"
+    }
   }
-}];
+};
 const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -646,17 +588,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view"
+    }
   }
 };
 const uniques5 = [{
@@ -683,16 +626,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +655,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,19 +682,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    primaryKey: "street_id,property_id",
-    foreignKey: extensions8.tags.foreignKey,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -771,17 +709,18 @@ const registryConfig_pgResources_houses_houses = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: {
+      primaryKey: "street_id,property_id",
+      foreignKey: extensions8.tags.foreignKey,
+      behavior: ["-insert", "-update", "-delete"]
+    }
   }
 };
 const uniques9 = [{
@@ -801,7 +740,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -1407,21 +1356,6 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Building);
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1440,785 +1374,54 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Post_offersByPostId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_offersByPostId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_offersByPostId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_offersByPostId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_offersByPostId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_housesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_housesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_housesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_housesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_housesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_housesByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_housesByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_housesByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_housesByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_housesByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Building_housesByBuildingId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_housesByBuildingId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_housesByBuildingId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_housesByBuildingId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_housesByBuildingId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4564,7 +3767,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4731,23 +3936,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4774,23 +3989,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4817,23 +4042,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4860,23 +4095,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4903,23 +4148,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4946,23 +4201,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4989,23 +4254,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5045,23 +4320,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5084,9 +4369,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5120,8 +4412,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5304,23 +4600,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5350,23 +4656,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5396,23 +4712,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5442,23 +4768,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5481,9 +4817,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5518,23 +4861,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5564,23 +4917,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5610,23 +4973,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5649,9 +5022,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5778,23 +5158,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5817,9 +5207,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6492,9 +5889,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7053,9 +6457,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7167,9 +6578,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7349,7 +6767,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7364,7 +6784,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7379,7 +6801,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7394,7 +6818,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7409,7 +6835,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7424,7 +6852,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7438,7 +6868,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7454,7 +6886,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7468,7 +6902,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7484,7 +6920,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7498,7 +6936,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7514,7 +6954,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7530,7 +6972,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7544,7 +6988,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7560,7 +7006,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7574,7 +7022,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7591,7 +7041,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7605,7 +7057,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7621,7 +7075,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7635,7 +7091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7651,7 +7109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7665,7 +7125,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7681,7 +7143,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7695,7 +7159,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7711,7 +7177,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7727,7 +7195,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7741,7 +7211,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7757,7 +7229,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7771,7 +7245,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7788,7 +7264,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7802,7 +7280,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7818,16 +7298,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7862,11 +7350,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7881,9 +7374,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7923,11 +7422,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7949,9 +7453,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7986,11 +7496,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8012,9 +7527,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8054,11 +7575,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8087,9 +7613,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8134,11 +7666,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8167,9 +7704,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8214,11 +7757,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8261,9 +7809,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8298,11 +7852,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8316,18 +7875,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8367,11 +7937,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -8392,18 +7967,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8438,11 +8024,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8463,27 +8054,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8523,11 +8130,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8555,18 +8167,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8611,11 +8234,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8643,19 +8271,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8700,11 +8339,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8746,23 +8390,34 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8797,26 +8452,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8856,26 +8521,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8910,32 +8585,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8975,26 +8662,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9039,27 +8736,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -9104,13 +8811,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -117,7 +117,7 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -157,7 +157,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -197,7 +197,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -280,7 +280,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -325,7 +325,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -414,7 +414,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -479,10 +479,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -511,7 +511,7 @@ const registryConfig_pgResources_post_table_post_table = {
     }
   }
 };
-const uniques2 = [{
+const postsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -520,12 +520,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -542,7 +542,7 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -571,7 +571,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -580,12 +580,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -602,7 +602,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -618,12 +618,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -638,7 +638,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -647,12 +647,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -665,7 +665,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -674,12 +674,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -692,7 +692,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -701,12 +701,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
   from: housesCodec.sqlType,
   codec: housesCodec,
-  uniques: uniques8,
+  uniques: housesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -723,7 +723,7 @@ const registryConfig_pgResources_houses_houses = {
     }
   }
 };
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -732,12 +732,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -4431,7 +4431,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4447,7 +4447,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5236,7 +5236,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5252,7 +5252,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5683,7 +5683,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5699,7 +5699,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5918,7 +5918,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5934,7 +5934,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6251,7 +6251,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6267,7 +6267,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6486,7 +6486,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6502,7 +6502,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6607,7 +6607,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6623,7 +6623,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7326,7 +7326,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7393,7 +7393,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7472,7 +7472,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7546,7 +7546,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7632,7 +7632,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7723,7 +7723,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7828,7 +7828,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7908,7 +7908,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8000,7 +8000,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8101,7 +8101,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8200,7 +8200,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8305,7 +8305,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8428,7 +8428,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8492,7 +8492,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8561,7 +8561,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8633,7 +8633,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8702,7 +8702,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8777,7 +8777,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -121,17 +123,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -165,17 +167,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +211,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -441,17 +443,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -510,16 +512,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -537,8 +539,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -575,8 +577,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -607,8 +609,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -639,8 +641,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,8 +734,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -764,8 +766,8 @@ const registryConfig_pgResources_houses_houses = {
   executor: executor_mainPgExecutor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: registryConfig_pgCodecs_houses_houses.sqlType,
-  codec: registryConfig_pgCodecs_houses_houses,
+  from: housesCodec.sqlType,
+  codec: housesCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -794,8 +796,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -803,20 +805,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -832,7 +834,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -847,7 +849,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -865,7 +867,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirBuildingId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -882,7 +884,7 @@ const registry = makeRegistry({
     }),
     houses: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -897,7 +899,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByMyBuildingId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["building_id"],
@@ -912,7 +914,7 @@ const registry = makeRegistry({
         }
       },
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -927,7 +929,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertyByMyStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id", "property_id"],
@@ -944,7 +946,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -961,7 +963,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postsByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -995,7 +997,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1012,7 +1014,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -1027,7 +1029,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1042,7 +1044,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1057,7 +1059,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1074,7 +1076,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1089,7 +1091,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1104,7 +1106,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id", "prop_id"],
@@ -1121,7 +1123,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1136,7 +1138,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1151,7 +1153,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -1169,7 +1171,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -5134,7 +5136,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5150,7 +5152,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5248,7 +5250,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -5271,7 +5273,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -5838,7 +5840,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5854,7 +5856,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6122,7 +6124,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -6145,7 +6147,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -6168,7 +6170,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -6191,7 +6193,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6214,7 +6216,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -6237,7 +6239,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6260,7 +6262,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }
@@ -6285,7 +6287,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6301,7 +6303,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6433,7 +6435,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -6456,7 +6458,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -6479,7 +6481,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -6513,7 +6515,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6529,7 +6531,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6729,7 +6731,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -6752,7 +6754,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6775,7 +6777,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -6798,7 +6800,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -6821,7 +6823,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -6846,7 +6848,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6862,7 +6864,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6994,7 +6996,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -7017,7 +7019,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -7040,7 +7042,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -7074,7 +7076,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7090,7 +7092,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7154,7 +7156,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -7188,7 +7190,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7204,7 +7206,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7302,7 +7304,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -7325,7 +7327,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,49 +100,25 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    uniqueKey: "id",
-    unique: "id|@behavior -single -update -delete"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      uniqueKey: "id",
+      unique: "id|@behavior -single -update -delete"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -167,17 +133,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -198,30 +180,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view(id)"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view(id)"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -242,28 +220,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -293,26 +267,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -342,26 +312,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -443,17 +409,14 @@ const extensions8 = {
     foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -501,41 +464,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -552,85 +498,80 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    uniqueKey: "id",
-    unique: "id|@behavior -single -update -delete"
-  }
-};
-const uniques2 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.assign(Object.create(null), {
-      behavior: "-single -update -delete"
-    })
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.assign(Object.create(null), {
+        behavior: "-single -update -delete"
+      })
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: {
+      name: "posts",
+      uniqueKey: "id",
+      unique: "id|@behavior -single -update -delete"
+    }
   }
-}];
+};
 const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view(id)"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -650,17 +591,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view(id)"
+    }
   }
 };
 const uniques5 = [{
@@ -687,16 +629,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -715,16 +658,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -743,19 +685,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    primaryKey: "street_id,property_id",
-    foreignKey: extensions8.tags.foreignKey,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -775,17 +712,18 @@ const registryConfig_pgResources_houses_houses = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: {
+      primaryKey: "street_id,property_id",
+      foreignKey: extensions8.tags.foreignKey,
+      behavior: ["-insert", "-update", "-delete"]
+    }
   }
 };
 const uniques9 = [{
@@ -805,7 +743,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -1384,21 +1332,6 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const resource_postsPgResource = registry.pgResources["posts"];
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1417,727 +1350,46 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Post_offersByPostId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_offersByPostId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_offersByPostId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_offersByPostId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_offersByPostId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_housesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_housesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_housesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_housesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_housesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_housesByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_housesByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_housesByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_housesByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_housesByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Building_housesByBuildingId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_housesByBuildingId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_housesByBuildingId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_housesByBuildingId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_housesByBuildingId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4320,7 +3572,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4468,23 +3722,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4511,23 +3775,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4554,23 +3828,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4597,23 +3881,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4640,23 +3934,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4683,23 +3987,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4726,23 +4040,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4796,23 +4120,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4835,9 +4169,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4853,8 +4194,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5037,23 +4382,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5083,23 +4438,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5129,23 +4494,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5175,23 +4550,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5214,9 +4599,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5251,23 +4643,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5297,23 +4699,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5343,23 +4755,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5382,9 +4804,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5511,23 +4940,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5550,9 +4989,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6225,9 +5671,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6786,9 +6239,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6868,9 +6328,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7050,7 +6517,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7065,7 +6534,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7080,7 +6551,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7095,7 +6568,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7110,7 +6585,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7125,7 +6602,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7139,7 +6618,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7155,7 +6636,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7169,7 +6652,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7185,7 +6670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7201,7 +6688,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7215,7 +6704,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7231,7 +6722,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7245,7 +6738,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7262,7 +6757,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7276,7 +6773,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7292,7 +6791,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7306,7 +6807,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7322,7 +6825,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7336,7 +6841,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7352,7 +6859,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7368,7 +6877,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7382,7 +6893,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7398,7 +6911,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7412,7 +6927,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7429,7 +6946,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7443,7 +6962,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7459,24 +6980,37 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7491,9 +7025,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7533,11 +7073,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7559,9 +7104,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7596,11 +7147,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7622,9 +7178,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7664,11 +7226,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7697,9 +7264,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7744,11 +7317,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7777,9 +7355,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7824,11 +7408,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7871,9 +7460,15 @@ export const plans = {
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7913,11 +7508,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -7938,18 +7538,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7984,11 +7595,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8009,27 +7625,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8069,11 +7701,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8101,18 +7738,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8157,11 +7805,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8189,19 +7842,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8246,11 +7910,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8292,23 +7961,34 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8348,26 +8028,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8402,32 +8092,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8467,26 +8169,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8531,27 +8243,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8596,13 +8318,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -122,17 +124,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -166,17 +168,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -210,17 +212,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -252,17 +254,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -301,17 +303,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -350,17 +352,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -442,17 +444,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -511,16 +513,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -538,8 +540,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -579,8 +581,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -611,8 +613,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -643,8 +645,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -680,8 +682,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -708,8 +710,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -736,8 +738,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -768,8 +770,8 @@ const registryConfig_pgResources_houses_houses = {
   executor: executor_mainPgExecutor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: registryConfig_pgCodecs_houses_houses.sqlType,
-  codec: registryConfig_pgCodecs_houses_houses,
+  from: housesCodec.sqlType,
+  codec: housesCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -798,8 +800,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -807,20 +809,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -836,7 +838,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -851,7 +853,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -869,7 +871,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirBuildingId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -886,7 +888,7 @@ const registry = makeRegistry({
     }),
     houses: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -901,7 +903,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByMyBuildingId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["building_id"],
@@ -916,7 +918,7 @@ const registry = makeRegistry({
         }
       },
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -931,7 +933,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertyByMyStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id", "property_id"],
@@ -948,7 +950,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -965,7 +967,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postsByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -982,7 +984,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -999,7 +1001,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1016,7 +1018,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -1031,7 +1033,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1046,7 +1048,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1061,7 +1063,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1078,7 +1080,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1093,7 +1095,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1108,7 +1110,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id", "prop_id"],
@@ -1125,7 +1127,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1140,7 +1142,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1155,7 +1157,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -1173,7 +1175,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4867,7 +4869,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4883,7 +4885,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4981,7 +4983,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -5004,7 +5006,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -5571,7 +5573,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5587,7 +5589,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5855,7 +5857,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -5878,7 +5880,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5901,7 +5903,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -5924,7 +5926,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -5947,7 +5949,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -5970,7 +5972,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -5993,7 +5995,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }
@@ -6018,7 +6020,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6034,7 +6036,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6166,7 +6168,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -6189,7 +6191,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -6212,7 +6214,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -6246,7 +6248,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6262,7 +6264,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6462,7 +6464,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -6485,7 +6487,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6508,7 +6510,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -6531,7 +6533,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -6554,7 +6556,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -6579,7 +6581,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6595,7 +6597,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6727,7 +6729,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -6750,7 +6752,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6773,7 +6775,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6855,7 +6857,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -6889,7 +6891,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6905,7 +6907,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7003,7 +7005,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -7026,7 +7028,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -118,7 +118,7 @@ const postsCodec = recordCodec({
       unique: "id|@behavior -single -update -delete"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -158,7 +158,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -198,7 +198,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view(id)"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -236,7 +236,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -281,7 +281,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -326,7 +326,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -415,7 +415,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -480,10 +480,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -513,7 +513,7 @@ const registryConfig_pgResources_post_table_post_table = {
   }
 };
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
@@ -545,7 +545,7 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -574,7 +574,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -583,12 +583,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -605,7 +605,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -621,12 +621,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -641,7 +641,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -650,12 +650,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -668,7 +668,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -677,12 +677,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -695,7 +695,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -704,12 +704,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
   from: housesCodec.sqlType,
   codec: housesCodec,
-  uniques: uniques8,
+  uniques: housesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -726,7 +726,7 @@ const registryConfig_pgResources_houses_houses = {
     }
   }
 };
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -735,12 +735,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -4213,7 +4213,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4229,7 +4229,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5018,7 +5018,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5034,7 +5034,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5465,7 +5465,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5481,7 +5481,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5700,7 +5700,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5716,7 +5716,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6033,7 +6033,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6049,7 +6049,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6357,7 +6357,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6373,7 +6373,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7044,7 +7044,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7123,7 +7123,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7197,7 +7197,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7283,7 +7283,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7374,7 +7374,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7479,7 +7479,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7571,7 +7571,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7672,7 +7672,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7771,7 +7771,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7876,7 +7876,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7999,7 +7999,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8068,7 +8068,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8140,7 +8140,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8209,7 +8209,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8284,7 +8284,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -121,17 +123,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -165,17 +167,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +211,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -441,17 +443,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -510,16 +512,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -537,8 +539,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -575,8 +577,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -607,8 +609,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -639,8 +641,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -676,8 +678,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -704,8 +706,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -732,8 +734,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -764,8 +766,8 @@ const registryConfig_pgResources_houses_houses = {
   executor: executor_mainPgExecutor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: registryConfig_pgCodecs_houses_houses.sqlType,
-  codec: registryConfig_pgCodecs_houses_houses,
+  from: housesCodec.sqlType,
+  codec: housesCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -794,8 +796,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -803,20 +805,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -832,7 +834,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -847,7 +849,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -865,7 +867,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirBuildingId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -882,7 +884,7 @@ const registry = makeRegistry({
     }),
     houses: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -897,7 +899,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByMyBuildingId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["building_id"],
@@ -912,7 +914,7 @@ const registry = makeRegistry({
         }
       },
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -927,7 +929,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertyByMyStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_houses_houses,
+        localCodec: housesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id", "property_id"],
@@ -944,7 +946,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -961,7 +963,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postsByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -978,7 +980,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -995,7 +997,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1012,7 +1014,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -1027,7 +1029,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1042,7 +1044,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1057,7 +1059,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1074,7 +1076,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1089,7 +1091,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1104,7 +1106,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetIdAndPropertyId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id", "prop_id"],
@@ -1121,7 +1123,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1136,7 +1138,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1151,7 +1153,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -1169,7 +1171,7 @@ const registry = makeRegistry({
         }
       },
       housesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_houses_houses,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4990,7 +4992,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5006,7 +5008,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5104,7 +5106,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -5127,7 +5129,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -5694,7 +5696,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5710,7 +5712,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5978,7 +5980,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -6001,7 +6003,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -6024,7 +6026,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -6047,7 +6049,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6070,7 +6072,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -6093,7 +6095,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6116,7 +6118,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }
@@ -6141,7 +6143,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6157,7 +6159,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6289,7 +6291,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -6312,7 +6314,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -6335,7 +6337,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -6369,7 +6371,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6385,7 +6387,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6585,7 +6587,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -6608,7 +6610,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6631,7 +6633,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -6654,7 +6656,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -6677,7 +6679,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -6702,7 +6704,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6718,7 +6720,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6850,7 +6852,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -6873,7 +6875,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6896,7 +6898,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6978,7 +6980,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -7012,7 +7014,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7028,7 +7030,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -7126,7 +7128,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -7149,7 +7151,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,48 +100,24 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    unique: "id"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      unique: "id"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -166,17 +132,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -197,30 +179,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view(id)"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view(id)"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -241,28 +219,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -292,26 +266,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -341,26 +311,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -442,17 +408,14 @@ const extensions8 = {
     foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -500,41 +463,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -551,82 +497,77 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    unique: "id"
-  }
-};
-const uniques2 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
-}];
+};
 const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: {
+      name: "posts",
+      unique: "id"
+    }
   }
-}];
+};
 const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view(id)"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -646,17 +587,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view(id)"
+    }
   }
 };
 const uniques5 = [{
@@ -683,16 +625,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -711,16 +654,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -739,19 +681,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    primaryKey: "street_id,property_id",
-    foreignKey: extensions8.tags.foreignKey,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -771,17 +708,18 @@ const registryConfig_pgResources_houses_houses = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions17
-};
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: {
+      primaryKey: "street_id,property_id",
+      foreignKey: extensions8.tags.foreignKey,
+      behavior: ["-insert", "-update", "-delete"]
+    }
   }
 };
 const uniques9 = [{
@@ -801,7 +739,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -1380,21 +1328,6 @@ const fetcher6 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Building);
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1413,761 +1346,46 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Post_offersByPostId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_offersByPostId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_offersByPostId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_offersByPostId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_offersByPostId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_housesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_housesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_housesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_housesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_housesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_housesByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_housesByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_housesByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_housesByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_housesByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Building_housesByBuildingId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Building_housesByBuildingId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Building_housesByBuildingId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Building_housesByBuildingId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Building_housesByBuildingId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4433,7 +3651,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4591,23 +3811,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4634,23 +3864,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4677,23 +3917,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4720,23 +3970,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4763,23 +4023,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4806,23 +4076,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4849,23 +4129,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4901,23 +4191,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4940,9 +4240,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4976,8 +4283,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5160,23 +4471,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5206,23 +4527,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5252,23 +4583,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5298,23 +4639,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_housesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5337,9 +4688,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5374,23 +4732,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5420,23 +4788,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5466,23 +4844,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_housesByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5505,9 +4893,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5634,23 +5029,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Building_housesByBuildingId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5673,9 +5078,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6348,9 +5760,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6909,9 +6328,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6991,9 +6417,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -7173,7 +6606,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7188,7 +6623,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7203,7 +6640,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7218,7 +6657,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7233,7 +6674,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7248,7 +6691,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7264,7 +6709,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7278,7 +6725,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7294,7 +6743,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7308,7 +6759,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7324,7 +6777,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7340,7 +6795,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7354,7 +6811,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7370,7 +6829,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7384,7 +6845,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7401,7 +6864,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7415,7 +6880,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7431,7 +6898,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7447,7 +6916,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7461,7 +6932,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7477,7 +6950,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7491,7 +6966,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7507,7 +6984,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7523,7 +7002,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7537,7 +7018,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7553,7 +7036,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7567,7 +7052,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7584,7 +7071,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7598,7 +7087,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7614,24 +7105,37 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7646,9 +7150,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7688,11 +7198,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7714,9 +7229,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7751,11 +7272,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7777,9 +7303,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7819,11 +7351,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7852,9 +7389,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7899,11 +7442,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7932,9 +7480,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7979,11 +7533,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -8026,17 +7585,28 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -8050,9 +7620,15 @@ export const plans = {
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8092,11 +7668,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -8117,18 +7698,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8163,11 +7755,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8188,27 +7785,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8248,11 +7861,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8280,18 +7898,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8336,11 +7965,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8368,19 +8002,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8425,11 +8070,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8471,35 +8121,54 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
-    query: DeletePostPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8539,26 +8208,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8593,32 +8272,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8658,26 +8349,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8722,27 +8423,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8787,13 +8498,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -117,7 +117,7 @@ const postsCodec = recordCodec({
       unique: "id"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -157,7 +157,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -197,7 +197,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view(id)"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -280,7 +280,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -325,7 +325,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -414,7 +414,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -479,10 +479,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -512,7 +512,7 @@ const registryConfig_pgResources_post_table_post_table = {
   }
 };
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
@@ -541,7 +541,7 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -570,7 +570,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -579,12 +579,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -601,7 +601,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -617,12 +617,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -637,7 +637,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -646,12 +646,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -664,7 +664,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -673,12 +673,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -691,7 +691,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -700,12 +700,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
   from: housesCodec.sqlType,
   codec: housesCodec,
-  uniques: uniques8,
+  uniques: housesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -722,7 +722,7 @@ const registryConfig_pgResources_houses_houses = {
     }
   }
 };
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -731,12 +731,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -4302,7 +4302,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4318,7 +4318,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5107,7 +5107,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5123,7 +5123,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5554,7 +5554,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5570,7 +5570,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5789,7 +5789,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5805,7 +5805,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6122,7 +6122,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6138,7 +6138,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6446,7 +6446,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6462,7 +6462,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -7169,7 +7169,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7248,7 +7248,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7322,7 +7322,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7408,7 +7408,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7499,7 +7499,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7639,7 +7639,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7731,7 +7731,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7832,7 +7832,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7931,7 +7931,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8036,7 +8036,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8179,7 +8179,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8248,7 +8248,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8320,7 +8320,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8389,7 +8389,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8464,7 +8464,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, as
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const handler = {
   typeName: "Query",
   codec: {
@@ -29,40 +26,25 @@ const handler = {
     return constant`query`;
   }
 };
-function base64JSONDecode(value) {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-function base64JSONEncode(value) {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode: base64JSONEncode,
-  decode: base64JSONDecode
+  encode(value) {
+    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  },
+  decode(value) {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  }
 };
-function pipeStringDecode(value) {
-  return typeof value === "string" ? value.split("|") : null;
-}
-function pipeStringEncode(value) {
-  return Array.isArray(value) ? value.join("|") : null;
-}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode: pipeStringEncode,
-    decode: pipeStringDecode
-  }
-});
-const post_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
+    encode(value) {
+      return Array.isArray(value) ? value.join("|") : null;
+    },
+    decode(value) {
+      return typeof value === "string" ? value.split("|") : null;
     }
   }
 });
@@ -89,16 +71,24 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
-const post_tableCodecSpec = {
+const post_tableCodec = recordCodec({
   name: "post_table",
-  identifier: post_tableIdentifier,
-  attributes: post_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "post"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
-};
-const post_tableCodec = recordCodec(post_tableCodecSpec);
+});
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -110,48 +100,24 @@ const postsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "posts",
-    primaryKey: "id"
-  })
-};
-const parts2 = ["smart_comment_relations", "post_view"];
-const postsIdentifier = sql.identifier(...parts2);
-const postsCodecSpec = {
+const postsCodec = recordCodec({
   name: "posts",
-  identifier: postsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "post_view"),
   attributes: postsAttributes,
   description: undefined,
-  extensions: extensions2,
-  executor: executor_mainPgExecutor
-};
-const postsCodec = recordCodec(postsCodecSpec);
-const offer_tableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "posts",
+      primaryKey: "id"
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const extensions3 = {
   isTableLike: true,
@@ -166,17 +132,33 @@ const extensions3 = {
     behavior: ["-*"]
   })
 };
-const parts3 = ["smart_comment_relations", "offer"];
-const offer_tableIdentifier = sql.identifier(...parts3);
-const offer_tableCodecSpec = {
+const offer_tableCodec = recordCodec({
   name: "offer_table",
-  identifier: offer_tableIdentifier,
-  attributes: offer_tableAttributes,
+  identifier: sql.identifier("smart_comment_relations", "offer"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
-};
-const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+});
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -197,30 +179,26 @@ const offersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view (id)"
-  })
-};
-const parts4 = ["smart_comment_relations", "offer_view"];
-const offersIdentifier = sql.identifier(...parts4);
-const offersCodecSpec = {
+const offersCodec = recordCodec({
   name: "offers",
-  identifier: offersIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "offer_view"),
   attributes: offersAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view (id)"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const offersCodec = recordCodec(offersCodecSpec);
+});
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -241,28 +219,24 @@ const streetsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: Object.assign(Object.create(null), {
-    unique: "name"
-  })
-};
-const parts5 = ["smart_comment_relations", "streets"];
-const streetsIdentifier = sql.identifier(...parts5);
-const streetsCodecSpec = {
+const streetsCodec = recordCodec({
   name: "streets",
-  identifier: streetsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "streets"),
   attributes: streetsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: Object.assign(Object.create(null), {
+      unique: "name"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const streetsCodec = recordCodec(streetsCodecSpec);
+});
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -292,26 +266,22 @@ const propertiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["smart_comment_relations", "properties"];
-const propertiesIdentifier = sql.identifier(...parts6);
-const propertiesCodecSpec = {
+const propertiesCodec = recordCodec({
   name: "properties",
-  identifier: propertiesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "properties"),
   attributes: propertiesAttributes,
   description: undefined,
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const propertiesCodec = recordCodec(propertiesCodecSpec);
+});
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
@@ -341,26 +311,22 @@ const streetPropertyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["smart_comment_relations", "street_property"];
-const streetPropertyIdentifier = sql.identifier(...parts7);
-const streetPropertyCodecSpec = {
+const streetPropertyCodec = recordCodec({
   name: "streetProperty",
-  identifier: streetPropertyIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "street_property"),
   attributes: streetPropertyAttributes,
   description: undefined,
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+});
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
@@ -443,17 +409,14 @@ const extensions8 = {
     unique: ["street_name,property_id", "street_id,property_name_or_number", "street_name,building_name"]
   })
 };
-const parts8 = ["smart_comment_relations", "houses"];
-const housesIdentifier = sql.identifier(...parts8);
-const housesCodecSpec = {
+const housesCodec = recordCodec({
   name: "houses",
-  identifier: housesIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "houses"),
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
-};
-const housesCodec = recordCodec(housesCodecSpec);
+});
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -501,41 +464,24 @@ const buildingsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  })
-};
-const parts9 = ["smart_comment_relations", "buildings"];
-const buildingsIdentifier = sql.identifier(...parts9);
-const buildingsCodecSpec = {
+const buildingsCodec = recordCodec({
   name: "buildings",
-  identifier: buildingsIdentifier,
+  identifier: sql.identifier("smart_comment_relations", "buildings"),
   attributes: buildingsAttributes,
   description: undefined,
-  extensions: extensions9,
-  executor: executor_mainPgExecutor
-};
-const buildingsCodec = recordCodec(buildingsCodecSpec);
-const extensions10 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    })
   },
-  tags: {
-    name: "post_table",
-    omit: true,
-    behavior: extensions.tags.behavior
-  }
-};
+  executor: executor_mainPgExecutor
+});
 const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
@@ -552,18 +498,18 @@ const registryConfig_pgResources_post_table_post_table = {
   }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions10
-};
-const extensions11 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post_view"
-  },
-  tags: {
-    name: "posts",
-    primaryKey: "id"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: {
+      name: "post_table",
+      omit: true,
+      behavior: extensions.tags.behavior
+    }
   }
 };
 const uniques2 = [{
@@ -583,51 +529,47 @@ const registryConfig_pgResources_posts_posts = {
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions11
-};
-const extensions12 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: {
-    name: "offer_table",
-    omit: true,
-    behavior: extensions3.tags.behavior
-  }
-};
-const uniques3 = [{
-  isPrimary: true,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post_view"
+    },
+    tags: {
+      name: "posts",
+      primaryKey: "id"
+    }
   }
-}];
+};
 const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
   codec: offer_tableCodec,
-  uniques: uniques3,
+  uniques: [{
+    isPrimary: true,
+    attributes: ["id"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions12
-};
-const extensions13 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer_view"
-  },
-  tags: {
-    name: "offers",
-    primaryKey: "id",
-    foreignKey: "(post_id) references post_view (id)"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: {
+      name: "offer_table",
+      omit: true,
+      behavior: extensions3.tags.behavior
+    }
   }
 };
 const uniques4 = [{
@@ -647,17 +589,18 @@ const registryConfig_pgResources_offers_offers = {
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions13
-};
-const extensions14 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "streets"
-  },
-  tags: {
-    unique: "name"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer_view"
+    },
+    tags: {
+      name: "offers",
+      primaryKey: "id",
+      foreignKey: "(post_id) references post_view (id)"
+    }
   }
 };
 const uniques5 = [{
@@ -684,16 +627,17 @@ const registryConfig_pgResources_streets_streets = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions14
-};
-const extensions15 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "properties"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "streets"
+    },
+    tags: {
+      unique: "name"
+    }
+  }
 };
 const uniques6 = [{
   isPrimary: true,
@@ -712,16 +656,15 @@ const registryConfig_pgResources_properties_properties = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions15
-};
-const extensions16 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "street_property"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "properties"
+    },
+    tags: {}
+  }
 };
 const uniques7 = [{
   isPrimary: true,
@@ -740,20 +683,14 @@ const registryConfig_pgResources_street_property_street_property = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions16
-};
-const extensions17 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: {
-    name: "houses",
-    primaryKey: "street_id,property_id",
-    unique: extensions8.tags.unique,
-    behavior: ["-insert", "-update", "-delete"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "street_property"
+    },
+    tags: {}
   }
 };
 const uniques8 = [{
@@ -785,17 +722,6 @@ const uniques8 = [{
     tags: Object.create(null)
   }
 }];
-const extensions18 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "buildings"
-  },
-  tags: {
-    foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
-  }
-};
 const uniques9 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -813,7 +739,17 @@ const registryConfig_pgResources_buildings_buildings = {
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions18
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "buildings"
+    },
+    tags: {
+      foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
+    }
+  }
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
@@ -849,7 +785,20 @@ const registry = makeRegistry({
       uniques: uniques8,
       isVirtual: false,
       description: undefined,
-      extensions: extensions17
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "smart_comment_relations",
+          name: "houses"
+        },
+        tags: {
+          name: "houses",
+          primaryKey: "street_id,property_id",
+          unique: extensions8.tags.unique,
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     buildings: registryConfig_pgResources_buildings_buildings
   }),
@@ -1307,21 +1256,6 @@ const fetcher7 = (handler => {
   fn.deprecationReason = handler.deprecationReason;
   return fn;
 })(nodeIdHandlerByTypeName.Building);
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -1340,740 +1274,54 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allOffers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOffers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOffers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOffers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOffers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allStreetProperties_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allStreetProperties_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allStreetProperties_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allStreetProperties_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allStreetProperties_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allHouses_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allHouses_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allHouses_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allHouses_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allHouses_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBuildings_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBuildings_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBuildings_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBuildings_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBuildings_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Post_offersByPostId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_offersByPostId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_offersByPostId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_offersByPostId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_offersByPostId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function OffersConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OffersConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OffersConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function Street_propertiesByStreetId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_propertiesByStreetId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_propertiesByStreetId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_propertiesByStreetId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_propertiesByStreetId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_streetPropertiesByStrId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_streetPropertiesByStrId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_streetPropertiesByStrId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_streetPropertiesByStrId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_streetPropertiesByStrId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Street_buildingsNamedAfterStreet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Street_buildingsNamedAfterStreet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Property_streetPropertiesByPropId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_streetPropertiesByPropId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_streetPropertiesByPropId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_streetPropertiesByPropId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_streetPropertiesByPropId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Property_buildingsByPropertyId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Property_buildingsByPropertyId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Property_buildingsByPropertyId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Property_buildingsByPropertyId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Property_buildingsByPropertyId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function StreetPropertiesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetPropertiesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetPropertiesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BuildingsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BuildingsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BuildingsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StreetsConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StreetsConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StreetsConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function HousesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function HousesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function HousesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_updatePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs2 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_updateOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs3 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_updateStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs4 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_updateProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs5 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_updateStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs6 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_updateBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs7 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
 };
-function Mutation_deletePost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs8 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
 };
-function Mutation_deleteOffer_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOfferById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs9 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Street, $nodeId);
 };
-function Mutation_deleteStreet_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetById_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetByName_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs10 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Property, $nodeId);
 };
-function Mutation_deleteProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePropertyById_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs11 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.StreetProperty, $nodeId);
 };
-function Mutation_deleteStreetProperty_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan(_, $object) {
-  return $object;
-}
 const specFromArgs12 = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Building, $nodeId);
 };
-function Mutation_deleteBuilding_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBuildingById_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function CreateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOfferInput_offer_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetInput_street_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function CreatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePropertyInput_property_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function CreateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateStreetPropertyInput_streetProperty_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function CreateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBuildingInput_building_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function UpdateOfferPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOfferByIdInput_offerPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByIdInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetByNameInput_streetPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function UpdatePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePropertyByIdInput_propertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function UpdateStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function UpdateBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBuildingByIdInput_buildingPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOfferPayload_offerPlan($object) {
-  return $object.get("result");
-}
-function DeleteOfferPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOfferInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOfferByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPayload_streetPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePropertyPayload_propertyPlan($object) {
-  return $object.get("result");
-}
-function DeletePropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePropertyByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteStreetPropertyPayload_streetPropertyPlan($object) {
-  return $object.get("result");
-}
-function DeleteStreetPropertyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteStreetPropertyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBuildingPayload_buildingPlan($object) {
-  return $object.get("result");
-}
-function DeleteBuildingPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBuildingInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBuildingByIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -4326,7 +3574,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     nodeId($parent) {
       const specifier = handler.plan($parent);
       return lambda(specifier, nodeIdCodecs[handler.codec.name].encode);
@@ -4529,23 +3779,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4572,23 +3832,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOffers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4615,23 +3885,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4658,23 +3938,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4701,23 +3991,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allStreetProperties_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4744,23 +4044,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allHouses_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4787,23 +4097,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBuildings_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4843,23 +4163,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_offersByPostId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -4882,9 +4212,16 @@ export const plans = {
   },
   OffersConnection: {
     __assertStep: ConnectionStep,
-    nodes: OffersConnection_nodesPlan,
-    edges: OffersConnection_edgesPlan,
-    pageInfo: OffersConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -4918,8 +4255,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -5102,23 +4443,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_propertiesByStreetId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5148,23 +4499,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_streetPropertiesByStrId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5194,23 +4555,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Street_buildingsNamedAfterStreet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5233,9 +4604,16 @@ export const plans = {
   },
   PropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: PropertiesConnection_nodesPlan,
-    edges: PropertiesConnection_edgesPlan,
-    pageInfo: PropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5270,23 +4648,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_streetPropertiesByPropId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5316,23 +4704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Property_buildingsByPropertyId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -5355,9 +4753,16 @@ export const plans = {
   },
   StreetPropertiesConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetPropertiesConnection_nodesPlan,
-    edges: StreetPropertiesConnection_edgesPlan,
-    pageInfo: StreetPropertiesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -5609,9 +5014,16 @@ export const plans = {
   },
   BuildingsConnection: {
     __assertStep: ConnectionStep,
-    nodes: BuildingsConnection_nodesPlan,
-    edges: BuildingsConnection_edgesPlan,
-    pageInfo: BuildingsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6230,9 +5642,16 @@ export const plans = {
   },
   PostsConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostsConnection_nodesPlan,
-    edges: PostsConnection_edgesPlan,
-    pageInfo: PostsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6344,9 +5763,16 @@ export const plans = {
   },
   StreetsConnection: {
     __assertStep: ConnectionStep,
-    nodes: StreetsConnection_nodesPlan,
-    edges: StreetsConnection_edgesPlan,
-    pageInfo: StreetsConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6515,9 +5941,16 @@ export const plans = {
   },
   HousesConnection: {
     __assertStep: ConnectionStep,
-    nodes: HousesConnection_nodesPlan,
-    edges: HousesConnection_edgesPlan,
-    pageInfo: HousesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -6982,7 +6415,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -6997,7 +6432,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7012,7 +6449,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7027,7 +6466,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7042,7 +6483,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7057,7 +6500,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7071,7 +6516,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7087,7 +6534,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7101,7 +6550,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7117,7 +6568,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7131,7 +6584,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7147,7 +6602,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7163,7 +6620,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7177,7 +6636,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7193,7 +6654,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7207,7 +6670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7224,7 +6689,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7238,7 +6705,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7254,7 +6723,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7268,7 +6739,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7284,7 +6757,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7298,7 +6773,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOffer_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7314,7 +6791,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOfferById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7328,7 +6807,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7344,7 +6825,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7360,7 +6843,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7374,7 +6859,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7390,7 +6877,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePropertyById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7404,7 +6893,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetProperty_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7421,7 +6912,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteStreetPropertyByStrIdAndPropId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7435,7 +6928,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuilding_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -7451,16 +6946,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBuildingById_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7495,11 +6998,16 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7514,9 +7022,15 @@ export const plans = {
   },
   CreateOfferPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOfferPayload_clientMutationIdPlan,
-    offer: CreateOfferPayload_offerPlan,
-    query: CreateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7556,11 +7070,16 @@ export const plans = {
   },
   CreateOfferInput: {
     clientMutationId: {
-      applyPlan: CreateOfferInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     offer: {
-      applyPlan: CreateOfferInput_offer_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7582,9 +7101,15 @@ export const plans = {
   },
   CreateStreetPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPayload_clientMutationIdPlan,
-    street: CreateStreetPayload_streetPlan,
-    query: CreateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7619,11 +7144,16 @@ export const plans = {
   },
   CreateStreetInput: {
     clientMutationId: {
-      applyPlan: CreateStreetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     street: {
-      applyPlan: CreateStreetInput_street_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7645,9 +7175,15 @@ export const plans = {
   },
   CreatePropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePropertyPayload_clientMutationIdPlan,
-    property: CreatePropertyPayload_propertyPlan,
-    query: CreatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7687,11 +7223,16 @@ export const plans = {
   },
   CreatePropertyInput: {
     clientMutationId: {
-      applyPlan: CreatePropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     property: {
-      applyPlan: CreatePropertyInput_property_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7720,9 +7261,15 @@ export const plans = {
   },
   CreateStreetPropertyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: CreateStreetPropertyPayload_streetPropertyPlan,
-    query: CreateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7767,11 +7314,16 @@ export const plans = {
   },
   CreateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: CreateStreetPropertyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     streetProperty: {
-      applyPlan: CreateStreetPropertyInput_streetProperty_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7800,9 +7352,15 @@ export const plans = {
   },
   CreateBuildingPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBuildingPayload_clientMutationIdPlan,
-    building: CreateBuildingPayload_buildingPlan,
-    query: CreateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7847,11 +7405,16 @@ export const plans = {
   },
   CreateBuildingInput: {
     clientMutationId: {
-      applyPlan: CreateBuildingInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     building: {
-      applyPlan: CreateBuildingInput_building_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -7894,9 +7457,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -7931,11 +7500,16 @@ export const plans = {
   },
   UpdatePostInput: {
     clientMutationId: {
-      applyPlan: UpdatePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     postPatch: {
-      applyPlan: UpdatePostInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -7949,18 +7523,29 @@ export const plans = {
   },
   UpdatePostByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     postPatch: {
-      applyPlan: UpdatePostByIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOfferPayload_clientMutationIdPlan,
-    offer: UpdateOfferPayload_offerPlan,
-    query: UpdateOfferPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8000,11 +7585,16 @@ export const plans = {
   },
   UpdateOfferInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OfferPatch: {
@@ -8025,18 +7615,29 @@ export const plans = {
   },
   UpdateOfferByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     offerPatch: {
-      applyPlan: UpdateOfferByIdInput_offerPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPayload_clientMutationIdPlan,
-    street: UpdateStreetPayload_streetPlan,
-    query: UpdateStreetPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8071,11 +7672,16 @@ export const plans = {
   },
   UpdateStreetInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPatch: {
@@ -8096,27 +7702,43 @@ export const plans = {
   },
   UpdateStreetByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByIdInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     streetPatch: {
-      applyPlan: UpdateStreetByNameInput_streetPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePropertyPayload_clientMutationIdPlan,
-    property: UpdatePropertyPayload_propertyPlan,
-    query: UpdatePropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8156,11 +7778,16 @@ export const plans = {
   },
   UpdatePropertyInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PropertyPatch: {
@@ -8188,18 +7815,29 @@ export const plans = {
   },
   UpdatePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     propertyPatch: {
-      applyPlan: UpdatePropertyByIdInput_propertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: UpdateStreetPropertyPayload_streetPropertyPlan,
-    query: UpdateStreetPropertyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8244,11 +7882,16 @@ export const plans = {
   },
   UpdateStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   StreetPropertyPatch: {
@@ -8276,19 +7919,30 @@ export const plans = {
   },
   UpdateStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined,
     streetPropertyPatch: {
-      applyPlan: UpdateStreetPropertyByStrIdAndPropIdInput_streetPropertyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBuildingPayload_clientMutationIdPlan,
-    building: UpdateBuildingPayload_buildingPlan,
-    query: UpdateBuildingPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8333,11 +7987,16 @@ export const plans = {
   },
   UpdateBuildingInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BuildingPatch: {
@@ -8379,23 +8038,34 @@ export const plans = {
   },
   UpdateBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined,
     buildingPatch: {
-      applyPlan: UpdateBuildingByIdInput_buildingPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePostPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8430,26 +8100,36 @@ export const plans = {
   },
   DeletePostInput: {
     clientMutationId: {
-      applyPlan: DeletePostInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePostByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteOfferPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOfferPayload_clientMutationIdPlan,
-    offer: DeleteOfferPayload_offerPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    offer($object) {
+      return $object.get("result");
+    },
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteOfferPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     offerEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8489,26 +8169,36 @@ export const plans = {
   },
   DeleteOfferInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteOfferByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOfferByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPayload_clientMutationIdPlan,
-    street: DeleteStreetPayload_streetPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    street($object) {
+      return $object.get("result");
+    },
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8543,32 +8233,44 @@ export const plans = {
   },
   DeleteStreetInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePropertyPayload_clientMutationIdPlan,
-    property: DeletePropertyPayload_propertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    property($object) {
+      return $object.get("result");
+    },
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeletePropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     propertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8608,26 +8310,36 @@ export const plans = {
   },
   DeletePropertyInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeletePropertyByIdInput: {
     clientMutationId: {
-      applyPlan: DeletePropertyByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   },
   DeleteStreetPropertyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteStreetPropertyPayload_clientMutationIdPlan,
-    streetProperty: DeleteStreetPropertyPayload_streetPropertyPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    streetProperty($object) {
+      return $object.get("result");
+    },
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteStreetPropertyPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     streetPropertyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8672,27 +8384,37 @@ export const plans = {
   },
   DeleteStreetPropertyInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteStreetPropertyByStrIdAndPropIdInput: {
     clientMutationId: {
-      applyPlan: DeleteStreetPropertyByStrIdAndPropIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     strId: undefined,
     propId: undefined
   },
   DeleteBuildingPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBuildingPayload_clientMutationIdPlan,
-    building: DeleteBuildingPayload_buildingPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    building($object) {
+      return $object.get("result");
+    },
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
       return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
-    query: DeleteBuildingPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     buildingEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -8737,13 +8459,17 @@ export const plans = {
   },
   DeleteBuildingInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     nodeId: undefined
   },
   DeleteBuildingByIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBuildingByIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     id: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -48,7 +48,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -87,7 +87,7 @@ const post_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions,
-  executor: executor_mainPgExecutor
+  executor
 });
 const postsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -117,7 +117,7 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const extensions3 = {
   isTableLike: true,
@@ -157,7 +157,7 @@ const offer_tableCodec = recordCodec({
   }),
   description: undefined,
   extensions: extensions3,
-  executor: executor_mainPgExecutor
+  executor
 });
 const offersAttributes = Object.assign(Object.create(null), {
   id: {
@@ -197,7 +197,7 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view (id)"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -235,7 +235,7 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -280,7 +280,7 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
@@ -325,7 +325,7 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
@@ -415,7 +415,7 @@ const housesCodec = recordCodec({
   attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
-  executor: executor_mainPgExecutor
+  executor
 });
 const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -480,10 +480,10 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgResources_post_table_post_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
   from: post_tableCodec.sqlType,
@@ -512,7 +512,7 @@ const registryConfig_pgResources_post_table_post_table = {
     }
   }
 };
-const uniques2 = [{
+const postsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -521,12 +521,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
   from: postsCodec.sqlType,
   codec: postsCodec,
-  uniques: uniques2,
+  uniques: postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -543,7 +543,7 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
   from: offer_tableCodec.sqlType,
@@ -572,7 +572,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     }
   }
 };
-const uniques4 = [{
+const offersUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -581,12 +581,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
   from: offersCodec.sqlType,
   codec: offersCodec,
-  uniques: uniques4,
+  uniques: offersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -603,7 +603,7 @@ const registryConfig_pgResources_offers_offers = {
     }
   }
 };
-const uniques5 = [{
+const streetsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -619,12 +619,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
   from: streetsCodec.sqlType,
   codec: streetsCodec,
-  uniques: uniques5,
+  uniques: streetsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -639,7 +639,7 @@ const registryConfig_pgResources_streets_streets = {
     }
   }
 };
-const uniques6 = [{
+const propertiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -648,12 +648,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
   from: propertiesCodec.sqlType,
   codec: propertiesCodec,
-  uniques: uniques6,
+  uniques: propertiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -666,7 +666,7 @@ const registryConfig_pgResources_properties_properties = {
     tags: {}
   }
 };
-const uniques7 = [{
+const street_propertyUniques = [{
   isPrimary: true,
   attributes: ["str_id", "prop_id"],
   description: undefined,
@@ -675,12 +675,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
   from: streetPropertyCodec.sqlType,
   codec: streetPropertyCodec,
-  uniques: uniques7,
+  uniques: street_propertyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -693,7 +693,7 @@ const registryConfig_pgResources_street_property_street_property = {
     tags: {}
   }
 };
-const uniques8 = [{
+const housesUniques = [{
   isPrimary: true,
   attributes: ["street_id", "property_id"],
   description: undefined,
@@ -722,7 +722,7 @@ const uniques8 = [{
     tags: Object.create(null)
   }
 }];
-const uniques9 = [{
+const buildingsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -731,12 +731,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
   from: buildingsCodec.sqlType,
   codec: buildingsCodec,
-  uniques: uniques9,
+  uniques: buildingsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -777,12 +777,12 @@ const registry = makeRegistry({
     properties: registryConfig_pgResources_properties_properties,
     street_property: registryConfig_pgResources_street_property_street_property,
     houses: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "houses",
       identifier: "main.smart_comment_relations.houses",
       from: housesCodec.sqlType,
       codec: housesCodec,
-      uniques: uniques8,
+      uniques: housesUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -4274,7 +4274,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4290,7 +4290,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        offersUniques[0].attributes.forEach(attributeName => {
           const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4808,7 +4808,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -4824,7 +4824,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        street_propertyUniques[0].attributes.forEach(attributeName => {
           const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5075,7 +5075,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5091,7 +5091,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        buildingsUniques[0].attributes.forEach(attributeName => {
           const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5408,7 +5408,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5424,7 +5424,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        propertiesUniques[0].attributes.forEach(attributeName => {
           const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5671,7 +5671,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5687,7 +5687,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        postsUniques[0].attributes.forEach(attributeName => {
           const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5792,7 +5792,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5808,7 +5808,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        streetsUniques[0].attributes.forEach(attributeName => {
           const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5970,7 +5970,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -5986,7 +5986,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        housesUniques[0].attributes.forEach(attributeName => {
           const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -6974,7 +6974,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7041,7 +7041,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7120,7 +7120,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7194,7 +7194,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7280,7 +7280,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7371,7 +7371,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7476,7 +7476,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7556,7 +7556,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7648,7 +7648,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7749,7 +7749,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7848,7 +7848,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -7953,7 +7953,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8076,7 +8076,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = postsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8140,7 +8140,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = offersUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8209,7 +8209,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = streetsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8281,7 +8281,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = propertiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8350,7 +8350,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = street_propertyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -8425,7 +8425,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = buildingsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -55,6 +55,17 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     decode: pipeStringDecode
   }
 });
+const post_tableAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: true,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }
+});
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -78,26 +89,17 @@ const extensions = {
     behavior: ["-*"]
   })
 };
-const spec_post_table = {
+const post_tableIdentifier = sql.identifier(...["smart_comment_relations", "post"]);
+const post_tableCodecSpec = {
   name: "post_table",
-  identifier: sql.identifier(...["smart_comment_relations", "post"]),
-  attributes: Object.assign(Object.create(null), {
-    id: {
-      description: undefined,
-      codec: TYPES.text,
-      notNull: true,
-      hasDefault: false,
-      extensions: {
-        tags: {}
-      }
-    }
-  }),
+  identifier: post_tableIdentifier,
+  attributes: post_tableAttributes,
   description: undefined,
   extensions,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_post_table_post_table = recordCodec(spec_post_table);
-const attributes2 = Object.assign(Object.create(null), {
+const post_tableCodec = recordCodec(post_tableCodecSpec);
+const postsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.text,
@@ -121,17 +123,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["smart_comment_relations", "post_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_posts = {
+const postsIdentifier = sql.identifier(...parts2);
+const postsCodecSpec = {
   name: "posts",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: postsIdentifier,
+  attributes: postsAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_posts_posts = recordCodec(spec_posts);
-const attributes3 = Object.assign(Object.create(null), {
+const postsCodec = recordCodec(postsCodecSpec);
+const offer_tableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -165,17 +167,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["smart_comment_relations", "offer"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_offer_table = {
+const offer_tableIdentifier = sql.identifier(...parts3);
+const offer_tableCodecSpec = {
   name: "offer_table",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: offer_tableIdentifier,
+  attributes: offer_tableAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offer_table_offer_table = recordCodec(spec_offer_table);
-const attributes4 = Object.assign(Object.create(null), {
+const offer_tableCodec = recordCodec(offer_tableCodecSpec);
+const offersAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +211,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["smart_comment_relations", "offer_view"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_offers = {
+const offersIdentifier = sql.identifier(...parts4);
+const offersCodecSpec = {
   name: "offers",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: offersIdentifier,
+  attributes: offersAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_offers_offers = recordCodec(spec_offers);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const offersCodec = recordCodec(offersCodecSpec);
+const streetsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -251,17 +253,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["smart_comment_relations", "streets"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_streets = {
+const streetsIdentifier = sql.identifier(...parts5);
+const streetsCodecSpec = {
   name: "streets",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: streetsIdentifier,
+  attributes: streetsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streets_streets = recordCodec(spec_streets);
-const attributes5 = Object.assign(Object.create(null), {
+const streetsCodec = recordCodec(streetsCodecSpec);
+const propertiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -300,17 +302,17 @@ const extensions6 = {
   tags: Object.create(null)
 };
 const parts6 = ["smart_comment_relations", "properties"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_properties = {
+const propertiesIdentifier = sql.identifier(...parts6);
+const propertiesCodecSpec = {
   name: "properties",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: propertiesIdentifier,
+  attributes: propertiesAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_properties_properties = recordCodec(spec_properties);
-const attributes6 = Object.assign(Object.create(null), {
+const propertiesCodec = recordCodec(propertiesCodecSpec);
+const streetPropertyAttributes = Object.assign(Object.create(null), {
   str_id: {
     description: undefined,
     codec: TYPES.int,
@@ -349,17 +351,17 @@ const extensions7 = {
   tags: Object.create(null)
 };
 const parts7 = ["smart_comment_relations", "street_property"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_streetProperty = {
+const streetPropertyIdentifier = sql.identifier(...parts7);
+const streetPropertyCodecSpec = {
   name: "streetProperty",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: streetPropertyIdentifier,
+  attributes: streetPropertyAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_streetProperty_streetProperty = recordCodec(spec_streetProperty);
-const attributes7 = Object.assign(Object.create(null), {
+const streetPropertyCodec = recordCodec(streetPropertyCodecSpec);
+const housesAttributes = Object.assign(Object.create(null), {
   building_name: {
     description: undefined,
     codec: TYPES.text,
@@ -442,17 +444,17 @@ const extensions8 = {
   })
 };
 const parts8 = ["smart_comment_relations", "houses"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_houses = {
+const housesIdentifier = sql.identifier(...parts8);
+const housesCodecSpec = {
   name: "houses",
-  identifier: sqlIdent8,
-  attributes: attributes7,
+  identifier: housesIdentifier,
+  attributes: housesAttributes,
   description: undefined,
   extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_houses_houses = recordCodec(spec_houses);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const housesCodec = recordCodec(housesCodecSpec);
+const buildingsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -511,16 +513,16 @@ const extensions9 = {
   })
 };
 const parts9 = ["smart_comment_relations", "buildings"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_buildings = {
+const buildingsIdentifier = sql.identifier(...parts9);
+const buildingsCodecSpec = {
   name: "buildings",
-  identifier: sqlIdent9,
-  attributes: attributes_object_Object_2,
+  identifier: buildingsIdentifier,
+  attributes: buildingsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_buildings_buildings = recordCodec(spec_buildings);
+const buildingsCodec = recordCodec(buildingsCodecSpec);
 const extensions10 = {
   description: undefined,
   pg: {
@@ -538,8 +540,8 @@ const registryConfig_pgResources_post_table_post_table = {
   executor: executor_mainPgExecutor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: registryConfig_pgCodecs_post_table_post_table.sqlType,
-  codec: registryConfig_pgCodecs_post_table_post_table,
+  from: post_tableCodec.sqlType,
+  codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
     attributes: ["id"],
@@ -576,8 +578,8 @@ const registryConfig_pgResources_posts_posts = {
   executor: executor_mainPgExecutor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: registryConfig_pgCodecs_posts_posts.sqlType,
-  codec: registryConfig_pgCodecs_posts_posts,
+  from: postsCodec.sqlType,
+  codec: postsCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -608,8 +610,8 @@ const registryConfig_pgResources_offer_table_offer_table = {
   executor: executor_mainPgExecutor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: registryConfig_pgCodecs_offer_table_offer_table.sqlType,
-  codec: registryConfig_pgCodecs_offer_table_offer_table,
+  from: offer_tableCodec.sqlType,
+  codec: offer_tableCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -640,8 +642,8 @@ const registryConfig_pgResources_offers_offers = {
   executor: executor_mainPgExecutor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: registryConfig_pgCodecs_offers_offers.sqlType,
-  codec: registryConfig_pgCodecs_offers_offers,
+  from: offersCodec.sqlType,
+  codec: offersCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -677,8 +679,8 @@ const registryConfig_pgResources_streets_streets = {
   executor: executor_mainPgExecutor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: registryConfig_pgCodecs_streets_streets.sqlType,
-  codec: registryConfig_pgCodecs_streets_streets,
+  from: streetsCodec.sqlType,
+  codec: streetsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -705,8 +707,8 @@ const registryConfig_pgResources_properties_properties = {
   executor: executor_mainPgExecutor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: registryConfig_pgCodecs_properties_properties.sqlType,
-  codec: registryConfig_pgCodecs_properties_properties,
+  from: propertiesCodec.sqlType,
+  codec: propertiesCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -733,8 +735,8 @@ const registryConfig_pgResources_street_property_street_property = {
   executor: executor_mainPgExecutor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: registryConfig_pgCodecs_streetProperty_streetProperty.sqlType,
-  codec: registryConfig_pgCodecs_streetProperty_streetProperty,
+  from: streetPropertyCodec.sqlType,
+  codec: streetPropertyCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -806,8 +808,8 @@ const registryConfig_pgResources_buildings_buildings = {
   executor: executor_mainPgExecutor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: registryConfig_pgCodecs_buildings_buildings.sqlType,
-  codec: registryConfig_pgCodecs_buildings_buildings,
+  from: buildingsCodec.sqlType,
+  codec: buildingsCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -815,20 +817,20 @@ const registryConfig_pgResources_buildings_buildings = {
 };
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
-    post_table: registryConfig_pgCodecs_post_table_post_table,
+    post_table: post_tableCodec,
     text: TYPES.text,
-    posts: registryConfig_pgCodecs_posts_posts,
-    offer_table: registryConfig_pgCodecs_offer_table_offer_table,
+    posts: postsCodec,
+    offer_table: offer_tableCodec,
     int4: TYPES.int,
-    offers: registryConfig_pgCodecs_offers_offers,
-    streets: registryConfig_pgCodecs_streets_streets,
-    properties: registryConfig_pgCodecs_properties_properties,
-    streetProperty: registryConfig_pgCodecs_streetProperty_streetProperty,
-    houses: registryConfig_pgCodecs_houses_houses,
+    offers: offersCodec,
+    streets: streetsCodec,
+    properties: propertiesCodec,
+    streetProperty: streetPropertyCodec,
+    houses: housesCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     bool: TYPES.boolean,
-    buildings: registryConfig_pgCodecs_buildings_buildings
+    buildings: buildingsCodec
   }),
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
@@ -842,8 +844,8 @@ const registry = makeRegistry({
       executor: executor_mainPgExecutor,
       name: "houses",
       identifier: "main.smart_comment_relations.houses",
-      from: registryConfig_pgCodecs_houses_houses.sqlType,
-      codec: registryConfig_pgCodecs_houses_houses,
+      from: housesCodec.sqlType,
+      codec: housesCodec,
       uniques: uniques8,
       isVirtual: false,
       description: undefined,
@@ -854,7 +856,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     buildings: Object.assign(Object.create(null), {
       propertiesByMyPropertyId: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["property_id"],
@@ -869,7 +871,7 @@ const registry = makeRegistry({
         }
       },
       namedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_buildings_buildings,
+        localCodec: buildingsCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -889,7 +891,7 @@ const registry = makeRegistry({
     }),
     offer_table: Object.assign(Object.create(null), {
       postTableByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offer_table_offer_table,
+        localCodec: offer_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_post_table_post_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -906,7 +908,7 @@ const registry = makeRegistry({
     }),
     offers: Object.assign(Object.create(null), {
       postsByMyPostId: {
-        localCodec: registryConfig_pgCodecs_offers_offers,
+        localCodec: offersCodec,
         remoteResourceOptions: registryConfig_pgResources_posts_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_id"],
@@ -923,7 +925,7 @@ const registry = makeRegistry({
     }),
     post_table: Object.assign(Object.create(null), {
       offerTablesByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_post_table_post_table,
+        localCodec: post_tableCodec,
         remoteResourceOptions: registryConfig_pgResources_offer_table_offer_table,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -940,7 +942,7 @@ const registry = makeRegistry({
     }),
     posts: Object.assign(Object.create(null), {
       offersByTheirPostId: {
-        localCodec: registryConfig_pgCodecs_posts_posts,
+        localCodec: postsCodec,
         remoteResourceOptions: registryConfig_pgResources_offers_offers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -957,7 +959,7 @@ const registry = makeRegistry({
     }),
     properties: Object.assign(Object.create(null), {
       streetsByMyStreetId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["street_id"],
@@ -972,7 +974,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirPropId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -987,7 +989,7 @@ const registry = makeRegistry({
         }
       },
       buildingsByTheirPropertyId: {
-        localCodec: registryConfig_pgCodecs_properties_properties,
+        localCodec: propertiesCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1004,7 +1006,7 @@ const registry = makeRegistry({
     }),
     streetProperty: Object.assign(Object.create(null), {
       propertiesByMyPropId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["prop_id"],
@@ -1019,7 +1021,7 @@ const registry = makeRegistry({
         }
       },
       streetsByMyStrId: {
-        localCodec: registryConfig_pgCodecs_streetProperty_streetProperty,
+        localCodec: streetPropertyCodec,
         remoteResourceOptions: registryConfig_pgResources_streets_streets,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["str_id"],
@@ -1036,7 +1038,7 @@ const registry = makeRegistry({
     }),
     streets: Object.assign(Object.create(null), {
       propertiesByTheirStreetId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_properties_properties,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1051,7 +1053,7 @@ const registry = makeRegistry({
         }
       },
       streetPropertiesByTheirStrId: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_street_property_street_property,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -1066,7 +1068,7 @@ const registry = makeRegistry({
         }
       },
       buildingsNamedAfterStreet: {
-        localCodec: registryConfig_pgCodecs_streets_streets,
+        localCodec: streetsCodec,
         remoteResourceOptions: registryConfig_pgResources_buildings_buildings,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["name"],
@@ -4932,7 +4934,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -4948,7 +4950,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_offers_offers.attributes[attributeName];
+          const attribute = offersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5046,7 +5048,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
             }
           });
         }
@@ -5069,7 +5071,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
             }
           });
         }
@@ -5402,7 +5404,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5418,7 +5420,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streetProperty_streetProperty.attributes[attributeName];
+          const attribute = streetPropertyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5550,7 +5552,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
             }
           });
         }
@@ -5573,7 +5575,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
             }
           });
         }
@@ -5596,7 +5598,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
             }
           });
         }
@@ -5662,7 +5664,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5678,7 +5680,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_buildings_buildings.attributes[attributeName];
+          const attribute = buildingsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -5878,7 +5880,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
             }
           });
         }
@@ -5901,7 +5903,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
             }
           });
         }
@@ -5924,7 +5926,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
             }
           });
         }
@@ -5947,7 +5949,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
             }
           });
         }
@@ -5970,7 +5972,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
             }
           });
         }
@@ -5995,7 +5997,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6011,7 +6013,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_properties_properties.attributes[attributeName];
+          const attribute = propertiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6143,7 +6145,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
             }
           });
         }
@@ -6166,7 +6168,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6189,7 +6191,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6251,7 +6253,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6267,7 +6269,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_posts_posts.attributes[attributeName];
+          const attribute = postsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6331,7 +6333,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
             }
           });
         }
@@ -6365,7 +6367,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6381,7 +6383,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_streets_streets.attributes[attributeName];
+          const attribute = streetsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6479,7 +6481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
             }
           });
         }
@@ -6502,7 +6504,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
             }
           });
         }
@@ -6536,7 +6538,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6552,7 +6554,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_houses_houses.attributes[attributeName];
+          const attribute = housesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -6820,7 +6822,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
             }
           });
         }
@@ -6843,7 +6845,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -6866,7 +6868,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
             }
           });
         }
@@ -6889,7 +6891,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
             }
           });
         }
@@ -6912,7 +6914,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
             }
           });
         }
@@ -6935,7 +6937,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
             }
           });
         }
@@ -6958,7 +6960,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -2,9 +2,6 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-function Query_queryPlan() {
-  return rootValue();
-}
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -45,28 +42,27 @@ const registryConfig_pgCodecs_CFuncOutOutRecord_CFuncOutOutRecord = recordCodec(
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes2 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
-});
 const registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord = recordCodec({
   name: "CFuncOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes2,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -75,29 +71,28 @@ const registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord = re
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes3 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord = recordCodec({
   name: "CFuncOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes3,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -106,29 +101,28 @@ const registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord 
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes4 = Object.assign(Object.create(null), {
-  first_out: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "first_out"
-    }
-  },
-  second_out: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "second_out"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord = recordCodec({
   name: "CMutationOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes4,
+  attributes: Object.assign(Object.create(null), {
+    first_out: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "first_out"
+      }
+    },
+    second_out: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "second_out"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -137,29 +131,28 @@ const registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes5 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRecord = recordCodec({
   name: "CMutationOutOutSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes5,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -168,29 +161,28 @@ const registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes6 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: undefined
-    }
-  },
-  column2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: undefined
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnnamedRecord = recordCodec({
   name: "CMutationOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes6,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: undefined
+      }
+    },
+    column2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: undefined
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -199,29 +191,28 @@ const registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnname
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes7 = Object.assign(Object.create(null), {
-  id: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: "id"
-    }
-  },
-  total_duration: {
-    notNull: false,
-    codec: TYPES.interval,
-    extensions: {
-      argIndex: 1,
-      argName: "total_duration"
-    }
-  }
 });
 const registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRecord = recordCodec({
   name: "CSearchTestSummariesRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes7,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: "id"
+      }
+    },
+    total_duration: {
+      notNull: false,
+      codec: TYPES.interval,
+      extensions: {
+        argIndex: 1,
+        argName: "total_duration"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -230,37 +221,36 @@ const registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes8 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "CFuncOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes8,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -269,29 +259,28 @@ const registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamed
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes9 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableMultiColRecord = recordCodec({
   name: "CFuncReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes9,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -300,37 +289,36 @@ const registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableM
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes10 = Object.assign(Object.create(null), {
-  column1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 0,
-      argName: ""
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o2"
-    }
-  },
-  column3: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: ""
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOutUnnamedOutOutUnnamedRecord = recordCodec({
   name: "CMutationOutUnnamedOutOutUnnamedRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes10,
+  attributes: Object.assign(Object.create(null), {
+    column1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 0,
+        argName: ""
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o2"
+      }
+    },
+    column3: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: ""
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -339,29 +327,28 @@ const registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes11 = Object.assign(Object.create(null), {
-  col1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "col1"
-    }
-  },
-  col2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "col2"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationReturnsTableMultiColRecord = recordCodec({
   name: "CMutationReturnsTableMultiColRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes11,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "col1"
+      }
+    },
+    col2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "col2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -371,8 +358,7 @@ const registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationRetur
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const bGuidIdentifier = sql.identifier(...["b", "guid"]);
-const bGuidCodec = domainOfCodec(TYPES.varchar, "bGuid", bGuidIdentifier, {
+const bGuidCodec = domainOfCodec(TYPES.varchar, "bGuid", sql.identifier("b", "guid"), {
   description: undefined,
   extensions: {
     pg: {
@@ -384,30 +370,28 @@ const bGuidCodec = domainOfCodec(TYPES.varchar, "bGuid", bGuidIdentifier, {
   },
   notNull: false
 });
-const pgCatalogIntervalArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_interval"
-  },
-  tags: Object.create(null)
-};
 const pgCatalogIntervalArrayCodec = listOfCodec(TYPES.interval, {
-  extensions: pgCatalogIntervalArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_interval"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogIntervalArray"
 });
-const pgCatalogTextArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_text"
-  },
-  tags: Object.create(null)
-};
 const pgCatalogTextArrayCodec = listOfCodec(TYPES.text, {
-  extensions: pgCatalogTextArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_text"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogTextArray"
@@ -423,26 +407,22 @@ const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: Object.create(null)
-};
-const parts2 = ["a", "non_updatable_view"];
-const nonUpdatableViewIdentifier = sql.identifier(...parts2);
-const nonUpdatableViewCodecSpec = {
+const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: nonUpdatableViewIdentifier,
+  identifier: sql.identifier("a", "non_updatable_view"),
   attributes: nonUpdatableViewAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "non_updatable_view"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+});
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -454,26 +434,22 @@ const inputsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: Object.create(null)
-};
-const parts3 = ["a", "inputs"];
-const inputsIdentifier = sql.identifier(...parts3);
-const inputsCodecSpec = {
+const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: inputsIdentifier,
+  identifier: sql.identifier("a", "inputs"),
   attributes: inputsAttributes,
   description: "Should output as Input",
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "inputs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const inputsCodec = recordCodec(inputsCodecSpec);
+});
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -485,26 +461,22 @@ const patchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: Object.create(null)
-};
-const parts4 = ["a", "patchs"];
-const patchsIdentifier = sql.identifier(...parts4);
-const patchsCodecSpec = {
+const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: patchsIdentifier,
+  identifier: sql.identifier("a", "patchs"),
   attributes: patchsAttributes,
   description: "Should output as Patch",
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "patchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const patchsCodec = recordCodec(patchsCodecSpec);
+});
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -516,26 +488,22 @@ const reservedAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const reservedIdentifier = sql.identifier(...parts5);
-const reservedCodecSpec = {
+const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: reservedIdentifier,
+  identifier: sql.identifier("a", "reserved"),
   attributes: reservedAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedCodec = recordCodec(reservedCodecSpec);
+});
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -547,26 +515,22 @@ const reservedPatchsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const reservedPatchsIdentifier = sql.identifier(...parts6);
-const reservedPatchsCodecSpec = {
+const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: reservedPatchsIdentifier,
+  identifier: sql.identifier("a", "reservedPatchs"),
   attributes: reservedPatchsAttributes,
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions6,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reservedPatchs"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+});
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -578,26 +542,22 @@ const reservedInputAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: Object.create(null)
-};
-const parts7 = ["a", "reserved_input"];
-const reservedInputIdentifier = sql.identifier(...parts7);
-const reservedInputCodecSpec = {
+const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: reservedInputIdentifier,
+  identifier: sql.identifier("a", "reserved_input"),
   attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions7,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "reserved_input"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+});
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -618,26 +578,22 @@ const defaultValueAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: Object.create(null)
-};
-const parts8 = ["a", "default_value"];
-const defaultValueIdentifier = sql.identifier(...parts8);
-const defaultValueCodecSpec = {
+const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: defaultValueIdentifier,
+  identifier: sql.identifier("a", "default_value"),
   attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions8,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "default_value"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+});
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -667,26 +623,22 @@ const foreignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: Object.create(null)
-};
-const parts9 = ["a", "foreign_key"];
-const foreignKeyIdentifier = sql.identifier(...parts9);
-const foreignKeyCodecSpec = {
+const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: foreignKeyIdentifier,
+  identifier: sql.identifier("a", "foreign_key"),
   attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+});
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -707,26 +659,22 @@ const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["a", "no_primary_key"];
-const noPrimaryKeyIdentifier = sql.identifier(...parts10);
-const noPrimaryKeyCodecSpec = {
+const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: noPrimaryKeyIdentifier,
+  identifier: sql.identifier("a", "no_primary_key"),
   attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "no_primary_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+});
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
@@ -756,26 +704,22 @@ const testviewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: Object.create(null)
-};
-const parts11 = ["a", "testview"];
-const testviewIdentifier = sql.identifier(...parts11);
-const testviewCodecSpec = {
+const testviewCodec = recordCodec({
   name: "testview",
-  identifier: testviewIdentifier,
+  identifier: sql.identifier("a", "testview"),
   attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "testview"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const testviewCodec = recordCodec(testviewCodecSpec);
+});
 const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
@@ -796,28 +740,24 @@ const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter"
-  })
-};
-const parts12 = ["a", "unique_foreign_key"];
-const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
-const uniqueForeignKeyCodecSpec = {
+const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: uniqueForeignKeyIdentifier,
+  identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+});
 const cMyTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -838,26 +778,22 @@ const cMyTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: Object.create(null)
-};
-const parts13 = ["c", "my_table"];
-const cMyTableIdentifier = sql.identifier(...parts13);
-const cMyTableCodecSpec = {
+const cMyTableCodec = recordCodec({
   name: "cMyTable",
-  identifier: cMyTableIdentifier,
+  identifier: sql.identifier("c", "my_table"),
   attributes: cMyTableAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "my_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cMyTableCodec = recordCodec(cMyTableCodecSpec);
+});
 const cPersonSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -880,28 +816,24 @@ const cPersonSecretAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: Object.assign(Object.create(null), {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  })
-};
-const parts14 = ["c", "person_secret"];
-const cPersonSecretIdentifier = sql.identifier(...parts14);
-const cPersonSecretCodecSpec = {
+const cPersonSecretCodec = recordCodec({
   name: "cPersonSecret",
-  identifier: cPersonSecretIdentifier,
+  identifier: sql.identifier("c", "person_secret"),
   attributes: cPersonSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: Object.assign(Object.create(null), {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const cPersonSecretCodec = recordCodec(cPersonSecretCodecSpec);
+});
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -931,26 +863,22 @@ const viewTableAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["a", "view_table"];
-const viewTableIdentifier = sql.identifier(...parts15);
-const viewTableCodecSpec = {
+const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: viewTableIdentifier,
+  identifier: sql.identifier("a", "view_table"),
   attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "view_table"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const viewTableCodec = recordCodec(viewTableCodecSpec);
+});
 const bUpdatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
@@ -989,28 +917,24 @@ const bUpdatableViewAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: Object.assign(Object.create(null), {
-    uniqueKey: "x"
-  })
-};
-const parts16 = ["b", "updatable_view"];
-const bUpdatableViewIdentifier = sql.identifier(...parts16);
-const bUpdatableViewCodecSpec = {
+const bUpdatableViewCodec = recordCodec({
   name: "bUpdatableView",
-  identifier: bUpdatableViewIdentifier,
+  identifier: sql.identifier("b", "updatable_view"),
   attributes: bUpdatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "updatable_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      uniqueKey: "x"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const bUpdatableViewCodec = recordCodec(bUpdatableViewCodecSpec);
+});
 const cCompoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
@@ -1040,26 +964,22 @@ const cCompoundKeyAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: Object.create(null)
-};
-const parts17 = ["c", "compound_key"];
-const cCompoundKeyIdentifier = sql.identifier(...parts17);
-const cCompoundKeyCodecSpec = {
+const cCompoundKeyCodec = recordCodec({
   name: "cCompoundKey",
-  identifier: cCompoundKeyIdentifier,
+  identifier: sql.identifier("c", "compound_key"),
   attributes: cCompoundKeyAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cCompoundKeyCodec = recordCodec(cCompoundKeyCodecSpec);
+});
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1098,26 +1018,22 @@ const similarTable1Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: Object.create(null)
-};
-const parts18 = ["a", "similar_table_1"];
-const similarTable1Identifier = sql.identifier(...parts18);
-const similarTable1CodecSpec = {
+const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: similarTable1Identifier,
+  identifier: sql.identifier("a", "similar_table_1"),
   attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_1"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+});
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1156,26 +1072,22 @@ const similarTable2Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: Object.create(null)
-};
-const parts19 = ["a", "similar_table_2"];
-const similarTable2Identifier = sql.identifier(...parts19);
-const similarTable2CodecSpec = {
+const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: similarTable2Identifier,
+  identifier: sql.identifier("a", "similar_table_2"),
   attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "similar_table_2"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+});
 const cNullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1214,36 +1126,31 @@ const cNullTestRecordAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: Object.create(null)
-};
-const parts20 = ["c", "null_test_record"];
-const cNullTestRecordIdentifier = sql.identifier(...parts20);
-const cNullTestRecordCodecSpec = {
+const cNullTestRecordCodec = recordCodec({
   name: "cNullTestRecord",
-  identifier: cNullTestRecordIdentifier,
+  identifier: sql.identifier("c", "null_test_record"),
   attributes: cNullTestRecordAttributes,
   description: undefined,
-  extensions: extensions20,
-  executor: executor_mainPgExecutor
-};
-const cNullTestRecordCodec = recordCodec(cNullTestRecordCodecSpec);
-const pgCatalogUuidArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_uuid"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "null_test_record"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
+  executor: executor_mainPgExecutor
+});
 const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
-  extensions: pgCatalogUuidArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_uuid"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogUuidArray"
@@ -1277,26 +1184,22 @@ const cEdgeCaseAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: Object.create(null)
-};
-const parts21 = ["c", "edge_case"];
-const cEdgeCaseIdentifier = sql.identifier(...parts21);
-const cEdgeCaseCodecSpec = {
+const cEdgeCaseCodec = recordCodec({
   name: "cEdgeCase",
-  identifier: cEdgeCaseIdentifier,
+  identifier: sql.identifier("c", "edge_case"),
   attributes: cEdgeCaseAttributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "edge_case"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cEdgeCaseCodec = recordCodec(cEdgeCaseCodecSpec);
+});
 const cLeftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1335,106 +1238,94 @@ const cLeftArmAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: Object.create(null)
-};
-const parts22 = ["c", "left_arm"];
-const cLeftArmIdentifier = sql.identifier(...parts22);
-const cLeftArmCodecSpec = {
+const cLeftArmCodec = recordCodec({
   name: "cLeftArm",
-  identifier: cLeftArmIdentifier,
+  identifier: sql.identifier("c", "left_arm"),
   attributes: cLeftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions22,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "left_arm"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cLeftArmCodec = recordCodec(cLeftArmCodecSpec);
-const bJwtTokenAttributes = Object.assign(Object.create(null), {
-  role: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  exp: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions23 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: Object.create(null)
-};
-const parts23 = ["b", "jwt_token"];
-const bJwtTokenIdentifier = sql.identifier(...parts23);
-const bJwtTokenCodecSpec = {
+const bJwtTokenCodec = recordCodec({
   name: "bJwtToken",
-  identifier: bJwtTokenIdentifier,
-  attributes: bJwtTokenAttributes,
+  identifier: sql.identifier("b", "jwt_token"),
+  attributes: Object.assign(Object.create(null), {
+    role: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    exp: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor: executor_mainPgExecutor
-};
-const bJwtTokenCodec = recordCodec(bJwtTokenCodecSpec);
-const extensions24 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "not_null_timestamp"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "jwt_token"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts24 = ["c", "not_null_timestamp"];
-const cNotNullTimestampIdentifier = sql.identifier(...parts24);
-const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", cNotNullTimestampIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
-  extensions: extensions24,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "not_null_timestamp"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
 const cIssue756Attributes = Object.assign(Object.create(null), {
@@ -1457,245 +1348,220 @@ const cIssue756Attributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: Object.create(null)
-};
-const parts25 = ["c", "issue756"];
-const cIssue756Identifier = sql.identifier(...parts25);
-const cIssue756CodecSpec = {
+const cIssue756Codec = recordCodec({
   name: "cIssue756",
-  identifier: cIssue756Identifier,
+  identifier: sql.identifier("c", "issue756"),
   attributes: cIssue756Attributes,
   description: undefined,
-  extensions: extensions25,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "issue756"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const cIssue756Codec = recordCodec(cIssue756CodecSpec);
-const bAuthPayloadAttributes = Object.assign(Object.create(null), {
-  jwt: {
-    description: undefined,
-    codec: bJwtTokenCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  admin: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: "(id) references c.person"
-  })
-};
-const parts26 = ["b", "auth_payload"];
-const bAuthPayloadIdentifier = sql.identifier(...parts26);
-const bAuthPayloadCodecSpec = {
+const bAuthPayloadCodec = recordCodec({
   name: "bAuthPayload",
-  identifier: bAuthPayloadIdentifier,
-  attributes: bAuthPayloadAttributes,
+  identifier: sql.identifier("b", "auth_payload"),
+  attributes: Object.assign(Object.create(null), {
+    jwt: {
+      description: undefined,
+      codec: bJwtTokenCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    admin: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
-const bAuthPayloadCodec = recordCodec(bAuthPayloadCodecSpec);
-const extensions27 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "color"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "auth_payload"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: "(id) references c.person"
+    })
   },
-  tags: Object.create(null)
-};
-const parts27 = ["b", "color"];
+  executor: executor_mainPgExecutor
+});
 const bColorCodec = enumCodec({
   name: "bColor",
-  identifier: sql.identifier(...parts27),
+  identifier: sql.identifier("b", "color"),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions27
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "color"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions28 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_caps"
-  },
-  tags: Object.create(null)
-};
-const parts28 = ["b", "enum_caps"];
-const sqlIdent2 = sql.identifier(...parts28);
 const bEnumCapsCodec = enumCodec({
   name: "bEnumCaps",
-  identifier: sqlIdent2,
-  values: enumLabels2,
+  identifier: sql.identifier("b", "enum_caps"),
+  values: ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"],
   description: undefined,
-  extensions: extensions28
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_caps"
+    },
+    tags: Object.create(null)
+  }
 });
-const enumLabels3 = ["", "one", "two"];
-const extensions29 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "enum_with_empty_string"
-  },
-  tags: Object.create(null)
-};
-const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent3 = sql.identifier(...parts29);
 const bEnumWithEmptyStringCodec = enumCodec({
   name: "bEnumWithEmptyString",
-  identifier: sqlIdent3,
-  values: enumLabels3,
+  identifier: sql.identifier("b", "enum_with_empty_string"),
+  values: ["", "one", "two"],
   description: undefined,
-  extensions: extensions29
-});
-const cCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  c: {
-    description: undefined,
-    codec: bColorCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  d: {
-    description: undefined,
-    codec: TYPES.uuid,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  e: {
-    description: undefined,
-    codec: bEnumCapsCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  f: {
-    description: undefined,
-    codec: bEnumWithEmptyStringCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  g: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  foo_bar: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "enum_with_empty_string"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions30 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts30 = ["c", "compound_type"];
-const cCompoundTypeIdentifier = sql.identifier(...parts30);
-const cCompoundTypeCodecSpec = {
+const cCompoundTypeCodec = recordCodec({
   name: "cCompoundType",
-  identifier: cCompoundTypeIdentifier,
-  attributes: cCompoundTypeAttributes,
+  identifier: sql.identifier("c", "compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    c: {
+      description: undefined,
+      codec: bColorCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    d: {
+      description: undefined,
+      codec: TYPES.uuid,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    e: {
+      description: undefined,
+      codec: bEnumCapsCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    f: {
+      description: undefined,
+      codec: bEnumWithEmptyStringCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    g: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    foo_bar: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Awesome feature!",
-  extensions: extensions30,
-  executor: executor_mainPgExecutor
-};
-const cCompoundTypeCodec = recordCodec(cCompoundTypeCodecSpec);
-const attributes12 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    tags: Object.create(null)
   },
-  o2: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord = recordCodec({
   name: "CFuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes12,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1704,29 +1570,28 @@ const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundT
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes13 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord = recordCodec({
   name: "CMutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes13,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1736,88 +1601,77 @@ const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutC
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const anEnumArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_an_enum"
-  },
-  tags: Object.create(null)
-};
-const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions31 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_enum"
-  },
-  tags: Object.create(null)
-};
-const parts31 = ["a", "an_enum"];
-const sqlIdent4 = sql.identifier(...parts31);
 const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent4,
-  values: enumLabels4,
+  identifier: sql.identifier("a", "an_enum"),
+  values: ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"],
   description: undefined,
-  extensions: extensions31
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_enum"
+    },
+    tags: Object.create(null)
+  }
 });
 const anEnumArrayCodec = listOfCodec(anEnumCodec, {
-  extensions: anEnumArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_an_enum"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const comptypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_comptype"
-  },
-  tags: Object.create(null)
-};
-const comptypeAttributes = Object.assign(Object.create(null), {
-  schedule: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_optimised: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions32 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "comptype"
-  },
-  tags: Object.create(null)
-};
-const parts32 = ["a", "comptype"];
-const comptypeIdentifier = sql.identifier(...parts32);
-const comptypeCodecSpec = {
+const comptypeCodec = recordCodec({
   name: "comptype",
-  identifier: comptypeIdentifier,
-  attributes: comptypeAttributes,
+  identifier: sql.identifier("a", "comptype"),
+  attributes: Object.assign(Object.create(null), {
+    schedule: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_optimised: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions32,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "comptype"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const comptypeCodec = recordCodec(comptypeCodecSpec);
+});
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
-  extensions: comptypeArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_comptype"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
@@ -1878,56 +1732,51 @@ const postAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.create(null)
-};
-const parts33 = ["a", "post"];
-const postIdentifier = sql.identifier(...parts33);
-const postCodecSpec = {
+const postCodec = recordCodec({
   name: "post",
-  identifier: postIdentifier,
+  identifier: sql.identifier("a", "post"),
   attributes: postAttributes,
   description: undefined,
-  extensions: extensions33,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const postCodec = recordCodec(postCodecSpec);
-const attributes14 = Object.assign(Object.create(null), {
-  txt: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "txt"
-    }
-  },
-  left_arm: {
-    notNull: false,
-    codec: cLeftArmCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "left_arm"
-    }
-  },
-  post: {
-    notNull: false,
-    codec: postCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "post"
-    }
-  }
 });
 const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord = recordCodec({
   name: "CQueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes14,
+  attributes: Object.assign(Object.create(null), {
+    txt: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "txt"
+      }
+    },
+    left_arm: {
+      notNull: false,
+      codec: cLeftArmCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "left_arm"
+      }
+    },
+    post: {
+      notNull: false,
+      codec: postCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "post"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1936,29 +1785,28 @@ const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes15 = Object.assign(Object.create(null), {
-  o1: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "o1"
-    }
-  },
-  o2: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o2"
-    }
-  }
 });
 const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord = recordCodec({
   name: "CPersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes15,
+  attributes: Object.assign(Object.create(null), {
+    o1: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "o1"
+      }
+    },
+    o2: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o2"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1967,29 +1815,28 @@ const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutR
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes16 = Object.assign(Object.create(null), {
-  ino: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 1,
-      argName: "ino"
-    }
-  },
-  o: {
-    notNull: false,
-    codec: TYPES.text,
-    extensions: {
-      argIndex: 2,
-      argName: "o"
-    }
-  }
 });
 const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord = recordCodec({
   name: "CPersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes16,
+  attributes: Object.assign(Object.create(null), {
+    ino: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 1,
+        argName: "ino"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.text,
+      extensions: {
+        argIndex: 2,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1999,67 +1846,56 @@ const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInout
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "email"
-  },
-  tags: Object.create(null)
-};
-const parts34 = ["b", "email"];
-const bEmailIdentifier = sql.identifier(...parts34);
-const bEmailCodec = domainOfCodec(TYPES.text, "bEmail", bEmailIdentifier, {
+const bEmailCodec = domainOfCodec(TYPES.text, "bEmail", sql.identifier("b", "email"), {
   description: undefined,
-  extensions: extensions34,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "email"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions35 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "not_null_url"
-  },
-  tags: Object.create(null)
-};
-const parts35 = ["b", "not_null_url"];
-const bNotNullUrlIdentifier = sql.identifier(...parts35);
-const bNotNullUrlCodec = domainOfCodec(TYPES.varchar, "bNotNullUrl", bNotNullUrlIdentifier, {
+const bNotNullUrlCodec = domainOfCodec(TYPES.varchar, "bNotNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
-  extensions: extensions35,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "not_null_url"
+    },
+    tags: Object.create(null)
+  },
   notNull: true
 });
-const bWrappedUrlAttributes = Object.assign(Object.create(null), {
-  url: {
-    description: undefined,
-    codec: bNotNullUrlCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions36 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "wrapped_url"
-  },
-  tags: Object.create(null)
-};
-const parts36 = ["b", "wrapped_url"];
-const bWrappedUrlIdentifier = sql.identifier(...parts36);
-const bWrappedUrlCodecSpec = {
+const bWrappedUrlCodec = recordCodec({
   name: "bWrappedUrl",
-  identifier: bWrappedUrlIdentifier,
-  attributes: bWrappedUrlAttributes,
+  identifier: sql.identifier("b", "wrapped_url"),
+  attributes: Object.assign(Object.create(null), {
+    url: {
+      description: undefined,
+      codec: bNotNullUrlCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions36,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "wrapped_url"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const bWrappedUrlCodec = recordCodec(bWrappedUrlCodecSpec);
+});
 const cPersonAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
@@ -2165,48 +2001,43 @@ const cPersonAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: Object.create(null)
-};
-const parts37 = ["c", "person"];
-const cPersonIdentifier = sql.identifier(...parts37);
-const cPersonCodecSpec = {
+const cPersonCodec = recordCodec({
   name: "cPerson",
-  identifier: cPersonIdentifier,
+  identifier: sql.identifier("c", "person"),
   attributes: cPersonAttributes,
   description: "Person test comment",
-  extensions: extensions37,
-  executor: executor_mainPgExecutor
-};
-const cPersonCodec = recordCodec(cPersonCodecSpec);
-const attributes17 = Object.assign(Object.create(null), {
-  person: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 0,
-      argName: "person"
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person"
+    },
+    tags: Object.create(null)
   },
-  o: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 1,
-      argName: "o"
-    }
-  }
+  executor: executor_mainPgExecutor
 });
 const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "CPersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes17,
+  attributes: Object.assign(Object.create(null), {
+    person: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 0,
+        argName: "person"
+      }
+    },
+    o: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 1,
+        argName: "o"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2215,37 +2046,36 @@ const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonCompu
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes18 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = recordCodec({
   name: "CFuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes18,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2254,37 +2084,36 @@ const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = reco
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes19 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRecord = recordCodec({
   name: "CFuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes19,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2293,37 +2122,36 @@ const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRec
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes20 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord = recordCodec({
   name: "CMutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes20,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2332,37 +2160,36 @@ const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecor
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes21 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 2,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 3,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord = recordCodec({
   name: "CMutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes21,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 2,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 3,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2371,37 +2198,36 @@ const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplex
   },
   executor: executor_mainPgExecutor,
   isAnonymous: true
-});
-const attributes22 = Object.assign(Object.create(null), {
-  x: {
-    notNull: false,
-    codec: TYPES.int,
-    extensions: {
-      argIndex: 3,
-      argName: "x"
-    }
-  },
-  y: {
-    notNull: false,
-    codec: cCompoundTypeCodec,
-    extensions: {
-      argIndex: 4,
-      argName: "y"
-    }
-  },
-  z: {
-    notNull: false,
-    codec: cPersonCodec,
-    extensions: {
-      argIndex: 5,
-      argName: "z"
-    }
-  }
 });
 const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord = recordCodec({
   name: "CPersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes22,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      notNull: false,
+      codec: TYPES.int,
+      extensions: {
+        argIndex: 3,
+        argName: "x"
+      }
+    },
+    y: {
+      notNull: false,
+      codec: cCompoundTypeCodec,
+      extensions: {
+        argIndex: 4,
+        argName: "y"
+      }
+    },
+    z: {
+      notNull: false,
+      codec: cPersonCodec,
+      extensions: {
+        argIndex: 5,
+        argName: "z"
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2411,195 +2237,166 @@ const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComple
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const bColorArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_color"
-  },
-  tags: Object.create(null)
-};
 const bColorArrayCodec = listOfCodec(bColorCodec, {
-  extensions: bColorArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "_color"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "bColorArray"
 });
-const extensions38 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int"
-  },
-  tags: Object.create(null)
-};
-const parts38 = ["a", "an_int"];
-const anIntIdentifier = sql.identifier(...parts38);
-const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", sql.identifier("a", "an_int"), {
   description: undefined,
-  extensions: extensions38,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions39 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "another_int"
-  },
-  tags: Object.create(null)
-};
-const parts39 = ["b", "another_int"];
-const bAnotherIntIdentifier = sql.identifier(...parts39);
-const bAnotherIntCodec = domainOfCodec(anIntCodec, "bAnotherInt", bAnotherIntIdentifier, {
+const bAnotherIntCodec = domainOfCodec(anIntCodec, "bAnotherInt", sql.identifier("b", "another_int"), {
   description: undefined,
-  extensions: extensions39,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "another_int"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions40 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "numrange"
-  },
-  tags: Object.create(null)
-};
-const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent5 = sql.identifier(...parts40);
-const pgCatalogNumrangeCodec = rangeOfCodec(TYPES.numeric, "pgCatalogNumrange", sqlIdent5, {
+const pgCatalogNumrangeCodec = rangeOfCodec(TYPES.numeric, "pgCatalogNumrange", sql.identifier("pg_catalog", "numrange"), {
   description: "range of numerics",
-  extensions: extensions40
-});
-const extensions41 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "daterange"
-  },
-  tags: Object.create(null)
-};
-const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent6 = sql.identifier(...parts41);
-const pgCatalogDaterangeCodec = rangeOfCodec(TYPES.date, "pgCatalogDaterange", sqlIdent6, {
-  description: "range of dates",
-  extensions: extensions41
-});
-const extensions42 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "an_int_range"
-  },
-  tags: Object.create(null)
-};
-const parts42 = ["a", "an_int_range"];
-const sqlIdent7 = sql.identifier(...parts42);
-const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
-  description: undefined,
-  extensions: extensions42
-});
-const bNestedCompoundTypeAttributes = Object.assign(Object.create(null), {
-  a: {
-    description: undefined,
-    codec: cCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  b: {
-    description: undefined,
-    codec: cCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  baz_buz: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "numrange"
+    },
+    tags: Object.create(null)
   }
 });
-const extensions43 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "nested_compound_type"
-  },
-  tags: Object.create(null)
-};
-const parts43 = ["b", "nested_compound_type"];
-const bNestedCompoundTypeIdentifier = sql.identifier(...parts43);
-const bNestedCompoundTypeCodecSpec = {
+const pgCatalogDaterangeCodec = rangeOfCodec(TYPES.date, "pgCatalogDaterange", sql.identifier("pg_catalog", "daterange"), {
+  description: "range of dates",
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "daterange"
+    },
+    tags: Object.create(null)
+  }
+});
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sql.identifier("a", "an_int_range"), {
+  description: undefined,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "an_int_range"
+    },
+    tags: Object.create(null)
+  }
+});
+const bNestedCompoundTypeCodec = recordCodec({
   name: "bNestedCompoundType",
-  identifier: bNestedCompoundTypeIdentifier,
-  attributes: bNestedCompoundTypeAttributes,
+  identifier: sql.identifier("b", "nested_compound_type"),
+  attributes: Object.assign(Object.create(null), {
+    a: {
+      description: undefined,
+      codec: cCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    b: {
+      description: undefined,
+      codec: cCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    baz_buz: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions43,
-  executor: executor_mainPgExecutor
-};
-const bNestedCompoundTypeCodec = recordCodec(bNestedCompoundTypeCodecSpec);
-const extensions44 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "text_array_domain"
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "nested_compound_type"
+    },
+    tags: Object.create(null)
   },
-  tags: Object.create(null)
-};
-const parts44 = ["c", "text_array_domain"];
-const cTextArrayDomainIdentifier = sql.identifier(...parts44);
-const cTextArrayDomainCodec = domainOfCodec(pgCatalogTextArrayCodec, "cTextArrayDomain", cTextArrayDomainIdentifier, {
+  executor: executor_mainPgExecutor
+});
+const cTextArrayDomainCodec = domainOfCodec(pgCatalogTextArrayCodec, "cTextArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
-  extensions: extensions44,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "text_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const extensions45 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int8_array_domain"
-  },
-  tags: Object.create(null)
-};
-const pgCatalogInt8ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int8"
-  },
-  tags: Object.create(null)
-};
 const pgCatalogInt8ArrayCodec = listOfCodec(TYPES.bigint, {
-  extensions: pgCatalogInt8ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int8"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogInt8Array"
 });
-const parts45 = ["c", "int8_array_domain"];
-const cInt8ArrayDomainIdentifier = sql.identifier(...parts45);
-const cInt8ArrayDomainCodec = domainOfCodec(pgCatalogInt8ArrayCodec, "cInt8ArrayDomain", cInt8ArrayDomainIdentifier, {
+const cInt8ArrayDomainCodec = domainOfCodec(pgCatalogInt8ArrayCodec, "cInt8ArrayDomain", sql.identifier("c", "int8_array_domain"), {
   description: undefined,
-  extensions: extensions45,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "int8_array_domain"
+    },
+    tags: Object.create(null)
+  },
   notNull: false
 });
-const pgCatalogByteaArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_bytea"
-  },
-  tags: Object.create(null)
-};
 const pgCatalogByteaArrayCodec = listOfCodec(TYPES.bytea, {
-  extensions: pgCatalogByteaArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_bytea"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogByteaArray"
@@ -3071,1496 +2868,114 @@ const extensions46 = {
     foreignKey: ["(smallint) references a.post", "(id) references a.post"]
   })
 };
-const parts46 = ["b", "types"];
-const bTypesIdentifier = sql.identifier(...parts46);
-const bTypesCodecSpec = {
+const bTypesCodec = recordCodec({
   name: "bTypes",
-  identifier: bTypesIdentifier,
+  identifier: sql.identifier("b", "types"),
   attributes: bTypesAttributes,
   description: undefined,
   extensions: extensions46,
   executor: executor_mainPgExecutor
-};
-const bTypesCodec = recordCodec(bTypesCodecSpec);
-const cCompoundTypeArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "_compound_type"
-  },
-  tags: Object.create(null)
-};
-const bJwtTokenArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_jwt_token"
-  },
-  tags: Object.create(null)
-};
-const bTypesArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "_types"
-  },
-  tags: Object.create(null)
-};
-const pgCatalogInt4ArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "pg_catalog",
-    name: "_int4"
-  },
-  tags: Object.create(null)
-};
+});
 const pgCatalogInt4ArrayCodec = listOfCodec(TYPES.int, {
-  extensions: pgCatalogInt4ArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "pg_catalog",
+      name: "_int4"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogInt4Array"
 });
-const extensions47 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "floatrange"
-  },
-  tags: Object.create(null)
-};
-const parts47 = ["c", "floatrange"];
-const sqlIdent8 = sql.identifier(...parts47);
-const cFloatrangeCodec = rangeOfCodec(TYPES.float, "cFloatrange", sqlIdent8, {
+const cFloatrangeCodec = rangeOfCodec(TYPES.float, "cFloatrange", sql.identifier("c", "floatrange"), {
   description: undefined,
-  extensions: extensions47
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "floatrange"
+    },
+    tags: Object.create(null)
+  }
 });
-const postArrayCodecExtensions = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "_post"
-  },
-  tags: Object.create(null)
-};
 const postArrayCodec = listOfCodec(postCodec, {
-  extensions: postArrayCodecExtensions,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "_post"
+    },
+    tags: Object.create(null)
+  },
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions48 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_2"
-  },
-  tags: Object.create(null)
-};
-const parts48 = ["a", "tablefunc_crosstab_2"];
-const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
-const tablefuncCrosstab2CodecSpec = {
-  name: "tablefuncCrosstab2",
-  identifier: tablefuncCrosstab2Identifier,
-  attributes: tablefuncCrosstab2Attributes,
-  description: undefined,
-  extensions: extensions48,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions49 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_3"
-  },
-  tags: Object.create(null)
-};
-const parts49 = ["a", "tablefunc_crosstab_3"];
-const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
-const tablefuncCrosstab3CodecSpec = {
-  name: "tablefuncCrosstab3",
-  identifier: tablefuncCrosstab3Identifier,
-  attributes: tablefuncCrosstab3Attributes,
-  description: undefined,
-  extensions: extensions49,
-  executor: executor_mainPgExecutor
-};
-const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
-  row_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_1: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_2: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_3: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  category_4: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions50 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "tablefunc_crosstab_4"
-  },
-  tags: Object.create(null)
-};
-const parts50 = ["a", "tablefunc_crosstab_4"];
-const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
-const tablefuncCrosstab4CodecSpec = {
-  name: "tablefuncCrosstab4",
-  identifier: tablefuncCrosstab4Identifier,
-  attributes: tablefuncCrosstab4Attributes,
-  description: undefined,
-  extensions: extensions50,
-  executor: executor_mainPgExecutor
-};
-const extensions51 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "current_user_id"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts51 = ["c", "current_user_id"];
-const sqlIdent9 = sql.identifier(...parts51);
-const extensions52 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts52 = ["c", "func_out"];
-const sqlIdent10 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
-const parameters2 = [];
-const extensions53 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts53 = ["c", "func_out_setof"];
-const sqlIdent11 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
-const parameters3 = [];
-const extensions54 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent12 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
-const parameters4 = [];
-const extensions55 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts55 = ["c", "mutation_out"];
-const sqlIdent13 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
-const parameters5 = [];
-const extensions56 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent14 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
-const parameters6 = [];
-const extensions57 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent15 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
-const parameters7 = [];
-const extensions58 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts58 = ["c", "no_args_mutation"];
-const sqlIdent16 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
-const parameters8 = [];
-const extensions59 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "no_args_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts59 = ["c", "no_args_query"];
-const sqlIdent17 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
-const parameters9 = [];
-const extensions60 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "return_void_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts60 = ["a", "return_void_mutation"];
-const sqlIdent18 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
-const parameters10 = [];
-const extensions61 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_set"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent19 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
-const parameters11 = [];
-const extensions62 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_set"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts62 = ["a", "query_interval_set"];
-const sqlIdent20 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
-const parameters12 = [];
-const extensions63 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "static_big_integer"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts63 = ["a", "static_big_integer"];
-const sqlIdent21 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
-const parameters13 = [];
-const extensions64 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts64 = ["c", "func_in_out"];
-const sqlIdent22 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
-const parameters14 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions65 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent23 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
-const parameters15 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions66 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o"
-};
-const parts66 = ["c", "mutation_in_out"];
-const sqlIdent24 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
-const parameters16 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions67 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_one_col"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "col1"
-};
-const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent25 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
-const parameters17 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions68 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts68 = ["a", "assert_something"];
-const sqlIdent26 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
-const parameters18 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions69 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "assert_something_nx"
-  },
-  tags: {
-    omit: "execute",
-    behavior: ["-filter -order"]
-  }
-};
-const parts69 = ["a", "assert_something_nx"];
-const sqlIdent27 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
-const parameters19 = [{
-  name: "in_arg",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions70 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts70 = ["c", "json_identity"];
-const sqlIdent28 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
-const parameters20 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions71 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "json_identity_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent29 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
-const parameters21 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.json
-}];
-const extensions72 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts72 = ["c", "jsonb_identity"];
-const sqlIdent30 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
-const parameters22 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions73 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent31 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
-const parameters23 = [{
-  name: "json",
-  required: true,
-  notNull: false,
-  codec: TYPES.jsonb
-}];
-const extensions74 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent32 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
-const parameters24 = [{
-  name: "_the_json",
-  required: true,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions75 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "jsonb_identity_mutation_plpgsql_with_default"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent33 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
-const parameters25 = [{
-  name: "_the_json",
-  required: false,
-  notNull: true,
-  codec: TYPES.jsonb
-}];
-const extensions76 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts76 = ["a", "add_1_mutation"];
-const sqlIdent34 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
-const parameters26 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions77 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_1_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts77 = ["a", "add_1_query"];
-const sqlIdent35 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
-const parameters27 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions78 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts78 = ["a", "add_2_mutation"];
-const sqlIdent36 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
-const parameters28 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions79 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_2_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts79 = ["a", "add_2_query"];
-const sqlIdent37 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
-const parameters29 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions80 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts80 = ["a", "add_3_mutation"];
-const sqlIdent38 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
-const parameters30 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions81 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_3_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts81 = ["a", "add_3_query"];
-const sqlIdent39 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
-const parameters31 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions82 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts82 = ["a", "add_4_mutation"];
-const sqlIdent40 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
-const parameters32 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions83 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_mutation_error"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent41 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
-const parameters33 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions84 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "add_4_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts84 = ["a", "add_4_query"];
-const sqlIdent42 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
-const parameters34 = [{
-  name: "",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions85 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_1"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts85 = ["b", "mult_1"];
-const sqlIdent43 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
-const parameters35 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions86 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_2"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts86 = ["b", "mult_2"];
-const sqlIdent44 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
-const parameters36 = [{
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions87 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_3"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts87 = ["b", "mult_3"];
-const sqlIdent45 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
-const parameters37 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions88 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "mult_4"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts88 = ["b", "mult_4"];
-const sqlIdent46 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
-const parameters38 = [{
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: null,
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions89 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_in_inout"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts89 = ["c", "func_in_inout"];
-const sqlIdent47 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
-const parameters39 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions90 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts90 = ["c", "func_out_out"];
-const sqlIdent48 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
-const parameters40 = [];
-const extensions91 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent49 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
-const parameters41 = [];
-const extensions92 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent50 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
-const parameters42 = [];
-const extensions93 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_in_inout"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent51 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
-const parameters43 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions94 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts94 = ["c", "mutation_out_out"];
-const sqlIdent52 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
-const parameters44 = [];
-const extensions95 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent53 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
-const parameters45 = [];
-const extensions96 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
-const parameters46 = [];
-const extensions97 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "search_test_summaries"
-  },
-  tags: {
-    simpleCollections: "only",
-    behavior: ["-filter -order"]
-  }
-};
-const parts97 = ["c", "search_test_summaries"];
-const sqlIdent55 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
-const parameters47 = [];
-const extensions98 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_1"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent56 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
-const parameters48 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions99 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_2"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent57 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
-const parameters49 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions100 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_3"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent58 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
-const parameters50 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "c",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions101 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_4"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent59 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
-const parameters51 = [{
-  name: "",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions102 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "optional_missing_middle_5"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent60 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
-const parameters52 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions103 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent61 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
-const parameters53 = [];
-const extensions104 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent62 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
-const parameters54 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions105 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts105 = ["c", "int_set_mutation"];
-const sqlIdent63 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
-const parameters55 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions106 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "int_set_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts106 = ["c", "int_set_query"];
-const sqlIdent64 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
-const parameters56 = [{
-  name: "x",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "y",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "z",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions107 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_unnamed_out_out_unnamed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent65 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
-const parameters57 = [];
-const extensions108 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_returns_table_multi_col"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent66 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
-const parameters58 = [{
-  name: "i",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions109 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "guid_fn"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts109 = ["b", "guid_fn"];
-const sqlIdent67 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
-const parameters59 = [{
-  name: "g",
-  required: true,
-  notNull: false,
-  codec: bGuidCodec
-}];
-const extensions110 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_interval_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent68 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
-const parameters60 = [];
-const extensions111 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_interval_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts111 = ["a", "query_interval_array"];
-const sqlIdent69 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
-const parameters61 = [];
-const extensions112 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "mutation_text_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts112 = ["a", "mutation_text_array"];
-const sqlIdent70 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
-const parameters62 = [];
-const extensions113 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "query_text_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts113 = ["a", "query_text_array"];
-const sqlIdent71 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
-const parameters63 = [];
-const extensions114 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "non_updatable_view"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
-  }
-};
-const extensions115 = {
-  description: "Should output as Input",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "inputs"
-  },
-  tags: {}
-};
+const sqlIdent9 = sql.identifier("c", "current_user_id");
+const sqlIdent10 = sql.identifier("c", "func_out");
+const sqlIdent11 = sql.identifier("c", "func_out_setof");
+const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
+const sqlIdent13 = sql.identifier("c", "mutation_out");
+const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
+const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
+const sqlIdent16 = sql.identifier("c", "no_args_mutation");
+const sqlIdent17 = sql.identifier("c", "no_args_query");
+const sqlIdent18 = sql.identifier("a", "return_void_mutation");
+const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
+const sqlIdent20 = sql.identifier("a", "query_interval_set");
+const sqlIdent21 = sql.identifier("a", "static_big_integer");
+const sqlIdent22 = sql.identifier("c", "func_in_out");
+const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
+const sqlIdent24 = sql.identifier("c", "mutation_in_out");
+const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
+const sqlIdent26 = sql.identifier("a", "assert_something");
+const sqlIdent27 = sql.identifier("a", "assert_something_nx");
+const sqlIdent28 = sql.identifier("c", "json_identity");
+const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
+const sqlIdent30 = sql.identifier("c", "jsonb_identity");
+const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
+const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const sqlIdent34 = sql.identifier("a", "add_1_mutation");
+const sqlIdent35 = sql.identifier("a", "add_1_query");
+const sqlIdent36 = sql.identifier("a", "add_2_mutation");
+const sqlIdent37 = sql.identifier("a", "add_2_query");
+const sqlIdent38 = sql.identifier("a", "add_3_mutation");
+const sqlIdent39 = sql.identifier("a", "add_3_query");
+const sqlIdent40 = sql.identifier("a", "add_4_mutation");
+const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
+const sqlIdent42 = sql.identifier("a", "add_4_query");
+const sqlIdent43 = sql.identifier("b", "mult_1");
+const sqlIdent44 = sql.identifier("b", "mult_2");
+const sqlIdent45 = sql.identifier("b", "mult_3");
+const sqlIdent46 = sql.identifier("b", "mult_4");
+const sqlIdent47 = sql.identifier("c", "func_in_inout");
+const sqlIdent48 = sql.identifier("c", "func_out_out");
+const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
+const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
+const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
+const sqlIdent52 = sql.identifier("c", "mutation_out_out");
+const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
+const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
+const sqlIdent55 = sql.identifier("c", "search_test_summaries");
+const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
+const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
+const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
+const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
+const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
+const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
+const sqlIdent63 = sql.identifier("c", "int_set_mutation");
+const sqlIdent64 = sql.identifier("c", "int_set_query");
+const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
+const sqlIdent67 = sql.identifier("b", "guid_fn");
+const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
+const sqlIdent69 = sql.identifier("a", "query_interval_array");
+const sqlIdent70 = sql.identifier("a", "mutation_text_array");
+const sqlIdent71 = sql.identifier("a", "query_text_array");
 const uniques2 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4569,15 +2984,6 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions116 = {
-  description: "Should output as Patch",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "patchs"
-  },
-  tags: {}
-};
 const uniques3 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4586,15 +2992,6 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions117 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved"
-  },
-  tags: {}
-};
 const uniques4 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4603,15 +3000,6 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions118 = {
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: {}
-};
 const uniques5 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4620,15 +3008,6 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions119 = {
-  description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reserved_input"
-  },
-  tags: {}
-};
 const uniques6 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4637,15 +3016,6 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions120 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "default_value"
-  },
-  tags: {}
-};
 const uniques7 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4654,92 +3024,52 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions121 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "foreign_key"
-  },
-  tags: {}
-};
-const uniques8 = [];
 const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
   codec: foreignKeyCodec,
-  uniques: uniques8,
+  uniques: [],
   isVirtual: false,
   description: undefined,
-  extensions: extensions121
-};
-const extensions122 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "no_primary_key"
-  },
-  tags: {}
-};
-const uniques9 = [{
-  isPrimary: false,
-  attributes: ["id"],
-  description: undefined,
   extensions: {
-    tags: Object.create(null)
-  }
-}];
-const extensions123 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "testview"
-  },
-  tags: {}
-};
-const uniques10 = [];
-const extensions124 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: {
-    omit: "create,update,delete,all,order,filter"
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "foreign_key"
+    },
+    tags: {}
   }
 };
-const uniques11 = [{
-  isPrimary: false,
-  attributes: ["compound_key_1", "compound_key_2"],
-  description: undefined,
-  extensions: {
-    tags: Object.create(null)
-  }
-}];
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
   codec: uniqueForeignKeyCodec,
-  uniques: uniques11,
+  uniques: [{
+    isPrimary: false,
+    attributes: ["compound_key_1", "compound_key_2"],
+    description: undefined,
+    extensions: {
+      tags: Object.create(null)
+    }
+  }],
   isVirtual: false,
   description: undefined,
-  extensions: extensions124
-};
-const extensions125 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "my_table"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: {
+      omit: "create,update,delete,all,order,filter"
+    }
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -4749,17 +3079,6 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions126 = {
-  description: "Tracks the person's secret",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_secret"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on table c.person_secret)."
-  }
-};
 const uniques13 = [{
   isPrimary: true,
   attributes: ["person_id"],
@@ -4777,16 +3096,17 @@ const registryConfig_pgResources_c_person_secret_c_person_secret = {
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions126
-};
-const extensions127 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "view_table"
-  },
-  tags: {}
+  extensions: {
+    description: "Tracks the person's secret",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "person_secret"
+    },
+    tags: {
+      deprecated: "This is deprecated (comment on table c.person_secret)."
+    }
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -4796,27 +3116,6 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions128 = {
-  description: "YOYOYO!!",
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "updatable_view"
-  },
-  tags: {
-    uniqueKey: "x"
-  }
-};
-const uniques15 = [];
-const extensions129 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_key"
-  },
-  tags: {}
-};
 const uniques16 = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
@@ -4834,16 +3133,15 @@ const registryConfig_pgResources_c_compound_key_c_compound_key = {
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
-  extensions: extensions129
-};
-const extensions130 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_1"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_key"
+    },
+    tags: {}
+  }
 };
 const uniques17 = [{
   isPrimary: true,
@@ -4853,15 +3151,6 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "similar_table_2"
-  },
-  tags: {}
-};
 const uniques18 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4870,15 +3159,6 @@ const uniques18 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "null_test_record"
-  },
-  tags: {}
-};
 const uniques19 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -4887,97 +3167,9 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case_computed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts114 = ["c", "edge_case_computed"];
-const sqlIdent72 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
-const parameters64 = [{
-  name: "edge_case",
-  required: true,
-  notNull: false,
-  codec: cEdgeCaseCodec
-}];
-const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent73 = sql.identifier(...parts115);
-const options_c_return_table_without_grants = {
-  name: "c_return_table_without_grants",
-  identifier: "main.c.return_table_without_grants()",
-  from(...args) {
-    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "return_table_without_grants"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions134 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "list_bde_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent74 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
-const parameters65 = [{
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: pgCatalogTextArrayCodec
-}, {
-  name: "d",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}, {
-  name: "e",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions135 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "edge_case"
-  },
-  tags: {}
-};
-const uniques20 = [];
-const extensions136 = {
-  description: "Tracks metadata about the left arms of various people",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "left_arm"
-  },
-  tags: {}
-};
+const sqlIdent72 = sql.identifier("c", "edge_case_computed");
+const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
+const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
 const uniques21 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5002,103 +3194,39 @@ const registryConfig_pgResources_c_left_arm_c_left_arm = {
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions136
-};
-const parts117 = ["b", "authenticate_fail"];
-const sqlIdent75 = sql.identifier(...parts117);
-const options_b_authenticate_fail = {
-  name: "b_authenticate_fail",
-  identifier: "main.b.authenticate_fail()",
-  from(...args) {
-    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: "Tracks metadata about the left arms of various people",
     pg: {
       serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_fail"
+      schemaName: "c",
+      name: "left_arm"
     },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions137 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "jwt_token"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques22 = [];
+const sqlIdent75 = sql.identifier("b", "authenticate_fail");
 const resourceConfig_b_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "b_jwt_token",
   identifier: "main.b.jwt_token",
   from: bJwtTokenCodec.sqlType,
   codec: bJwtTokenCodec,
-  uniques: uniques22,
+  uniques: [],
   isVirtual: true,
   description: undefined,
-  extensions: extensions137
-};
-const parts118 = ["b", "authenticate"];
-const sqlIdent76 = sql.identifier(...parts118);
-const options_b_authenticate = {
-  name: "b_authenticate",
-  identifier: "main.b.authenticate(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "authenticate"
+      name: "jwt_token"
     },
     tags: {
-      behavior: ["-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
+  }
 };
-const extensions138 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "issue756"
-  },
-  tags: {}
-};
+const sqlIdent76 = sql.identifier("b", "authenticate");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5116,571 +3244,35 @@ const registryConfig_pgResources_c_issue756_c_issue756 = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions138
-};
-const parts119 = ["c", "left_arm_identity"];
-const sqlIdent77 = sql.identifier(...parts119);
-const options_c_left_arm_identity = {
-  name: "c_left_arm_identity",
-  identifier: "main.c.left_arm_identity(c.left_arm)",
-  from(...args) {
-    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "left_arm",
-    required: true,
-    notNull: false,
-    codec: cLeftArmCodec,
-    extensions: {
-      variant: "base"
-    }
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "left_arm_identity"
+      name: "issue756"
     },
-    tags: {
-      arg0variant: "base",
-      resultFieldName: "leftArm",
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts120 = ["c", "issue756_mutation"];
-const sqlIdent78 = sql.identifier(...parts120);
-const options_c_issue756_mutation = {
-  name: "c_issue756_mutation",
-  identifier: "main.c.issue756_mutation()",
-  from(...args) {
-    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent79 = sql.identifier(...parts121);
-const options_c_issue756_set_mutation = {
-  name: "c_issue756_set_mutation",
-  identifier: "main.c.issue756_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "issue756_set_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts122 = ["b", "authenticate_many"];
-const sqlIdent80 = sql.identifier(...parts122);
-const options_b_authenticate_many = {
-  name: "b_authenticate_many",
-  identifier: "main.b.authenticate_many(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_many"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts123 = ["b", "authenticate_payload"];
-const sqlIdent81 = sql.identifier(...parts123);
-const options_b_authenticate_payload = {
-  name: "b_authenticate_payload",
-  identifier: "main.b.authenticate_payload(int4,numeric,int8)",
-  from(...args) {
-    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "a",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }, {
-    name: "b",
-    required: true,
-    notNull: false,
-    codec: TYPES.numeric
-  }, {
-    name: "c",
-    required: true,
-    notNull: false,
-    codec: TYPES.bigint
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "authenticate_payload"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions139 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "auth_payload"
-  },
-  tags: {
-    foreignKey: "(id) references c.person",
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques24 = [];
-const resourceConfig_b_auth_payload = {
-  executor: executor_mainPgExecutor,
-  name: "b_auth_payload",
-  identifier: "main.b.auth_payload",
-  from: bAuthPayloadCodec.sqlType,
-  codec: bAuthPayloadCodec,
-  uniques: uniques24,
-  isVirtual: true,
-  description: undefined,
-  extensions: extensions139
-};
-const extensions140 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_mutation"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts124 = ["c", "types_mutation"];
-const sqlIdent82 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
-const parameters66 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: pgCatalogInt4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: cFloatrangeCodec
-}];
-const extensions141 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "types_query"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts125 = ["c", "types_query"];
-const sqlIdent83 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
-const parameters67 = [{
-  name: "a",
-  required: true,
-  notNull: true,
-  codec: TYPES.bigint
-}, {
-  name: "b",
-  required: true,
-  notNull: true,
-  codec: TYPES.boolean
-}, {
-  name: "c",
-  required: true,
-  notNull: true,
-  codec: TYPES.varchar
-}, {
-  name: "d",
-  required: true,
-  notNull: true,
-  codec: pgCatalogInt4ArrayCodec
-}, {
-  name: "e",
-  required: true,
-  notNull: true,
-  codec: TYPES.json
-}, {
-  name: "f",
-  required: true,
-  notNull: true,
-  codec: cFloatrangeCodec
-}];
-const extensions142 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type_computed_field"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent84 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
-const parameters68 = [{
-  name: "compound_type",
-  required: true,
-  notNull: false,
-  codec: cCompoundTypeCodec
-}];
-const extensions143 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_set"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent85 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
-const parameters69 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions144 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_interval_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent86 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
-const parameters70 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions145 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_text_array"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent87 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
-const parameters71 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}];
-const extensions146 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_optional_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-filter -order"]
-  }
-};
-const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent88 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
-const parameters72 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions147 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_computed_with_required_arg"
-  },
-  tags: {
-    sortable: true,
-    filterable: true,
-    behavior: ["-filter -order"]
-  }
-};
-const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent89 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
-const parameters73 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "i",
-  required: true,
-  notNull: true,
-  codec: TYPES.int
-}];
-const extensions148 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent90 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
-const parameters74 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions149 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_out_compound_type"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent91 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
-const parameters75 = [{
-  name: "i1",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}];
-const extensions150 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent92 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
-const parameters76 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions151 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_no_defaults"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent93 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
-const parameters77 = [{
-  name: "post",
-  required: true,
-  notNull: false,
-  codec: postCodec
-}, {
-  name: "length",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions152 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post_headline_trimmed_strict"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent94 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
-const parameters78 = [{
-  name: "post",
-  required: true,
-  notNull: true,
-  codec: postCodec
-}, {
-  name: "length",
-  required: false,
-  notNull: true,
-  codec: TYPES.int
-}, {
-  name: "omission",
-  required: false,
-  notNull: true,
-  codec: TYPES.text
-}];
-const extensions153 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "query_output_two_rows"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent95 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
-const parameters79 = [{
-  name: "left_arm_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "post_id",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "txt",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions154 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: {}
-};
+const sqlIdent77 = sql.identifier("c", "left_arm_identity");
+const sqlIdent78 = sql.identifier("c", "issue756_mutation");
+const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
+const sqlIdent80 = sql.identifier("b", "authenticate_many");
+const sqlIdent81 = sql.identifier("b", "authenticate_payload");
+const sqlIdent82 = sql.identifier("c", "types_mutation");
+const sqlIdent83 = sql.identifier("c", "types_query");
+const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
+const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
+const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
+const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
+const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
+const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
+const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
+const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
+const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
+const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
+const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
 const uniques25 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -5698,732 +3290,63 @@ const registryConfig_pgResources_post_post = {
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions154
-};
-const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent96 = sql.identifier(...parts138);
-const options_c_compound_type_set_query = {
-  name: "c_compound_type_set_query",
-  identifier: "main.c.compound_type_set_query()",
-  from(...args) {
-    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
-      schemaName: "c",
-      name: "compound_type_set_query"
+      schemaName: "a",
+      name: "post"
     },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions155 = {
-  description: "Awesome feature!",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "compound_type"
-  },
-  tags: {
-    behavior: ["-insert", "-update", "-delete"]
+    tags: {}
   }
 };
-const uniques26 = [];
+const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_c_compound_type = {
   executor: executor_mainPgExecutor,
   name: "c_compound_type",
   identifier: "main.c.compound_type",
   from: cCompoundTypeCodec.sqlType,
   codec: cCompoundTypeCodec,
-  uniques: uniques26,
+  uniques: [],
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions155
-};
-const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent97 = sql.identifier(...parts139);
-const options_b_compound_type_mutation = {
-  name: "b_compound_type_mutation",
-  identifier: "main.b.compound_type_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
   extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts140 = ["b", "compound_type_query"];
-const sqlIdent98 = sql.identifier(...parts140);
-const options_b_compound_type_query = {
-  name: "b_compound_type_query",
-  identifier: "main.b.compound_type_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_query"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent99 = sql.identifier(...parts141);
-const options_b_compound_type_set_mutation = {
-  name: "b_compound_type_set_mutation",
-  identifier: "main.b.compound_type_set_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_set_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts142 = ["c", "table_mutation"];
-const sqlIdent100 = sql.identifier(...parts142);
-const options_c_table_mutation = {
-  name: "c_table_mutation",
-  identifier: "main.c.table_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
+    description: "Awesome feature!",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "table_mutation"
+      name: "compound_type"
     },
     tags: {
-      behavior: ["-filter -order"]
+      behavior: ["-insert", "-update", "-delete"]
     }
-  },
-  description: undefined
-};
-const parts143 = ["c", "table_query"];
-const sqlIdent101 = sql.identifier(...parts143);
-const options_c_table_query = {
-  name: "c_table_query",
-  identifier: "main.c.table_query(int4)",
-  from(...args) {
-    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_query"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts144 = ["a", "post_with_suffix"];
-const sqlIdent102 = sql.identifier(...parts144);
-const options_post_with_suffix = {
-  name: "post_with_suffix",
-  identifier: "main.a.post_with_suffix(a.post,text)",
-  from(...args) {
-    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "suffix",
-    required: true,
-    notNull: false,
-    codec: TYPES.text
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_with_suffix"
-    },
-    tags: {
-      deprecated: "This is deprecated (comment on function a.post_with_suffix).",
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent103 = sql.identifier(...parts145);
-const options_mutation_compound_type_array = {
-  name: "mutation_compound_type_array",
-  identifier: "main.a.mutation_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "mutation_compound_type_array"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent104 = sql.identifier(...parts146);
-const options_query_compound_type_array = {
-  name: "query_compound_type_array",
-  identifier: "main.a.query_compound_type_array(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "query_compound_type_array"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent105 = sql.identifier(...parts147);
-const options_b_compound_type_array_mutation = {
-  name: "b_compound_type_array_mutation",
-  identifier: "main.b.compound_type_array_mutation(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent106 = sql.identifier(...parts148);
-const options_b_compound_type_array_query = {
-  name: "b_compound_type_array_query",
-  identifier: "main.b.compound_type_array_query(c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "compound_type_array_query"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent107 = sql.identifier(...parts149);
-const options_post_computed_compound_type_array = {
-  name: "post_computed_compound_type_array",
-  identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
-  from(...args) {
-    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "post",
-    required: true,
-    notNull: false,
-    codec: postCodec
-  }, {
-    name: "object",
-    required: true,
-    notNull: false,
-    codec: cCompoundTypeCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_computed_compound_type_array"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts150 = ["a", "post_many"];
-const sqlIdent108 = sql.identifier(...parts150);
-const options_post_many = {
-  name: "post_many",
-  identifier: "main.a.post_many(a._post)",
-  from(...args) {
-    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "posts",
-    required: true,
-    notNull: false,
-    codec: postArrayCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "a",
-      name: "post_many"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions156 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out"
-  },
-  tags: {
-    notNull: true,
-    sortable: true,
-    filterable: true,
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "o1"
-};
-const parts151 = ["c", "person_computed_out"];
-const sqlIdent109 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
-const parameters80 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}];
-const extensions157 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_first_name"
-  },
-  tags: {
-    sortable: true,
-    behavior: ["-filter -order"]
   }
 };
-const parts152 = ["c", "person_first_name"];
-const sqlIdent110 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
-const parameters81 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}];
-const extensions158 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_out_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent111 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
-const parameters82 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}];
-const extensions159 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  },
-  singleOutputParameterName: "ino"
-};
-const parts154 = ["c", "person_computed_inout"];
-const sqlIdent112 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
-const parameters83 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions160 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_inout_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent113 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
-const parameters84 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}, {
-  name: "ino",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions161 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_exists"
-  },
-  tags: {
-    deprecated: "This is deprecated (comment on function c.person_exists).",
-    behavior: ["-filter -order"]
-  }
-};
-const parts156 = ["c", "person_exists"];
-const sqlIdent114 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
-const parameters85 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}, {
-  name: "email",
-  required: true,
-  notNull: false,
-  codec: bEmailCodec
-}];
-const extensions162 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_first_arg_inout_out"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent115 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
-const parameters86 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}];
-const extensions163 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts158 = ["c", "func_out_complex"];
-const sqlIdent116 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
-const parameters87 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions164 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "func_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent117 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
-const parameters88 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions165 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent118 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
-const parameters89 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions166 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "mutation_out_complex_setof"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent119 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
-const parameters90 = [{
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const extensions167 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person_computed_complex"
-  },
-  tags: {
-    behavior: ["-filter -order"]
-  }
-};
-const parts162 = ["c", "person_computed_complex"];
-const sqlIdent120 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
-const parameters91 = [{
-  name: "person",
-  required: true,
-  notNull: false,
-  codec: cPersonCodec
-}, {
-  name: "a",
-  required: true,
-  notNull: false,
-  codec: TYPES.int
-}, {
-  name: "b",
-  required: true,
-  notNull: false,
-  codec: TYPES.text
-}];
-const parts163 = ["c", "person_first_post"];
-const sqlIdent121 = sql.identifier(...parts163);
-const options_c_person_first_post = {
-  name: "c_person_first_post",
-  identifier: "main.c.person_first_post(c.person)",
-  from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_first_post"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: "The first post by the person."
-};
-const extensions168 = {
-  description: "Person test comment",
-  pg: {
-    serviceName: "main",
-    schemaName: "c",
-    name: "person"
-  },
-  tags: {}
-};
+const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
+const sqlIdent98 = sql.identifier("b", "compound_type_query");
+const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
+const sqlIdent100 = sql.identifier("c", "table_mutation");
+const sqlIdent101 = sql.identifier("c", "table_query");
+const sqlIdent102 = sql.identifier("a", "post_with_suffix");
+const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
+const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
+const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
+const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
+const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
+const sqlIdent108 = sql.identifier("a", "post_many");
+const sqlIdent109 = sql.identifier("c", "person_computed_out");
+const sqlIdent110 = sql.identifier("c", "person_first_name");
+const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
+const sqlIdent112 = sql.identifier("c", "person_computed_inout");
+const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
+const sqlIdent114 = sql.identifier("c", "person_exists");
+const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
+const sqlIdent116 = sql.identifier("c", "func_out_complex");
+const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
+const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
+const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
+const sqlIdent120 = sql.identifier("c", "person_computed_complex");
+const sqlIdent121 = sql.identifier("c", "person_first_post");
 const uniques27 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6448,274 +3371,26 @@ const registryConfig_pgResources_c_person_c_person = {
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions168
-};
-const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent122 = sql.identifier(...parts164);
-const options_c_badly_behaved_function = {
-  name: "c_badly_behaved_function",
-  identifier: "main.c.badly_behaved_function()",
-  from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: "Person test comment",
     pg: {
       serviceName: "main",
       schemaName: "c",
-      name: "badly_behaved_function"
+      name: "person"
     },
-    tags: {
-      deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts165 = ["c", "func_out_table"];
-const sqlIdent123 = sql.identifier(...parts165);
-const options_c_func_out_table = {
-  name: "c_func_out_table",
-  identifier: "main.c.func_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent124 = sql.identifier(...parts166);
-const options_c_func_out_table_setof = {
-  name: "c_func_out_table_setof",
-  identifier: "main.c.func_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "func_out_table_setof"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts167 = ["c", "mutation_out_table"];
-const sqlIdent125 = sql.identifier(...parts167);
-const options_c_mutation_out_table = {
-  name: "c_mutation_out_table",
-  identifier: "main.c.mutation_out_table(c.person)",
-  from(...args) {
-    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent126 = sql.identifier(...parts168);
-const options_c_mutation_out_table_setof = {
-  name: "c_mutation_out_table_setof",
-  identifier: "main.c.mutation_out_table_setof(c.person)",
-  from(...args) {
-    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "mutation_out_table_setof"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts169 = ["c", "table_set_mutation"];
-const sqlIdent127 = sql.identifier(...parts169);
-const options_c_table_set_mutation = {
-  name: "c_table_set_mutation",
-  identifier: "main.c.table_set_mutation()",
-  from(...args) {
-    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts170 = ["c", "table_set_query"];
-const sqlIdent128 = sql.identifier(...parts170);
-const options_c_table_set_query = {
-  name: "c_table_set_query",
-  identifier: "main.c.table_set_query()",
-  from(...args) {
-    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query"
-    },
-    tags: {
-      sortable: true,
-      filterable: true,
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent129 = sql.identifier(...parts171);
-const options_c_table_set_query_plpgsql = {
-  name: "c_table_set_query_plpgsql",
-  identifier: "main.c.table_set_query_plpgsql()",
-  from(...args) {
-    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "table_set_query_plpgsql"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent130 = sql.identifier(...parts172);
-const options_c_person_computed_first_arg_inout = {
-  name: "c_person_computed_first_arg_inout",
-  identifier: "main.c.person_computed_first_arg_inout(c.person)",
-  from(...args) {
-    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_computed_first_arg_inout"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    },
-    singleOutputParameterName: "person"
-  },
-  description: undefined
-};
-const parts173 = ["c", "person_friends"];
-const sqlIdent131 = sql.identifier(...parts173);
-const options_c_person_friends = {
-  name: "c_person_friends",
-  identifier: "main.c.person_friends(c.person)",
-  from(...args) {
-    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "person",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_friends"
-    },
-    tags: {
-      sortable: true,
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions169 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: {
-    foreignKey: extensions46.tags.foreignKey
+    tags: {}
   }
 };
+const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
+const sqlIdent123 = sql.identifier("c", "func_out_table");
+const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
+const sqlIdent125 = sql.identifier("c", "mutation_out_table");
+const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
+const sqlIdent127 = sql.identifier("c", "table_set_mutation");
+const sqlIdent128 = sql.identifier("c", "table_set_query");
+const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
+const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
+const sqlIdent131 = sql.identifier("c", "person_friends");
 const uniques28 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -6733,254 +3408,27 @@ const registryConfig_pgResources_b_types_b_types = {
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions169
-};
-const parts174 = ["b", "type_function_connection"];
-const sqlIdent132 = sql.identifier(...parts174);
-const options_b_type_function_connection = {
-  name: "b_type_function_connection",
-  identifier: "main.b.type_function_connection()",
-  from(...args) {
-    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "b",
-      name: "type_function_connection"
+      name: "types"
     },
     tags: {
-      behavior: ["-filter -order"]
+      foreignKey: extensions46.tags.foreignKey
     }
-  },
-  description: undefined
+  }
 };
-const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent133 = sql.identifier(...parts175);
-const options_b_type_function_connection_mutation = {
-  name: "b_type_function_connection_mutation",
-  identifier: "main.b.type_function_connection_mutation()",
-  from(...args) {
-    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_connection_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts176 = ["b", "type_function"];
-const sqlIdent134 = sql.identifier(...parts176);
-const options_b_type_function = {
-  name: "b_type_function",
-  identifier: "main.b.type_function(int4)",
-  from(...args) {
-    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts177 = ["b", "type_function_mutation"];
-const sqlIdent135 = sql.identifier(...parts177);
-const options_b_type_function_mutation = {
-  name: "b_type_function_mutation",
-  identifier: "main.b.type_function_mutation(int4)",
-  from(...args) {
-    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent136 = sql.identifier(...parts178);
-const options_c_person_type_function_connection = {
-  name: "c_person_type_function_connection",
-  identifier: "main.c.person_type_function_connection(c.person)",
-  from(...args) {
-    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_connection"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts179 = ["c", "person_type_function"];
-const sqlIdent137 = sql.identifier(...parts179);
-const options_c_person_type_function = {
-  name: "c_person_type_function",
-  identifier: "main.c.person_type_function(c.person,int4)",
-  from(...args) {
-    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }, {
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts180 = ["b", "type_function_list"];
-const sqlIdent138 = sql.identifier(...parts180);
-const options_b_type_function_list = {
-  name: "b_type_function_list",
-  identifier: "main.b.type_function_list()",
-  from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent139 = sql.identifier(...parts181);
-const options_b_type_function_list_mutation = {
-  name: "b_type_function_list_mutation",
-  identifier: "main.b.type_function_list_mutation()",
-  from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: true,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "b",
-      name: "type_function_list_mutation"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const parts182 = ["c", "person_type_function_list"];
-const sqlIdent140 = sql.identifier(...parts182);
-const options_c_person_type_function_list = {
-  name: "c_person_type_function_list",
-  identifier: "main.c.person_type_function_list(c.person)",
-  from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "p",
-    required: true,
-    notNull: false,
-    codec: cPersonCodec
-  }],
-  returnsArray: true,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "c",
-      name: "person_type_function_list"
-    },
-    tags: {
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
+const sqlIdent132 = sql.identifier("b", "type_function_connection");
+const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
+const sqlIdent134 = sql.identifier("b", "type_function");
+const sqlIdent135 = sql.identifier("b", "type_function_mutation");
+const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
+const sqlIdent137 = sql.identifier("c", "person_type_function");
+const sqlIdent138 = sql.identifier("b", "type_function_list");
+const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
+const sqlIdent140 = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -7095,19 +3543,40 @@ const registry = makeRegistry({
     "ltree[]": bTypesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     cCompoundTypeArray: listOfCodec(cCompoundTypeCodec, {
-      extensions: cCompoundTypeArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "_compound_type"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "cCompoundTypeArray"
     }),
     bJwtTokenArray: listOfCodec(bJwtTokenCodec, {
-      extensions: bJwtTokenArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_jwt_token"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "bJwtTokenArray"
     }),
     bTypesArray: listOfCodec(bTypesCodec, {
-      extensions: bTypesArrayCodecExtensions,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "_types"
+        },
+        tags: Object.create(null)
+      },
       typeDelim: ",",
       description: undefined,
       name: "bTypesArray"
@@ -7116,9 +3585,165 @@ const registry = makeRegistry({
     cFloatrange: cFloatrangeCodec,
     postArray: postArrayCodec,
     pgCatalogInt8Array: pgCatalogInt8ArrayCodec,
-    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
-    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
-    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
+    tablefuncCrosstab2: recordCodec({
+      name: "tablefuncCrosstab2",
+      identifier: sql.identifier("a", "tablefunc_crosstab_2"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_2"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab3: recordCodec({
+      name: "tablefuncCrosstab3",
+      identifier: sql.identifier("a", "tablefunc_crosstab_3"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_3"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    }),
+    tablefuncCrosstab4: recordCodec({
+      name: "tablefuncCrosstab4",
+      identifier: sql.identifier("a", "tablefunc_crosstab_4"),
+      attributes: Object.assign(Object.create(null), {
+        row_name: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_1: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_2: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_3: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        },
+        category_4: {
+          description: undefined,
+          codec: TYPES.text,
+          notNull: false,
+          hasDefault: false,
+          extensions: {
+            tags: {}
+          }
+        }
+      }),
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "tablefunc_crosstab_4"
+        },
+        tags: Object.create(null)
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     c_current_user_id: {
@@ -7133,813 +3758,1846 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions51,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "current_user_id"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out: {
       executor: executor_mainPgExecutor,
       name: "c_func_out",
       identifier: "main.c.func_out(int4)",
-      from: fromCallback2,
-      parameters: parameters2,
+      from(...args) {
+        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions52,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_func_out_setof: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
-      from: fromCallback3,
-      parameters: parameters3,
+      from(...args) {
+        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions53,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_func_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
-      from: fromCallback4,
-      parameters: parameters4,
+      from(...args) {
+        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions54,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out",
       identifier: "main.c.mutation_out(int4)",
-      from: fromCallback5,
-      parameters: parameters5,
+      from(...args) {
+        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions55,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_mutation_out_setof: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
-      from: fromCallback6,
-      parameters: parameters6,
+      from(...args) {
+        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions56,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_mutation_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
-      from: fromCallback7,
-      parameters: parameters7,
+      from(...args) {
+        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions57,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_no_args_mutation: {
       executor: executor_mainPgExecutor,
       name: "c_no_args_mutation",
       identifier: "main.c.no_args_mutation()",
-      from: fromCallback8,
-      parameters: parameters8,
+      from(...args) {
+        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions58,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_no_args_query: {
       executor: executor_mainPgExecutor,
       name: "c_no_args_query",
       identifier: "main.c.no_args_query()",
-      from: fromCallback9,
-      parameters: parameters9,
+      from(...args) {
+        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions59,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "no_args_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     return_void_mutation: {
       executor: executor_mainPgExecutor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
-      from: fromCallback10,
-      parameters: parameters10,
+      from(...args) {
+        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions60,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "return_void_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_set: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
-      from: fromCallback11,
-      parameters: parameters11,
+      from(...args) {
+        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions61,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_set"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_set: {
       executor: executor_mainPgExecutor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
-      from: fromCallback12,
-      parameters: parameters12,
+      from(...args) {
+        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions62,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_set"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     static_big_integer: {
       executor: executor_mainPgExecutor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
-      from: fromCallback13,
-      parameters: parameters13,
+      from(...args) {
+        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions63,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "static_big_integer"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_in_out: {
       executor: executor_mainPgExecutor,
       name: "c_func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
-      from: fromCallback14,
-      parameters: parameters14,
+      from(...args) {
+        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_func_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "c_func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
-      from: fromCallback15,
-      parameters: parameters15,
+      from(...args) {
+        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     c_mutation_in_out: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
-      from: fromCallback16,
-      parameters: parameters16,
+      from(...args) {
+        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions66,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o"
+      },
       description: undefined
     },
     c_mutation_returns_table_one_col: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
-      from: fromCallback17,
-      parameters: parameters17,
+      from(...args) {
+        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions67,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_one_col"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "col1"
+      },
       description: undefined
     },
     assert_something: {
       executor: executor_mainPgExecutor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
-      from: fromCallback18,
-      parameters: parameters18,
+      from(...args) {
+        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions68,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     assert_something_nx: {
       executor: executor_mainPgExecutor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
-      from: fromCallback19,
-      parameters: parameters19,
+      from(...args) {
+        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "in_arg",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions69,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "assert_something_nx"
+        },
+        tags: {
+          omit: "execute",
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_json_identity: {
       executor: executor_mainPgExecutor,
       name: "c_json_identity",
       identifier: "main.c.json_identity(json)",
-      from: fromCallback20,
-      parameters: parameters20,
+      from(...args) {
+        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions70,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_json_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "c_json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
-      from: fromCallback21,
-      parameters: parameters21,
+      from(...args) {
+        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.json
+      }],
       isUnique: !false,
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "json_identity_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_jsonb_identity: {
       executor: executor_mainPgExecutor,
       name: "c_jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
-      from: fromCallback22,
-      parameters: parameters22,
+      from(...args) {
+        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_jsonb_identity_mutation: {
       executor: executor_mainPgExecutor,
       name: "c_jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
-      from: fromCallback23,
-      parameters: parameters23,
+      from(...args) {
+        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "json",
+        required: true,
+        notNull: false,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql: {
       executor: executor_mainPgExecutor,
       name: "c_jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
-      from: fromCallback24,
-      parameters: parameters24,
+      from(...args) {
+        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: true,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql_with_default: {
       executor: executor_mainPgExecutor,
       name: "c_jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
-      from: fromCallback25,
-      parameters: parameters25,
+      from(...args) {
+        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "_the_json",
+        required: false,
+        notNull: true,
+        codec: TYPES.jsonb
+      }],
       isUnique: !false,
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions75,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "jsonb_identity_mutation_plpgsql_with_default"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     add_1_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
-      from: fromCallback26,
-      parameters: parameters26,
+      from(...args) {
+        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions76,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
       executor: executor_mainPgExecutor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
-      from: fromCallback27,
-      parameters: parameters27,
+      from(...args) {
+        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_1_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
-      from: fromCallback28,
-      parameters: parameters28,
+      from(...args) {
+        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions78,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
       executor: executor_mainPgExecutor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
-      from: fromCallback29,
-      parameters: parameters29,
+      from(...args) {
+        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions79,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_2_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
-      from: fromCallback30,
-      parameters: parameters30,
+      from(...args) {
+        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
       executor: executor_mainPgExecutor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
-      from: fromCallback31,
-      parameters: parameters31,
+      from(...args) {
+        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_3_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
-      from: fromCallback32,
-      parameters: parameters32,
+      from(...args) {
+        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions82,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
       executor: executor_mainPgExecutor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
-      from: fromCallback33,
-      parameters: parameters33,
+      from(...args) {
+        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions83,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_mutation_error"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     add_4_query: {
       executor: executor_mainPgExecutor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
-      from: fromCallback34,
-      parameters: parameters34,
+      from(...args) {
+        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions84,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "add_4_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: "lol, add some stuff 4 query"
     },
     b_mult_1: {
       executor: executor_mainPgExecutor,
       name: "b_mult_1",
       identifier: "main.b.mult_1(int4,int4)",
-      from: fromCallback35,
-      parameters: parameters35,
+      from(...args) {
+        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions85,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_1"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     b_mult_2: {
       executor: executor_mainPgExecutor,
       name: "b_mult_2",
       identifier: "main.b.mult_2(int4,int4)",
-      from: fromCallback36,
-      parameters: parameters36,
+      from(...args) {
+        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_2"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     b_mult_3: {
       executor: executor_mainPgExecutor,
       name: "b_mult_3",
       identifier: "main.b.mult_3(int4,int4)",
-      from: fromCallback37,
-      parameters: parameters37,
+      from(...args) {
+        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_3"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     b_mult_4: {
       executor: executor_mainPgExecutor,
       name: "b_mult_4",
       identifier: "main.b.mult_4(int4,int4)",
-      from: fromCallback38,
-      parameters: parameters38,
+      from(...args) {
+        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: null,
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "mult_4"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_in_inout: {
       executor: executor_mainPgExecutor,
       name: "c_func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
-      from: fromCallback39,
-      parameters: parameters39,
+      from(...args) {
+        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions89,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_in_inout"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     c_func_out_out: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
-      from: fromCallback40,
-      parameters: parameters40,
+      from(...args) {
+        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CFuncOutOutRecord_CFuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
-      from: fromCallback41,
-      parameters: parameters41,
+      from(...args) {
+        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions91,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
-      from: fromCallback42,
-      parameters: parameters42,
+      from(...args) {
+        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_in_inout: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
-      from: fromCallback43,
-      parameters: parameters43,
+      from(...args) {
+        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_in_inout"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     c_mutation_out_out: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
-      from: fromCallback44,
-      parameters: parameters44,
+      from(...args) {
+        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions94,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_out_setof: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
-      from: fromCallback45,
-      parameters: parameters45,
+      from(...args) {
+        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
-      from: fromCallback46,
-      parameters: parameters46,
+      from(...args) {
+        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_search_test_summaries: {
       executor: executor_mainPgExecutor,
       name: "c_search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
-      from: fromCallback47,
-      parameters: parameters47,
+      from(...args) {
+        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "search_test_summaries"
+        },
+        tags: {
+          simpleCollections: "only",
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_1: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
-      from: fromCallback48,
-      parameters: parameters48,
+      from(...args) {
+        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions98,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_1"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_2: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
-      from: fromCallback49,
-      parameters: parameters49,
+      from(...args) {
+        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions99,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_2"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_3: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
-      from: fromCallback50,
-      parameters: parameters50,
+      from(...args) {
+        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions100,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_3"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_4: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
-      from: fromCallback51,
-      parameters: parameters51,
+      from(...args) {
+        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions101,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_4"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     optional_missing_middle_5: {
       executor: executor_mainPgExecutor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
-      from: fromCallback52,
-      parameters: parameters52,
+      from(...args) {
+        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "optional_missing_middle_5"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback53,
-      parameters: parameters53,
+      from(...args) {
+        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "c_func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback54,
-      parameters: parameters54,
+      from(...args) {
+        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_int_set_mutation: {
       executor: executor_mainPgExecutor,
       name: "c_int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
-      from: fromCallback55,
-      parameters: parameters55,
+      from(...args) {
+        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions105,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_int_set_query: {
       executor: executor_mainPgExecutor,
       name: "c_int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
-      from: fromCallback56,
-      parameters: parameters56,
+      from(...args) {
+        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "x",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "y",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "z",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions106,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "int_set_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_unnamed_out_out_unnamed: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
-      from: fromCallback57,
-      parameters: parameters57,
+      from(...args) {
+        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_unnamed_out_out_unnamed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_returns_table_multi_col: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
-      from: fromCallback58,
-      parameters: parameters58,
+      from(...args) {
+        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_returns_table_multi_col"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     b_guid_fn: {
       executor: executor_mainPgExecutor,
       name: "b_guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
-      from: fromCallback59,
-      parameters: parameters59,
+      from(...args) {
+        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "g",
+        required: true,
+        notNull: false,
+        codec: bGuidCodec
+      }],
       isUnique: !false,
       codec: bGuidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "guid_fn"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_interval_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
-      from: fromCallback60,
-      parameters: parameters60,
+      from(...args) {
+        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions110,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_interval_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     query_interval_array: {
       executor: executor_mainPgExecutor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
-      from: fromCallback61,
-      parameters: parameters61,
+      from(...args) {
+        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_interval_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     mutation_text_array: {
       executor: executor_mainPgExecutor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
-      from: fromCallback62,
-      parameters: parameters62,
+      from(...args) {
+        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions112,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_text_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     query_text_array: {
       executor: executor_mainPgExecutor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
-      from: fromCallback63,
-      parameters: parameters63,
+      from(...args) {
+        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
       isUnique: !false,
       codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_text_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     non_updatable_view: {
@@ -7951,7 +5609,17 @@ const registry = makeRegistry({
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions114
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "non_updatable_view"
+        },
+        tags: {
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
     },
     inputs: {
       executor: executor_mainPgExecutor,
@@ -7962,7 +5630,15 @@ const registry = makeRegistry({
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions115
+      extensions: {
+        description: "Should output as Input",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "inputs"
+        },
+        tags: {}
+      }
     },
     patchs: {
       executor: executor_mainPgExecutor,
@@ -7973,7 +5649,15 @@ const registry = makeRegistry({
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions116
+      extensions: {
+        description: "Should output as Patch",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "patchs"
+        },
+        tags: {}
+      }
     },
     reserved: {
       executor: executor_mainPgExecutor,
@@ -7984,7 +5668,15 @@ const registry = makeRegistry({
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions117
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved"
+        },
+        tags: {}
+      }
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
@@ -7995,7 +5687,15 @@ const registry = makeRegistry({
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions118
+      extensions: {
+        description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reservedPatchs"
+        },
+        tags: {}
+      }
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
@@ -8006,7 +5706,15 @@ const registry = makeRegistry({
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions119
+      extensions: {
+        description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "reserved_input"
+        },
+        tags: {}
+      }
     },
     default_value: {
       executor: executor_mainPgExecutor,
@@ -8017,7 +5725,15 @@ const registry = makeRegistry({
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions120
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "default_value"
+        },
+        tags: {}
+      }
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
@@ -8026,10 +5742,25 @@ const registry = makeRegistry({
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
       codec: noPrimaryKeyCodec,
-      uniques: uniques9,
+      uniques: [{
+        isPrimary: false,
+        attributes: ["id"],
+        description: undefined,
+        extensions: {
+          tags: Object.create(null)
+        }
+      }],
       isVirtual: false,
       description: undefined,
-      extensions: extensions122
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "no_primary_key"
+        },
+        tags: {}
+      }
     },
     testview: {
       executor: executor_mainPgExecutor,
@@ -8037,10 +5768,18 @@ const registry = makeRegistry({
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
       codec: testviewCodec,
-      uniques: uniques10,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions123
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "testview"
+        },
+        tags: {}
+      }
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     c_my_table: {
@@ -8052,7 +5791,15 @@ const registry = makeRegistry({
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions125
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "my_table"
+        },
+        tags: {}
+      }
     },
     c_person_secret: registryConfig_pgResources_c_person_secret_c_person_secret,
     view_table: {
@@ -8064,7 +5811,15 @@ const registry = makeRegistry({
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "view_table"
+        },
+        tags: {}
+      }
     },
     b_updatable_view: {
       executor: executor_mainPgExecutor,
@@ -8072,10 +5827,20 @@ const registry = makeRegistry({
       identifier: "main.b.updatable_view",
       from: bUpdatableViewCodec.sqlType,
       codec: bUpdatableViewCodec,
-      uniques: uniques15,
+      uniques: [],
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions128
+      extensions: {
+        description: "YOYOYO!!",
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "updatable_view"
+        },
+        tags: {
+          uniqueKey: "x"
+        }
+      }
     },
     c_compound_key: registryConfig_pgResources_c_compound_key_c_compound_key,
     similar_table_1: {
@@ -8087,7 +5852,15 @@ const registry = makeRegistry({
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_1"
+        },
+        tags: {}
+      }
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
@@ -8098,7 +5871,15 @@ const registry = makeRegistry({
       uniques: uniques18,
       isVirtual: false,
       description: undefined,
-      extensions: extensions131
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "similar_table_2"
+        },
+        tags: {}
+      }
     },
     c_null_test_record: {
       executor: executor_mainPgExecutor,
@@ -8109,33 +5890,104 @@ const registry = makeRegistry({
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions132
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "null_test_record"
+        },
+        tags: {}
+      }
     },
     c_edge_case_computed: {
       executor: executor_mainPgExecutor,
       name: "c_edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
-      from: fromCallback64,
-      parameters: parameters64,
+      from(...args) {
+        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "edge_case",
+        required: true,
+        notNull: false,
+        codec: cEdgeCaseCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions133,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case_computed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
-    c_return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_c_compound_key_c_compound_key, options_c_return_table_without_grants),
+    c_return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_c_compound_key_c_compound_key, {
+      name: "c_return_table_without_grants",
+      identifier: "main.c.return_table_without_grants()",
+      from(...args) {
+        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "return_table_without_grants"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     b_list_bde_mutation: {
       executor: executor_mainPgExecutor,
       name: "b_list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
-      from: fromCallback65,
-      parameters: parameters65,
+      from(...args) {
+        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: pgCatalogTextArrayCodec
+      }, {
+        name: "d",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }, {
+        name: "e",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: pgCatalogUuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions134,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "list_bde_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_edge_case: {
@@ -8144,394 +5996,2011 @@ const registry = makeRegistry({
       identifier: "main.c.edge_case",
       from: cEdgeCaseCodec.sqlType,
       codec: cEdgeCaseCodec,
-      uniques: uniques20,
+      uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "edge_case"
+        },
+        tags: {}
+      }
     },
     c_left_arm: registryConfig_pgResources_c_left_arm_c_left_arm,
-    b_authenticate_fail: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, options_b_authenticate_fail),
-    b_authenticate: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, options_b_authenticate),
+    b_authenticate_fail: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, {
+      name: "b_authenticate_fail",
+      identifier: "main.b.authenticate_fail()",
+      from(...args) {
+        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_fail"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_authenticate: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, {
+      name: "b_authenticate",
+      identifier: "main.b.authenticate(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     c_issue756: registryConfig_pgResources_c_issue756_c_issue756,
-    c_left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_c_left_arm_c_left_arm, options_c_left_arm_identity),
-    c_issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_issue756_c_issue756, options_c_issue756_mutation),
-    c_issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_issue756_c_issue756, options_c_issue756_set_mutation),
-    b_authenticate_many: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, options_b_authenticate_many),
-    b_authenticate_payload: PgResource.functionResourceOptions(resourceConfig_b_auth_payload, options_b_authenticate_payload),
+    c_left_arm_identity: PgResource.functionResourceOptions(registryConfig_pgResources_c_left_arm_c_left_arm, {
+      name: "c_left_arm_identity",
+      identifier: "main.c.left_arm_identity(c.left_arm)",
+      from(...args) {
+        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm",
+        required: true,
+        notNull: false,
+        codec: cLeftArmCodec,
+        extensions: {
+          variant: "base"
+        }
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "left_arm_identity"
+        },
+        tags: {
+          arg0variant: "base",
+          resultFieldName: "leftArm",
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_issue756_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_issue756_c_issue756, {
+      name: "c_issue756_mutation",
+      identifier: "main.c.issue756_mutation()",
+      from(...args) {
+        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_issue756_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_issue756_c_issue756, {
+      name: "c_issue756_set_mutation",
+      identifier: "main.c.issue756_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "issue756_set_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_authenticate_many: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, {
+      name: "b_authenticate_many",
+      identifier: "main.b.authenticate_many(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_many"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_authenticate_payload: PgResource.functionResourceOptions({
+      executor: executor_mainPgExecutor,
+      name: "b_auth_payload",
+      identifier: "main.b.auth_payload",
+      from: bAuthPayloadCodec.sqlType,
+      codec: bAuthPayloadCodec,
+      uniques: [],
+      isVirtual: true,
+      description: undefined,
+      extensions: {
+        description: undefined,
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "auth_payload"
+        },
+        tags: {
+          foreignKey: "(id) references c.person",
+          behavior: ["-insert", "-update", "-delete"]
+        }
+      }
+    }, {
+      name: "b_authenticate_payload",
+      identifier: "main.b.authenticate_payload(int4,numeric,int8)",
+      from(...args) {
+        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.numeric
+      }, {
+        name: "c",
+        required: true,
+        notNull: false,
+        codec: TYPES.bigint
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "authenticate_payload"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     c_types_mutation: {
       executor: executor_mainPgExecutor,
       name: "c_types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback66,
-      parameters: parameters66,
+      from(...args) {
+        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: pgCatalogInt4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: cFloatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions140,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_types_query: {
       executor: executor_mainPgExecutor,
       name: "c_types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
-      from: fromCallback67,
-      parameters: parameters67,
+      from(...args) {
+        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.bigint
+      }, {
+        name: "b",
+        required: true,
+        notNull: true,
+        codec: TYPES.boolean
+      }, {
+        name: "c",
+        required: true,
+        notNull: true,
+        codec: TYPES.varchar
+      }, {
+        name: "d",
+        required: true,
+        notNull: true,
+        codec: pgCatalogInt4ArrayCodec
+      }, {
+        name: "e",
+        required: true,
+        notNull: true,
+        codec: TYPES.json
+      }, {
+        name: "f",
+        required: true,
+        notNull: true,
+        codec: cFloatrangeCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions141,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "types_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_compound_type_computed_field: {
       executor: executor_mainPgExecutor,
       name: "c_compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
-      from: fromCallback68,
-      parameters: parameters68,
+      from(...args) {
+        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "compound_type",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions142,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_computed_field"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_set: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
-      from: fromCallback69,
-      parameters: parameters69,
+      from(...args) {
+        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !true,
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions143,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_set"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_interval_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
-      from: fromCallback70,
-      parameters: parameters70,
+      from(...args) {
+        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions144,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_interval_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_text_array: {
       executor: executor_mainPgExecutor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
-      from: fromCallback71,
-      parameters: parameters71,
+      from(...args) {
+        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }],
       isUnique: !false,
       codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions145,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_text_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_optional_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
-      from: fromCallback72,
-      parameters: parameters72,
+      from(...args) {
+        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_optional_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_computed_with_required_arg: {
       executor: executor_mainPgExecutor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
-      from: fromCallback73,
-      parameters: parameters73,
+      from(...args) {
+        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "i",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions147,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_with_required_arg"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback74,
-      parameters: parameters74,
+      from(...args) {
+        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions148,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_out_compound_type: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
-      from: fromCallback75,
-      parameters: parameters75,
+      from(...args) {
+        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "i1",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions149,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_out_compound_type"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
-      from: fromCallback76,
-      parameters: parameters76,
+      from(...args) {
+        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions150,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
-      from: fromCallback77,
-      parameters: parameters77,
+      from(...args) {
+        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions151,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_no_defaults"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post_headline_trimmed_strict: {
       executor: executor_mainPgExecutor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
-      from: fromCallback78,
-      parameters: parameters78,
+      from(...args) {
+        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: true,
+        codec: postCodec
+      }, {
+        name: "length",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "omission",
+        required: false,
+        notNull: true,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions152,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_headline_trimmed_strict"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_query_output_two_rows: {
       executor: executor_mainPgExecutor,
       name: "c_query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
-      from: fromCallback79,
-      parameters: parameters79,
+      from(...args) {
+        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "left_arm_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "post_id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "txt",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions153,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "query_output_two_rows"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
-    c_compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_c_compound_type_set_query),
-    b_compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_b_compound_type_mutation),
-    b_compound_type_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_b_compound_type_query),
-    b_compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_b_compound_type_set_mutation),
-    c_table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_c_table_mutation),
-    c_table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_c_table_query),
-    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_with_suffix),
-    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_mutation_compound_type_array),
-    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_query_compound_type_array),
-    b_compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_b_compound_type_array_mutation),
-    b_compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_b_compound_type_array_query),
-    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, options_post_computed_compound_type_array),
-    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_post_many),
+    c_compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "c_compound_type_set_query",
+      identifier: "main.c.compound_type_set_query()",
+      from(...args) {
+        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "compound_type_set_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_compound_type_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "b_compound_type_mutation",
+      identifier: "main.b.compound_type_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_compound_type_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "b_compound_type_query",
+      identifier: "main.b.compound_type_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_compound_type_set_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "b_compound_type_set_mutation",
+      identifier: "main.b.compound_type_set_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_set_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "c_table_mutation",
+      identifier: "main.c.table_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_table_query: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "c_table_query",
+      identifier: "main.c.table_query(int4)",
+      from(...args) {
+        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_with_suffix: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_with_suffix",
+      identifier: "main.a.post_with_suffix(a.post,text)",
+      from(...args) {
+        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "suffix",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_with_suffix"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function a.post_with_suffix).",
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    mutation_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "mutation_compound_type_array",
+      identifier: "main.a.mutation_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "mutation_compound_type_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    query_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "query_compound_type_array",
+      identifier: "main.a.query_compound_type_array(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "query_compound_type_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_compound_type_array_mutation: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "b_compound_type_array_mutation",
+      identifier: "main.b.compound_type_array_mutation(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_compound_type_array_query: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "b_compound_type_array_query",
+      identifier: "main.b.compound_type_array_query(c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "compound_type_array_query"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_computed_compound_type_array: PgResource.functionResourceOptions(resourceConfig_c_compound_type, {
+      name: "post_computed_compound_type_array",
+      identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
+      from(...args) {
+        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "post",
+        required: true,
+        notNull: false,
+        codec: postCodec
+      }, {
+        name: "object",
+        required: true,
+        notNull: false,
+        codec: cCompoundTypeCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_computed_compound_type_array"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    post_many: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "post_many",
+      identifier: "main.a.post_many(a._post)",
+      from(...args) {
+        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "posts",
+        required: true,
+        notNull: false,
+        codec: postArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "a",
+          name: "post_many"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     c_person_computed_out: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
-      from: fromCallback80,
-      parameters: parameters80,
+      from(...args) {
+        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out"
+        },
+        tags: {
+          notNull: true,
+          sortable: true,
+          filterable: true,
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "o1"
+      },
       description: undefined
     },
     c_person_first_name: {
       executor: executor_mainPgExecutor,
       name: "c_person_first_name",
       identifier: "main.c.person_first_name(c.person)",
-      from: fromCallback81,
-      parameters: parameters81,
+      from(...args) {
+        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_name"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-filter -order"]
+        }
+      },
       description: "The first name of the person."
     },
     c_person_computed_out_out: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
-      from: fromCallback82,
-      parameters: parameters82,
+      from(...args) {
+        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_out_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_person_computed_inout: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
-      from: fromCallback83,
-      parameters: parameters83,
+      from(...args) {
+        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "ino"
+      },
       description: undefined
     },
     c_person_computed_inout_out: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
-      from: fromCallback84,
-      parameters: parameters84,
+      from(...args) {
+        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }, {
+        name: "ino",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_inout_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_person_exists: {
       executor: executor_mainPgExecutor,
       name: "c_person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
-      from: fromCallback85,
-      parameters: parameters85,
+      from(...args) {
+        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }, {
+        name: "email",
+        required: true,
+        notNull: false,
+        codec: bEmailCodec
+      }],
       isUnique: !false,
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_exists"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.person_exists).",
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_person_computed_first_arg_inout_out: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
-      from: fromCallback86,
-      parameters: parameters86,
+      from(...args) {
+        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions162,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout_out"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_complex: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback87,
-      parameters: parameters87,
+      from(...args) {
+        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_func_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "c_func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback88,
-      parameters: parameters88,
+      from(...args) {
+        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_complex: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback89,
-      parameters: parameters89,
+      from(...args) {
+        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions165,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_mutation_out_complex_setof: {
       executor: executor_mainPgExecutor,
       name: "c_mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback90,
-      parameters: parameters90,
+      from(...args) {
+        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !true,
       codec: registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions166,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_complex_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     c_person_computed_complex: {
       executor: executor_mainPgExecutor,
       name: "c_person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
-      from: fromCallback91,
-      parameters: parameters91,
+      from(...args) {
+        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: true,
+        notNull: false,
+        codec: TYPES.text
+      }],
       isUnique: !false,
       codec: registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions167,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_complex"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
-    c_person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_c_person_first_post),
+    c_person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
+      name: "c_person_first_post",
+      identifier: "main.c.person_first_post(c.person)",
+      from(...args) {
+        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_first_post"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: "The first post by the person."
+    }),
     c_person: registryConfig_pgResources_c_person_c_person,
-    c_badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_badly_behaved_function),
-    c_func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_func_out_table),
-    c_func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_func_out_table_setof),
-    c_mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_mutation_out_table),
-    c_mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_mutation_out_table_setof),
-    c_table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_table_set_mutation),
-    c_table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_table_set_query),
-    c_table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_table_set_query_plpgsql),
-    c_person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_person_computed_first_arg_inout),
-    c_person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, options_c_person_friends),
+    c_badly_behaved_function: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_badly_behaved_function",
+      identifier: "main.c.badly_behaved_function()",
+      from(...args) {
+        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "badly_behaved_function"
+        },
+        tags: {
+          deprecated: "This is deprecated (comment on function c.badly_behaved_function).",
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_func_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_func_out_table",
+      identifier: "main.c.func_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_func_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_func_out_table_setof",
+      identifier: "main.c.func_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "func_out_table_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_mutation_out_table: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_mutation_out_table",
+      identifier: "main.c.mutation_out_table(c.person)",
+      from(...args) {
+        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_mutation_out_table_setof: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_mutation_out_table_setof",
+      identifier: "main.c.mutation_out_table_setof(c.person)",
+      from(...args) {
+        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "mutation_out_table_setof"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_table_set_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_table_set_mutation",
+      identifier: "main.c.table_set_mutation()",
+      from(...args) {
+        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_table_set_query: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_table_set_query",
+      identifier: "main.c.table_set_query()",
+      from(...args) {
+        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query"
+        },
+        tags: {
+          sortable: true,
+          filterable: true,
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_table_set_query_plpgsql: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_table_set_query_plpgsql",
+      identifier: "main.c.table_set_query_plpgsql()",
+      from(...args) {
+        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_plpgsql"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_person_computed_first_arg_inout: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_person_computed_first_arg_inout",
+      identifier: "main.c.person_computed_first_arg_inout(c.person)",
+      from(...args) {
+        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_computed_first_arg_inout"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        },
+        singleOutputParameterName: "person"
+      },
+      description: undefined
+    }),
+    c_person_friends: PgResource.functionResourceOptions(registryConfig_pgResources_c_person_c_person, {
+      name: "c_person_friends",
+      identifier: "main.c.person_friends(c.person)",
+      from(...args) {
+        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "person",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_friends"
+        },
+        tags: {
+          sortable: true,
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     b_types: registryConfig_pgResources_b_types_b_types,
-    b_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function_connection),
-    b_type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function_connection_mutation),
-    b_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function),
-    b_type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function_mutation),
-    c_person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_c_person_type_function_connection),
-    c_person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_c_person_type_function),
-    b_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function_list),
-    b_type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_b_type_function_list_mutation),
-    c_person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, options_c_person_type_function_list)
+    b_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function_connection",
+      identifier: "main.b.type_function_connection()",
+      from(...args) {
+        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_type_function_connection_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function_connection_mutation",
+      identifier: "main.b.type_function_connection_mutation()",
+      from(...args) {
+        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_connection_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function",
+      identifier: "main.b.type_function(int4)",
+      from(...args) {
+        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_type_function_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function_mutation",
+      identifier: "main.b.type_function_mutation(int4)",
+      from(...args) {
+        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_person_type_function_connection: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "c_person_type_function_connection",
+      identifier: "main.c.person_type_function_connection(c.person)",
+      from(...args) {
+        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_connection"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_person_type_function: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "c_person_type_function",
+      identifier: "main.c.person_type_function(c.person,int4)",
+      from(...args) {
+        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }, {
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function_list",
+      identifier: "main.b.type_function_list()",
+      from(...args) {
+        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    b_type_function_list_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "b_type_function_list_mutation",
+      identifier: "main.b.type_function_list_mutation()",
+      from(...args) {
+        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "b",
+          name: "type_function_list_mutation"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    c_person_type_function_list: PgResource.functionResourceOptions(registryConfig_pgResources_b_types_b_types, {
+      name: "c_person_type_function_list",
+      identifier: "main.c.person_type_function_list(c.person)",
+      from(...args) {
+        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: false,
+        codec: cPersonCodec
+      }],
+      returnsArray: true,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_type_function_list"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    })
   }),
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
@@ -9035,25 +8504,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs3(args);
   return resource_c_func_out_setofPgResource.execute(selectArgs);
 };
-function Query_cFuncOutSetofPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_cFuncOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple4 = [];
 const makeArgs4 = (args, path = []) => {
   const selectArgs = [];
@@ -9196,21 +8646,6 @@ const getSelectPlanFromParentAndArgs2 = ($root, args, _info) => {
   const selectArgs = makeArgs6(args);
   return resource_query_interval_setPgResource.execute(selectArgs);
 };
-function Query_queryIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_queryIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_queryIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_queryIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_queryIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple7 = [];
 const makeArgs7 = (args, path = []) => {
   const selectArgs = [];
@@ -9261,21 +8696,6 @@ const getSelectPlanFromParentAndArgs3 = ($root, args, _info) => {
   const selectArgs = makeArgs7(args);
   return resource_static_big_integerPgResource.execute(selectArgs);
 };
-function Query_staticBigInteger_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_staticBigInteger_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_staticBigInteger_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_staticBigInteger_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_staticBigInteger_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple8 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -9384,21 +8804,6 @@ const getSelectPlanFromParentAndArgs4 = ($root, args, _info) => {
   const selectArgs = makeArgs9(args);
   return resource_c_func_returns_table_one_colPgResource.execute(selectArgs);
 };
-function Query_cFuncReturnsTableOneCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncReturnsTableOneCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncReturnsTableOneCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncReturnsTableOneCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncReturnsTableOneCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple10 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -9889,21 +9294,6 @@ const getSelectPlanFromParentAndArgs5 = ($root, args, _info) => {
   const selectArgs = makeArgs18(args);
   return resource_c_func_out_out_setofPgResource.execute(selectArgs);
 };
-function Query_cFuncOutOutSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncOutOutSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncOutOutSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncOutOutSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncOutOutSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple19 = [];
 const makeArgs19 = (args, path = []) => {
   const selectArgs = [];
@@ -10000,21 +9390,6 @@ const getSelectPlanFromParentAndArgs6 = ($root, args, _info) => {
   const selectArgs = makeArgs20(args);
   return resource_c_search_test_summariesPgResource.execute(selectArgs);
 };
-function Query_cSearchTestSummaries_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cSearchTestSummaries_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cSearchTestSummaries_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cSearchTestSummaries_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cSearchTestSummaries_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple21 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -10437,21 +9812,6 @@ const getSelectPlanFromParentAndArgs7 = ($root, args, _info) => {
   const selectArgs = makeArgs27(args);
   return resource_c_func_returns_table_multi_colPgResource.execute(selectArgs);
 };
-function Query_cFuncReturnsTableMultiCol_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncReturnsTableMultiCol_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncReturnsTableMultiCol_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncReturnsTableMultiCol_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncReturnsTableMultiCol_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple28 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -10520,21 +9880,6 @@ const getSelectPlanFromParentAndArgs8 = ($root, args, _info) => {
   const selectArgs = makeArgs28(args);
   return resource_c_int_set_queryPgResource.execute(selectArgs);
 };
-function Query_cIntSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cIntSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cIntSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cIntSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cIntSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple29 = [];
 const makeArgs29 = (args, path = []) => {
   const selectArgs = [];
@@ -10973,21 +10318,6 @@ const getSelectPlanFromParentAndArgs9 = ($root, args, _info) => {
   const selectArgs = makeArgs36(args);
   return resource_c_compound_type_set_queryPgResource.execute(selectArgs);
 };
-function Query_cCompoundTypeSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cCompoundTypeSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cCompoundTypeSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cCompoundTypeSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cCompoundTypeSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple37 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -11316,21 +10646,6 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   const selectArgs = makeArgs42(args);
   return resource_c_func_out_complex_setofPgResource.execute(selectArgs);
 };
-function Query_cFuncOutComplexSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncOutComplexSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncOutComplexSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncOutComplexSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncOutComplexSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple43 = [];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
@@ -11381,21 +10696,6 @@ const getSelectPlanFromParentAndArgs11 = ($root, args, _info) => {
   const selectArgs = makeArgs43(args);
   return resource_c_badly_behaved_functionPgResource.execute(selectArgs);
 };
-function Query_cBadlyBehavedFunction_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cBadlyBehavedFunction_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cBadlyBehavedFunction_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cBadlyBehavedFunction_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cBadlyBehavedFunction_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -11492,21 +10792,6 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   const selectArgs = makeArgs45(args);
   return resource_c_func_out_table_setofPgResource.execute(selectArgs);
 };
-function Query_cFuncOutTableSetof_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cFuncOutTableSetof_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cFuncOutTableSetof_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cFuncOutTableSetof_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cFuncOutTableSetof_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
   const selectArgs = [];
@@ -11557,21 +10842,6 @@ const getSelectPlanFromParentAndArgs13 = ($root, args, _info) => {
   const selectArgs = makeArgs46(args);
   return resource_c_table_set_queryPgResource.execute(selectArgs);
 };
-function Query_cTableSetQuery_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cTableSetQuery_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cTableSetQuery_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cTableSetQuery_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cTableSetQuery_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple47 = [];
 const makeArgs47 = (args, path = []) => {
   const selectArgs = [];
@@ -11622,21 +10892,6 @@ const getSelectPlanFromParentAndArgs14 = ($root, args, _info) => {
   const selectArgs = makeArgs47(args);
   return resource_c_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
-function Query_cTableSetQueryPlpgsql_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_cTableSetQueryPlpgsql_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_cTableSetQueryPlpgsql_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_cTableSetQueryPlpgsql_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_cTableSetQueryPlpgsql_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple48 = [];
 const makeArgs48 = (args, path = []) => {
   const selectArgs = [];
@@ -11687,21 +10942,6 @@ const getSelectPlanFromParentAndArgs15 = ($root, args, _info) => {
   const selectArgs = makeArgs48(args);
   return resource_b_type_function_connectionPgResource.execute(selectArgs);
 };
-function Query_bTypeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_bTypeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_bTypeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_bTypeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_bTypeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple49 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -11801,21 +11041,6 @@ const makeArgs50 = (args, path = []) => {
 };
 const resource_b_type_function_listPgResource = registry.pgResources["b_type_function_list"];
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
-function Query_allNonUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNonUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNonUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNonUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNonUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -11834,385 +11059,10 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
-function Query_allInputs_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allInputs_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allInputs_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allInputs_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allInputs_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPatches_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPatches_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPatches_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPatches_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPatches_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReserveds_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReserveds_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReserveds_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReserveds_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReserveds_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedPatchRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedPatchRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedPatchRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedPatchRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedPatchRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allReservedInputRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allReservedInputRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allReservedInputRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allReservedInputRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allReservedInputRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allDefaultValues_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allDefaultValues_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allDefaultValues_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allDefaultValues_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allDefaultValues_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
-function Query_allForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allNoPrimaryKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allNoPrimaryKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allNoPrimaryKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allNoPrimaryKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allNoPrimaryKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_testviewPgResource = registry.pgResources["testview"];
-function Query_allTestviews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allTestviews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allTestviews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allTestviews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allTestviews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allUniqueForeignKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allUniqueForeignKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allUniqueForeignKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allUniqueForeignKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allUniqueForeignKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCMyTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCMyTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCMyTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCMyTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCMyTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCPersonSecrets_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCPersonSecrets_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCPersonSecrets_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCPersonSecrets_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCPersonSecrets_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allViewTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allViewTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allViewTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allViewTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allViewTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_b_updatable_viewPgResource = registry.pgResources["b_updatable_view"];
-function Query_allBUpdatableViews_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBUpdatableViews_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBUpdatableViews_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBUpdatableViews_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBUpdatableViews_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCCompoundKeys_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCCompoundKeys_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCCompoundKeys_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCCompoundKeys_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCCompoundKeys_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable1S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable1S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable1S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable1S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable1S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSimilarTable2S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSimilarTable2S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSimilarTable2S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSimilarTable2S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSimilarTable2S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCNullTestRecords_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCNullTestRecords_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCNullTestRecords_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCNullTestRecords_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCNullTestRecords_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_c_edge_casePgResource = registry.pgResources["c_edge_case"];
-function Query_allCEdgeCases_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCEdgeCases_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCEdgeCases_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCEdgeCases_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCEdgeCases_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCLeftArms_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCLeftArms_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCLeftArms_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCLeftArms_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCLeftArms_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCIssue756S_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCIssue756S_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCIssue756S_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCIssue756S_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCIssue756S_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allCPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allCPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allCPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allCPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allCPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allBTypes_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allBTypes_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allBTypes_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allBTypes_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allBTypes_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -12786,21 +11636,6 @@ const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_c_person_friendsPgResource.execute(selectArgs);
 };
-function CPerson_friends_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_friends_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_friends_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_friends_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_friends_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple62 = [];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
@@ -12881,21 +11716,6 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_c_person_type_function_connectionPgResource.execute(selectArgs);
 };
-function CPerson_typeFunctionConnection_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_typeFunctionConnection_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_typeFunctionConnection_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_typeFunctionConnection_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_typeFunctionConnection_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple63 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -12995,66 +11815,6 @@ const makeArgs64 = (args, path = []) => {
 };
 const resource_c_person_type_function_listPgResource = registry.pgResources["c_person_type_function_list"];
 const resource_frmcdc_bWrappedUrlPgResource = registry.pgResources["frmcdc_bWrappedUrl"];
-function CPerson_postsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_postsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_postsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_postsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_postsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CPerson_foreignKeysByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_foreignKeysByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_foreignKeysByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_foreignKeysByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_foreignKeysByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId1_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId1_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId1_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId1_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId1_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId2_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId2_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId2_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId2_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function CPerson_cCompoundKeysByPersonId2_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const resource_frmcdc_cCompoundTypePgResource = registry.pgResources["frmcdc_cCompoundType"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
@@ -13236,24 +11996,6 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-function Interval_secondsPlan($r) {
-  return access($r, ["seconds"]);
-}
-function Interval_minutesPlan($r) {
-  return access($r, ["minutes"]);
-}
-function Interval_hoursPlan($r) {
-  return access($r, ["hours"]);
-}
-function Interval_daysPlan($r) {
-  return access($r, ["days"]);
-}
-function Interval_monthsPlan($r) {
-  return access($r, ["months"]);
-}
-function Interval_yearsPlan($r) {
-  return access($r, ["years"]);
-}
 const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
@@ -13334,21 +12076,6 @@ const getSelectPlanFromParentAndArgs18 = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_post_computed_interval_setPgResource.execute(selectArgs);
 };
-function Post_computedIntervalSet_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_computedIntervalSet_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_computedIntervalSet_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_computedIntervalSet_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_computedIntervalSet_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
@@ -13772,368 +12499,7 @@ const makeArgs77 = (args, path = []) => {
 };
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
-function Post_bTypesBySmallint_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Post_bTypesBySmallint_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Post_bTypesBySmallint_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Post_bTypesBySmallint_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Post_bTypesBySmallint_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function PostComputedIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostComputedIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostComputedIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function BTypeConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BTypeConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BTypeConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const resource_frmcdc_bNestedCompoundTypePgResource = registry.pgResources["frmcdc_bNestedCompoundType"];
-function CPersonConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CPersonConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CPersonConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PostConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PostConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PostConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ForeignKeyConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ForeignKeyConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ForeignKeyConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CCompoundKeyConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CCompoundKeyConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CCompoundKeyConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CFuncOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CFuncOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CFuncOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function QueryIntervalSetConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function QueryIntervalSetConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function QueryIntervalSetConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function StaticBigIntegerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function StaticBigIntegerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function StaticBigIntegerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CFuncReturnsTableOneColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CFuncReturnsTableOneColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CFuncReturnsTableOneColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CFuncOutOutSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CFuncOutOutSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CFuncOutOutSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CSearchTestSummariesConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CSearchTestSummariesConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CSearchTestSummariesConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CFuncReturnsTableMultiColConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CFuncReturnsTableMultiColConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CFuncReturnsTableMultiColConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CIntSetQueryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CIntSetQueryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CIntSetQueryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CCompoundTypeConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CCompoundTypeConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CCompoundTypeConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CFuncOutComplexSetofConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CFuncOutComplexSetofConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CFuncOutComplexSetofConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NonUpdatableViewConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NonUpdatableViewConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NonUpdatableViewConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function InputConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function InputConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function InputConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PatchConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PatchConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PatchConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedPatchRecordConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedPatchRecordConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedPatchRecordConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ReservedInputRecordConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ReservedInputRecordConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ReservedInputRecordConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function DefaultValueConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function DefaultValueConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function DefaultValueConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function NoPrimaryKeyConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function NoPrimaryKeyConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function NoPrimaryKeyConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function TestviewConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function TestviewConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function TestviewConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function UniqueForeignKeyConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function UniqueForeignKeyConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function UniqueForeignKeyConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CMyTableConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CMyTableConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CMyTableConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CPersonSecretConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CPersonSecretConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CPersonSecretConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ViewTableConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ViewTableConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ViewTableConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function BUpdatableViewConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function BUpdatableViewConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function BUpdatableViewConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable1Connection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable1Connection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable1Connection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SimilarTable2Connection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SimilarTable2Connection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SimilarTable2Connection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CNullTestRecordConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CNullTestRecordConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CNullTestRecordConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CEdgeCaseConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CEdgeCaseConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CEdgeCaseConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -14180,26 +12546,6 @@ const makeArgs78 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_edge_case_computedPgResource = registry.pgResources["c_edge_case_computed"];
-function CLeftArmConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CLeftArmConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CLeftArmConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function CIssue756Connection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function CIssue756Connection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function CIssue756Connection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -14246,9 +12592,6 @@ const makeArgs79 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_outPgResource = registry.pgResources["c_mutation_out"];
-function Mutation_cMutationOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -14295,9 +12638,6 @@ const makeArgs80 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_setofPgResource = registry.pgResources["c_mutation_out_setof"];
-function Mutation_cMutationOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
@@ -14344,9 +12684,6 @@ const makeArgs81 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed"];
-function Mutation_cMutationOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
@@ -14393,9 +12730,6 @@ const makeArgs82 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_no_args_mutationPgResource = registry.pgResources["c_no_args_mutation"];
-function Mutation_cNoArgsMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
@@ -14442,9 +12776,6 @@ const makeArgs83 = (args, path = []) => {
   return selectArgs;
 };
 const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
-function Mutation_returnVoidMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
@@ -14491,9 +12822,6 @@ const makeArgs84 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-function Mutation_mutationIntervalSet_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple85 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14546,9 +12874,6 @@ const makeArgs85 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_in_outPgResource = registry.pgResources["c_mutation_in_out"];
-function Mutation_cMutationInOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple86 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -14601,9 +12926,6 @@ const makeArgs86 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_returns_table_one_colPgResource = registry.pgResources["c_mutation_returns_table_one_col"];
-function Mutation_cMutationReturnsTableOneCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple87 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14656,9 +12978,6 @@ const makeArgs87 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_json_identity_mutationPgResource = registry.pgResources["c_json_identity_mutation"];
-function Mutation_cJsonIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple88 = [{
   graphqlArgName: "json",
   postgresArgName: "json",
@@ -14711,9 +13030,6 @@ const makeArgs88 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_jsonb_identity_mutationPgResource = registry.pgResources["c_jsonb_identity_mutation"];
-function Mutation_cJsonbIdentityMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple89 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -14766,9 +13082,6 @@ const makeArgs89 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql"];
-function Mutation_cJsonbIdentityMutationPlpgsql_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple90 = [{
   graphqlArgName: "_theJson",
   postgresArgName: "_the_json",
@@ -14821,9 +13134,6 @@ const makeArgs90 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql_with_default"];
-function Mutation_cJsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple91 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -14882,9 +13192,6 @@ const makeArgs91 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
-function Mutation_add1Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple92 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14943,9 +13250,6 @@ const makeArgs92 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
-function Mutation_add2Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple93 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15004,9 +13308,6 @@ const makeArgs93 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
-function Mutation_add3Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple94 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15065,9 +13366,6 @@ const makeArgs94 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
-function Mutation_add4Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
   postgresArgName: "",
@@ -15126,9 +13424,6 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
-function Mutation_add4MutationError_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple96 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15187,9 +13482,6 @@ const makeArgs96 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_mult_1PgResource = registry.pgResources["b_mult_1"];
-function Mutation_bMult1_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple97 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15248,9 +13540,6 @@ const makeArgs97 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_mult_2PgResource = registry.pgResources["b_mult_2"];
-function Mutation_bMult2_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple98 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15309,9 +13598,6 @@ const makeArgs98 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_mult_3PgResource = registry.pgResources["b_mult_3"];
-function Mutation_bMult3_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple99 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -15370,9 +13656,6 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_mult_4PgResource = registry.pgResources["b_mult_4"];
-function Mutation_bMult4_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple100 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15431,9 +13714,6 @@ const makeArgs100 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_in_inoutPgResource = registry.pgResources["c_mutation_in_inout"];
-function Mutation_cMutationInInout_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
@@ -15480,9 +13760,6 @@ const makeArgs101 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_outPgResource = registry.pgResources["c_mutation_out_out"];
-function Mutation_cMutationOutOut_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
@@ -15529,9 +13806,6 @@ const makeArgs102 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_out_setofPgResource = registry.pgResources["c_mutation_out_out_setof"];
-function Mutation_cMutationOutOutSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
@@ -15578,9 +13852,6 @@ const makeArgs103 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_out_unnamed"];
-function Mutation_cMutationOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple104 = [{
   graphqlArgName: "x",
   postgresArgName: "x",
@@ -15645,9 +13916,6 @@ const makeArgs104 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_int_set_mutationPgResource = registry.pgResources["c_int_set_mutation"];
-function Mutation_cIntSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
@@ -15694,9 +13962,6 @@ const makeArgs105 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed_out_out_unnamed"];
-function Mutation_cMutationOutUnnamedOutOutUnnamed_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple106 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
@@ -15749,9 +14014,6 @@ const makeArgs106 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_returns_table_multi_colPgResource = registry.pgResources["c_mutation_returns_table_multi_col"];
-function Mutation_cMutationReturnsTableMultiCol_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple107 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
@@ -15804,9 +14066,6 @@ const makeArgs107 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_guid_fnPgResource = registry.pgResources["b_guid_fn"];
-function Mutation_bGuidFn_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple108 = [];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
@@ -15853,9 +14112,6 @@ const makeArgs108 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-function Mutation_mutationIntervalArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
@@ -15902,9 +14158,6 @@ const makeArgs109 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-function Mutation_mutationTextArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple110 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
@@ -15969,9 +14222,6 @@ const makeArgs110 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_list_bde_mutationPgResource = registry.pgResources["b_list_bde_mutation"];
-function Mutation_bListBdeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple111 = [];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
@@ -16018,9 +14268,6 @@ const makeArgs111 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_authenticate_failPgResource = registry.pgResources["b_authenticate_fail"];
-function Mutation_bAuthenticateFail_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple112 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16085,9 +14332,6 @@ const makeArgs112 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_authenticatePgResource = registry.pgResources["b_authenticate"];
-function Mutation_bAuthenticate_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple113 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
@@ -16140,9 +14384,6 @@ const makeArgs113 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_left_arm_identityPgResource = registry.pgResources["c_left_arm_identity"];
-function Mutation_cLeftArmIdentity_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple114 = [];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
@@ -16189,9 +14430,6 @@ const makeArgs114 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_issue756_mutationPgResource = registry.pgResources["c_issue756_mutation"];
-function Mutation_cIssue756Mutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
@@ -16238,9 +14476,6 @@ const makeArgs115 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_issue756_set_mutationPgResource = registry.pgResources["c_issue756_set_mutation"];
-function Mutation_cIssue756SetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple116 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16305,9 +14540,6 @@ const makeArgs116 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_authenticate_manyPgResource = registry.pgResources["b_authenticate_many"];
-function Mutation_bAuthenticateMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple117 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16372,9 +14604,6 @@ const makeArgs117 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_authenticate_payloadPgResource = registry.pgResources["b_authenticate_payload"];
-function Mutation_bAuthenticatePayload_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple118 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16457,9 +14686,6 @@ const makeArgs118 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_types_mutationPgResource = registry.pgResources["c_types_mutation"];
-function Mutation_cTypesMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple119 = [{
   graphqlArgName: "i1",
   postgresArgName: "i1",
@@ -16512,9 +14738,6 @@ const makeArgs119 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_out_compound_typePgResource = registry.pgResources["c_mutation_out_out_compound_type"];
-function Mutation_cMutationOutOutCompoundType_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16567,9 +14790,6 @@ const makeArgs120 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_compound_type_mutationPgResource = registry.pgResources["b_compound_type_mutation"];
-function Mutation_bCompoundTypeMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16622,9 +14842,6 @@ const makeArgs121 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_compound_type_set_mutationPgResource = registry.pgResources["b_compound_type_set_mutation"];
-function Mutation_bCompoundTypeSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple122 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -16677,9 +14894,6 @@ const makeArgs122 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_table_mutationPgResource = registry.pgResources["c_table_mutation"];
-function Mutation_cTableMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple123 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
@@ -16738,9 +14952,6 @@ const makeArgs123 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
-function Mutation_postWithSuffix_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple124 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16793,9 +15004,6 @@ const makeArgs124 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
-function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple125 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -16848,9 +15056,6 @@ const makeArgs125 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_compound_type_array_mutationPgResource = registry.pgResources["b_compound_type_array_mutation"];
-function Mutation_bCompoundTypeArrayMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple126 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
@@ -16903,9 +15108,6 @@ const makeArgs126 = (args, path = []) => {
   return selectArgs;
 };
 const resource_post_manyPgResource = registry.pgResources["post_many"];
-function Mutation_postMany_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple127 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -16964,9 +15166,6 @@ const makeArgs127 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_complexPgResource = registry.pgResources["c_mutation_out_complex"];
-function Mutation_cMutationOutComplex_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple128 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -17025,9 +15224,6 @@ const makeArgs128 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_complex_setofPgResource = registry.pgResources["c_mutation_out_complex_setof"];
-function Mutation_cMutationOutComplexSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple129 = [];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
@@ -17074,9 +15270,6 @@ const makeArgs129 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_tablePgResource = registry.pgResources["c_mutation_out_table"];
-function Mutation_cMutationOutTable_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -17123,9 +15316,6 @@ const makeArgs130 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_mutation_out_table_setofPgResource = registry.pgResources["c_mutation_out_table_setof"];
-function Mutation_cMutationOutTableSetof_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple131 = [];
 const makeArgs131 = (args, path = []) => {
   const selectArgs = [];
@@ -17172,9 +15362,6 @@ const makeArgs131 = (args, path = []) => {
   return selectArgs;
 };
 const resource_c_table_set_mutationPgResource = registry.pgResources["c_table_set_mutation"];
-function Mutation_cTableSetMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple132 = [];
 const makeArgs132 = (args, path = []) => {
   const selectArgs = [];
@@ -17221,9 +15408,6 @@ const makeArgs132 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_type_function_connection_mutationPgResource = registry.pgResources["b_type_function_connection_mutation"];
-function Mutation_bTypeFunctionConnectionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple133 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -17276,9 +15460,6 @@ const makeArgs133 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_type_function_mutationPgResource = registry.pgResources["b_type_function_mutation"];
-function Mutation_bTypeFunctionMutation_input_applyPlan(_, $object) {
-  return $object;
-}
 const argDetailsSimple134 = [];
 const makeArgs134 = (args, path = []) => {
   const selectArgs = [];
@@ -17325,1682 +15506,7 @@ const makeArgs134 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_type_function_list_mutationPgResource = registry.pgResources["b_type_function_list_mutation"];
-function Mutation_bTypeFunctionListMutation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createInput_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPatch_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReserved_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedPatchRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createReservedInputRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createDefaultValue_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createNoPrimaryKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createTestview_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createUniqueForeignKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCMyTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCPersonSecret_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createViewTable_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBUpdatableView_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCCompoundKey_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable1_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSimilarTable2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCNullTestRecord_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCEdgeCase_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCLeftArm_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCIssue756_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPost_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createCPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createBType_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateInputByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePatchByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedPatchRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateReservedInputRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateDefaultValueByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateNoPrimaryKeyByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateUniqueForeignKeyByCompoundKey1AndCompoundKey2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCMyTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCPersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateViewTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable1ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSimilarTable2ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCNullTestRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCLeftArmByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCIssue756ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePostByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCPersonByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateCPersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateBTypeByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteInputByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePatchByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedPatchRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteReservedInputRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteDefaultValueByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteNoPrimaryKeyByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteUniqueForeignKeyByCompoundKey1AndCompoundKey2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCMyTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCPersonSecretByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteViewTableByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCCompoundKeyByPersonId1AndPersonId2_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable1ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSimilarTable2ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCNullTestRecordByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCLeftArmByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCLeftArmByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCIssue756ByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePostByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCPersonByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteCPersonByEmail_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteBTypeByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function CMutationOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CNoArgsMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CNoArgsMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CNoArgsMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function ReturnVoidMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function ReturnVoidMutationPayload_queryPlan() {
-  return rootValue();
-}
-function ReturnVoidMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalSetPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalSetPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalSetInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationInOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationInOutPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationInOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationReturnsTableOneColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationReturnsTableOneColPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationReturnsTableOneColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CJsonIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CJsonIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CJsonIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CJsonbIdentityMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CJsonbIdentityMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CJsonbIdentityMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CJsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CJsonbIdentityMutationPlpgsqlPayload_queryPlan() {
-  return rootValue();
-}
-function CJsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CJsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CJsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan() {
-  return rootValue();
-}
-function CJsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add1MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add1MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add1MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add2MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add2MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add2MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add3MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add3MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add3MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function Add4MutationErrorPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function Add4MutationErrorPayload_queryPlan() {
-  return rootValue();
-}
-function Add4MutationErrorInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BMult1Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BMult1Payload_queryPlan() {
-  return rootValue();
-}
-function BMult1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BMult2Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BMult2Payload_queryPlan() {
-  return rootValue();
-}
-function BMult2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BMult3Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BMult3Payload_queryPlan() {
-  return rootValue();
-}
-function BMult3Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BMult4Payload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BMult4Payload_queryPlan() {
-  return rootValue();
-}
-function BMult4Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationInInoutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationInInoutPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationInInoutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutOutPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutOutPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutOutInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutOutSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutOutSetofPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutOutSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CIntSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CIntSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CIntSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutUnnamedOutOutUnnamedPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationReturnsTableMultiColPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationReturnsTableMultiColPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationReturnsTableMultiColInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BGuidFnPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BGuidFnPayload_queryPlan() {
-  return rootValue();
-}
-function BGuidFnInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationIntervalArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationIntervalArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationIntervalArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationTextArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationTextArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationTextArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BListBdeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BListBdeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BListBdeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BAuthenticateFailPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BAuthenticateFailPayload_queryPlan() {
-  return rootValue();
-}
-function BAuthenticateFailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BAuthenticatePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BAuthenticatePayload_queryPlan() {
-  return rootValue();
-}
-function BAuthenticateInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CLeftArmIdentityPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CLeftArmIdentityPayload_queryPlan() {
-  return rootValue();
-}
-function CLeftArmIdentityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CIssue756MutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CIssue756MutationPayload_queryPlan() {
-  return rootValue();
-}
-function CIssue756MutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CIssue756SetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CIssue756SetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CIssue756SetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BAuthenticateManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BAuthenticateManyPayload_queryPlan() {
-  return rootValue();
-}
-function BAuthenticateManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BAuthenticatePayloadPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BAuthenticatePayloadPayload_queryPlan() {
-  return rootValue();
-}
 const resource_frmcdc_bJwtTokenPgResource = registry.pgResources["frmcdc_bJwtToken"];
-function BAuthenticatePayloadInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CTypesMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CTypesMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CTypesMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutOutCompoundTypePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutOutCompoundTypePayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutOutCompoundTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BCompoundTypeMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BCompoundTypeMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BCompoundTypeMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BCompoundTypeSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BCompoundTypeSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BCompoundTypeSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CTableMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CTableMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CTableMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostWithSuffixPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostWithSuffixPayload_queryPlan() {
-  return rootValue();
-}
-function PostWithSuffixInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function MutationCompoundTypeArrayPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function MutationCompoundTypeArrayPayload_queryPlan() {
-  return rootValue();
-}
-function MutationCompoundTypeArrayInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BCompoundTypeArrayMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BCompoundTypeArrayMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BCompoundTypeArrayMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function PostManyPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function PostManyPayload_queryPlan() {
-  return rootValue();
-}
-function PostManyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutComplexPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutComplexPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutComplexInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutComplexSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutComplexSetofPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutComplexSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutTablePayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutTablePayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CMutationOutTableSetofPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CMutationOutTableSetofPayload_queryPlan() {
-  return rootValue();
-}
-function CMutationOutTableSetofInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CTableSetMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function CTableSetMutationPayload_queryPlan() {
-  return rootValue();
-}
-function CTableSetMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BTypeFunctionConnectionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BTypeFunctionConnectionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BTypeFunctionConnectionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BTypeFunctionMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BTypeFunctionMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BTypeFunctionMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function BTypeFunctionListMutationPayload_clientMutationIdPlan($object) {
-  return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
-}
-function BTypeFunctionListMutationPayload_queryPlan() {
-  return rootValue();
-}
-function BTypeFunctionListMutationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function CreateInputPayload_queryPlan() {
-  return rootValue();
-}
-function CreateInputInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateInputInput_input_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function CreatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePatchInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePatchInput_patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInput_reserved_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedPatchRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateReservedInputRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateReservedInputRecordInput_reservedInputRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function CreateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function CreateDefaultValueInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateDefaultValueInput_defaultValue_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateForeignKeyPayload_foreignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateForeignKeyInput_foreignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateNoPrimaryKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateTestviewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateTestviewPayload_testviewPlan($object) {
-  return $object.get("result");
-}
-function CreateTestviewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateTestviewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateTestviewInput_testview_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateUniqueForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateUniqueForeignKeyPayload_uniqueForeignKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateUniqueForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateUniqueForeignKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateUniqueForeignKeyInput_uniqueForeignKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCMyTablePayload_cMyTablePlan($object) {
-  return $object.get("result");
-}
-function CreateCMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateCMyTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCMyTableInput_cMyTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCPersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCPersonSecretPayload_cPersonSecretPlan($object) {
-  return $object.get("result");
-}
-function CreateCPersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCPersonSecretInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCPersonSecretInput_cPersonSecret_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function CreateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function CreateViewTableInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateViewTableInput_viewTable_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBUpdatableViewPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBUpdatableViewPayload_bUpdatableViewPlan($object) {
-  return $object.get("result");
-}
-function CreateBUpdatableViewPayload_queryPlan() {
-  return rootValue();
-}
-function CreateBUpdatableViewInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBUpdatableViewInput_bUpdatableView_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCCompoundKeyPayload_cCompoundKeyPlan($object) {
-  return $object.get("result");
-}
-function CreateCCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCCompoundKeyInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCCompoundKeyInput_cCompoundKey_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable1Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable1Input_similarTable1_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function CreateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function CreateSimilarTable2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSimilarTable2Input_similarTable2_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCNullTestRecordPayload_cNullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function CreateCNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCNullTestRecordInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCNullTestRecordInput_cNullTestRecord_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCEdgeCasePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCEdgeCasePayload_cEdgeCasePlan($object) {
-  return $object.get("result");
-}
-function CreateCEdgeCasePayload_queryPlan() {
-  return rootValue();
-}
-function CreateCEdgeCaseInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCEdgeCaseInput_cEdgeCase_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCLeftArmPayload_cLeftArmPlan($object) {
-  return $object.get("result");
-}
-function CreateCLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCLeftArmInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCLeftArmInput_cLeftArm_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCIssue756Payload_cIssue756Plan($object) {
-  return $object.get("result");
-}
-function CreateCIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function CreateCIssue756Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCIssue756Input_cIssue756_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function CreatePostPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePostInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePostInput_post_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateCPersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateCPersonPayload_cPersonPlan($object) {
-  return $object.get("result");
-}
-function CreateCPersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreateCPersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateCPersonInput_cPerson_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateBTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateBTypePayload_bTypePlan($object) {
-  return $object.get("result");
-}
-function CreateBTypePayload_queryPlan() {
-  return rootValue();
-}
-function CreateBTypeInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateBTypeInput_bType_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function UpdateInputPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateInputByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateInputByRowIdInput_inputPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function UpdatePatchPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePatchByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePatchByRowIdInput_patchPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedByRowIdInput_reservedPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedPatchRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedPatchRecordByRowIdInput_reservedPatchRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateReservedInputRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateReservedInputRecordByRowIdInput_reservedInputRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function UpdateDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateDefaultValueByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateDefaultValueByRowIdInput_defaultValuePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateNoPrimaryKeyByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateNoPrimaryKeyByRowIdInput_noPrimaryKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateUniqueForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateUniqueForeignKeyPayload_uniqueForeignKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateUniqueForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_uniqueForeignKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCMyTablePayload_cMyTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateCMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCMyTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCMyTableByRowIdInput_cMyTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCPersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCPersonSecretPayload_cPersonSecretPlan($object) {
-  return $object.get("result");
-}
-function UpdateCPersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCPersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCPersonSecretByPersonIdInput_cPersonSecretPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function UpdateViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateViewTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateViewTableByRowIdInput_viewTablePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCCompoundKeyPayload_cCompoundKeyPlan($object) {
-  return $object.get("result");
-}
-function UpdateCCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCCompoundKeyByPersonId1AndPersonId2Input_cCompoundKeyPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable1ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable1ByRowIdInput_similarTable1Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function UpdateSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateSimilarTable2ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSimilarTable2ByRowIdInput_similarTable2Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCNullTestRecordPayload_cNullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function UpdateCNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCNullTestRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCNullTestRecordByRowIdInput_cNullTestRecordPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCLeftArmPayload_cLeftArmPlan($object) {
-  return $object.get("result");
-}
-function UpdateCLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCLeftArmByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCLeftArmByRowIdInput_cLeftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCLeftArmByPersonIdInput_cLeftArmPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCIssue756Payload_cIssue756Plan($object) {
-  return $object.get("result");
-}
-function UpdateCIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function UpdateCIssue756ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCIssue756ByRowIdInput_cIssue756Patch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function UpdatePostPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePostByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePostByRowIdInput_postPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCPersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateCPersonPayload_cPersonPlan($object) {
-  return $object.get("result");
-}
-function UpdateCPersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateCPersonByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCPersonByRowIdInput_cPersonPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateCPersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateCPersonByEmailInput_cPersonPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateBTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateBTypePayload_bTypePlan($object) {
-  return $object.get("result");
-}
-function UpdateBTypePayload_queryPlan() {
-  return rootValue();
-}
-function UpdateBTypeByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateBTypeByRowIdInput_bTypePatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteInputPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteInputPayload_inputPlan($object) {
-  return $object.get("result");
-}
-function DeleteInputPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteInputByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePatchPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePatchPayload_patchPlan($object) {
-  return $object.get("result");
-}
-function DeletePatchPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePatchByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPayload_reservedPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedPatchRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedPatchRecordPayload_reservedPatchRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedPatchRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedPatchRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteReservedInputRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteReservedInputRecordPayload_reservedInputRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteReservedInputRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteReservedInputRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteDefaultValuePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteDefaultValuePayload_defaultValuePlan($object) {
-  return $object.get("result");
-}
-function DeleteDefaultValuePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteDefaultValueByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteNoPrimaryKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteNoPrimaryKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteNoPrimaryKeyByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteUniqueForeignKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteUniqueForeignKeyPayload_uniqueForeignKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteUniqueForeignKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCMyTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCMyTablePayload_cMyTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteCMyTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCMyTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCPersonSecretPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCPersonSecretPayload_cPersonSecretPlan($object) {
-  return $object.get("result");
-}
-function DeleteCPersonSecretPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCPersonSecretByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteViewTablePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteViewTablePayload_viewTablePlan($object) {
-  return $object.get("result");
-}
-function DeleteViewTablePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteViewTableByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCCompoundKeyPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCCompoundKeyPayload_cCompoundKeyPlan($object) {
-  return $object.get("result");
-}
-function DeleteCCompoundKeyPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable1Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable1Payload_similarTable1Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable1Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable1ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSimilarTable2Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSimilarTable2Payload_similarTable2Plan($object) {
-  return $object.get("result");
-}
-function DeleteSimilarTable2Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteSimilarTable2ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCNullTestRecordPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCNullTestRecordPayload_cNullTestRecordPlan($object) {
-  return $object.get("result");
-}
-function DeleteCNullTestRecordPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCNullTestRecordByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCLeftArmPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCLeftArmPayload_cLeftArmPlan($object) {
-  return $object.get("result");
-}
-function DeleteCLeftArmPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCLeftArmByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCLeftArmByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCIssue756Payload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCIssue756Payload_cIssue756Plan($object) {
-  return $object.get("result");
-}
-function DeleteCIssue756Payload_queryPlan() {
-  return rootValue();
-}
-function DeleteCIssue756ByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePostPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePostPayload_postPlan($object) {
-  return $object.get("result");
-}
-function DeletePostPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePostByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCPersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteCPersonPayload_cPersonPlan($object) {
-  return $object.get("result");
-}
-function DeleteCPersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteCPersonByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteCPersonByEmailInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteBTypePayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteBTypePayload_bTypePlan($object) {
-  return $object.get("result");
-}
-function DeleteBTypePayload_queryPlan() {
-  return rootValue();
-}
-function DeleteBTypeByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query {
   """
@@ -28075,7 +24581,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     inputByRowId: {
       plan(_$root, args) {
         return resource_inputsPgResource.get({
@@ -28309,27 +24817,40 @@ export const plans = {
       return resource_c_func_outPgResource.execute(selectArgs);
     },
     cFuncOutSetof: {
-      plan: Query_cFuncOutSetofPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28349,23 +24870,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_queryIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28377,23 +24908,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_staticBigInteger_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28415,23 +24956,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableOneCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableOneCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableOneCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableOneCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableOneCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28515,23 +25066,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutOutSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutOutSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutOutSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutOutSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutOutSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28547,23 +25108,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cSearchTestSummaries_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cSearchTestSummaries_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cSearchTestSummaries_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cSearchTestSummaries_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cSearchTestSummaries_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28635,23 +25206,33 @@ export const plans = {
         i: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableMultiCol_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableMultiCol_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableMultiCol_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableMultiCol_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncReturnsTableMultiCol_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28666,23 +25247,33 @@ export const plans = {
         z: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cIntSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cIntSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cIntSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cIntSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cIntSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28749,23 +25340,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cCompoundTypeSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cCompoundTypeSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cCompoundTypeSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cCompoundTypeSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cCompoundTypeSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28825,23 +25426,33 @@ export const plans = {
         b: undefined,
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutComplexSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutComplexSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutComplexSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutComplexSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutComplexSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28853,23 +25464,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cBadlyBehavedFunction_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cBadlyBehavedFunction_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cBadlyBehavedFunction_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cBadlyBehavedFunction_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cBadlyBehavedFunction_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28885,23 +25506,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutTableSetof_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutTableSetof_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutTableSetof_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutTableSetof_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cFuncOutTableSetof_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28913,23 +25544,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQuery_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQuery_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQuery_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQuery_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQuery_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28941,23 +25582,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQueryPlpgsql_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQueryPlpgsql_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQueryPlpgsql_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQueryPlpgsql_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_cTableSetQueryPlpgsql_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -28969,23 +25620,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_bTypeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_bTypeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_bTypeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_bTypeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_bTypeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -29009,23 +25670,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNonUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29052,23 +25723,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allInputs_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29095,23 +25776,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPatches_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29138,23 +25829,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReserveds_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29181,23 +25882,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedPatchRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29224,23 +25935,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allReservedInputRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29267,23 +25988,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allDefaultValues_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29310,23 +26041,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29353,23 +26094,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allNoPrimaryKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29396,23 +26147,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allTestviews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29439,23 +26200,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUniqueForeignKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUniqueForeignKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUniqueForeignKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUniqueForeignKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allUniqueForeignKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29482,23 +26253,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCMyTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCMyTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCMyTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCMyTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCMyTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29525,23 +26306,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPersonSecrets_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPersonSecrets_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPersonSecrets_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPersonSecrets_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPersonSecrets_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29568,23 +26359,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allViewTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29611,23 +26412,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBUpdatableViews_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBUpdatableViews_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBUpdatableViews_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBUpdatableViews_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBUpdatableViews_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29654,23 +26465,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCCompoundKeys_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCCompoundKeys_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCCompoundKeys_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCCompoundKeys_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCCompoundKeys_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29697,23 +26518,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable1S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29740,23 +26571,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSimilarTable2S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29783,23 +26624,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCNullTestRecords_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCNullTestRecords_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCNullTestRecords_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCNullTestRecords_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCNullTestRecords_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29826,23 +26677,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCEdgeCases_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCEdgeCases_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCEdgeCases_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCEdgeCases_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCEdgeCases_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29869,23 +26730,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCLeftArms_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCLeftArms_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCLeftArms_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCLeftArms_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCLeftArms_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29912,23 +26783,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCIssue756S_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCIssue756S_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCIssue756S_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCIssue756S_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCIssue756S_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29955,23 +26836,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -29998,23 +26889,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allCPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30041,23 +26942,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBTypes_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBTypes_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBTypes_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBTypes_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allBTypes_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30173,23 +27084,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CCompoundKey_foreignKeysByCompoundKey1AndCompoundKey2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30587,23 +27508,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_friends_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_friends_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_friends_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_friends_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_friends_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30615,23 +27546,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_typeFunctionConnection_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_typeFunctionConnection_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_typeFunctionConnection_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_typeFunctionConnection_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_typeFunctionConnection_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -30757,23 +27698,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_postsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_postsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_postsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_postsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_postsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30803,23 +27754,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_foreignKeysByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_foreignKeysByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_foreignKeysByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_foreignKeysByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_foreignKeysByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30859,23 +27820,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId1_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId1_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId1_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId1_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId1_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -30905,23 +27876,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId2_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId2_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId2_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId2_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: CPerson_cCompoundKeysByPersonId2_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31174,12 +28155,24 @@ export const plans = {
   },
   Interval: {
     __assertStep: assertExecutableStep,
-    seconds: Interval_secondsPlan,
-    minutes: Interval_minutesPlan,
-    hours: Interval_hoursPlan,
-    days: Interval_daysPlan,
-    months: Interval_monthsPlan,
-    years: Interval_yearsPlan
+    seconds($r) {
+      return access($r, ["seconds"]);
+    },
+    minutes($r) {
+      return access($r, ["minutes"]);
+    },
+    hours($r) {
+      return access($r, ["hours"]);
+    },
+    days($r) {
+      return access($r, ["days"]);
+    },
+    months($r) {
+      return access($r, ["months"]);
+    },
+    years($r) {
+      return access($r, ["years"]);
+    }
   },
   Post: {
     __assertStep: assertPgClassSingleStep,
@@ -31191,23 +28184,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_computedIntervalSet_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -31552,23 +28555,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_bTypesBySmallint_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_bTypesBySmallint_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_bTypesBySmallint_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_bTypesBySmallint_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Post_bTypesBySmallint_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -31596,9 +28609,16 @@ export const plans = {
   },
   PostComputedIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostComputedIntervalSetConnection_nodesPlan,
-    edges: PostComputedIntervalSetConnection_edgesPlan,
-    pageInfo: PostComputedIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -31614,8 +28634,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -31747,9 +28771,16 @@ export const plans = {
   },
   BTypeConnection: {
     __assertStep: ConnectionStep,
-    nodes: BTypeConnection_nodesPlan,
-    edges: BTypeConnection_edgesPlan,
-    pageInfo: BTypeConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33904,9 +30935,16 @@ export const plans = {
   },
   CPersonConnection: {
     __assertStep: ConnectionStep,
-    nodes: CPersonConnection_nodesPlan,
-    edges: CPersonConnection_edgesPlan,
-    pageInfo: CPersonConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -33928,9 +30966,16 @@ export const plans = {
   },
   PostConnection: {
     __assertStep: ConnectionStep,
-    nodes: PostConnection_nodesPlan,
-    edges: PostConnection_edgesPlan,
-    pageInfo: PostConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34213,9 +31258,16 @@ export const plans = {
   },
   ForeignKeyConnection: {
     __assertStep: ConnectionStep,
-    nodes: ForeignKeyConnection_nodesPlan,
-    edges: ForeignKeyConnection_edgesPlan,
-    pageInfo: ForeignKeyConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34466,9 +31518,16 @@ export const plans = {
   },
   CCompoundKeyConnection: {
     __assertStep: ConnectionStep,
-    nodes: CCompoundKeyConnection_nodesPlan,
-    edges: CCompoundKeyConnection_edgesPlan,
-    pageInfo: CCompoundKeyConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34769,9 +31828,16 @@ export const plans = {
   },
   CFuncOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: CFuncOutSetofConnection_nodesPlan,
-    edges: CFuncOutSetofConnection_edgesPlan,
-    pageInfo: CFuncOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34787,9 +31853,16 @@ export const plans = {
   },
   QueryIntervalSetConnection: {
     __assertStep: ConnectionStep,
-    nodes: QueryIntervalSetConnection_nodesPlan,
-    edges: QueryIntervalSetConnection_edgesPlan,
-    pageInfo: QueryIntervalSetConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34805,9 +31878,16 @@ export const plans = {
   },
   StaticBigIntegerConnection: {
     __assertStep: ConnectionStep,
-    nodes: StaticBigIntegerConnection_nodesPlan,
-    edges: StaticBigIntegerConnection_edgesPlan,
-    pageInfo: StaticBigIntegerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34823,9 +31903,16 @@ export const plans = {
   },
   CFuncReturnsTableOneColConnection: {
     __assertStep: ConnectionStep,
-    nodes: CFuncReturnsTableOneColConnection_nodesPlan,
-    edges: CFuncReturnsTableOneColConnection_edgesPlan,
-    pageInfo: CFuncReturnsTableOneColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34850,9 +31937,16 @@ export const plans = {
   },
   CFuncOutOutSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: CFuncOutOutSetofConnection_nodesPlan,
-    edges: CFuncOutOutSetofConnection_edgesPlan,
-    pageInfo: CFuncOutOutSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34886,9 +31980,16 @@ export const plans = {
   },
   CSearchTestSummariesConnection: {
     __assertStep: ConnectionStep,
-    nodes: CSearchTestSummariesConnection_nodesPlan,
-    edges: CSearchTestSummariesConnection_edgesPlan,
-    pageInfo: CSearchTestSummariesConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34925,9 +32026,16 @@ export const plans = {
   },
   CFuncReturnsTableMultiColConnection: {
     __assertStep: ConnectionStep,
-    nodes: CFuncReturnsTableMultiColConnection_nodesPlan,
-    edges: CFuncReturnsTableMultiColConnection_edgesPlan,
-    pageInfo: CFuncReturnsTableMultiColConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -34952,9 +32060,16 @@ export const plans = {
   },
   CIntSetQueryConnection: {
     __assertStep: ConnectionStep,
-    nodes: CIntSetQueryConnection_nodesPlan,
-    edges: CIntSetQueryConnection_edgesPlan,
-    pageInfo: CIntSetQueryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35017,9 +32132,16 @@ export const plans = {
   },
   CCompoundTypeConnection: {
     __assertStep: ConnectionStep,
-    nodes: CCompoundTypeConnection_nodesPlan,
-    edges: CCompoundTypeConnection_edgesPlan,
-    pageInfo: CCompoundTypeConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35059,9 +32181,16 @@ export const plans = {
   },
   CFuncOutComplexSetofConnection: {
     __assertStep: ConnectionStep,
-    nodes: CFuncOutComplexSetofConnection_nodesPlan,
-    edges: CFuncOutComplexSetofConnection_edgesPlan,
-    pageInfo: CFuncOutComplexSetofConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35101,9 +32230,16 @@ export const plans = {
   },
   NonUpdatableViewConnection: {
     __assertStep: ConnectionStep,
-    nodes: NonUpdatableViewConnection_nodesPlan,
-    edges: NonUpdatableViewConnection_edgesPlan,
-    pageInfo: NonUpdatableViewConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35189,9 +32325,16 @@ export const plans = {
   },
   InputConnection: {
     __assertStep: ConnectionStep,
-    nodes: InputConnection_nodesPlan,
-    edges: InputConnection_edgesPlan,
-    pageInfo: InputConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35303,9 +32446,16 @@ export const plans = {
   },
   PatchConnection: {
     __assertStep: ConnectionStep,
-    nodes: PatchConnection_nodesPlan,
-    edges: PatchConnection_edgesPlan,
-    pageInfo: PatchConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35417,9 +32567,16 @@ export const plans = {
   },
   ReservedConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedConnection_nodesPlan,
-    edges: ReservedConnection_edgesPlan,
-    pageInfo: ReservedConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35531,9 +32688,16 @@ export const plans = {
   },
   ReservedPatchRecordConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedPatchRecordConnection_nodesPlan,
-    edges: ReservedPatchRecordConnection_edgesPlan,
-    pageInfo: ReservedPatchRecordConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35645,9 +32809,16 @@ export const plans = {
   },
   ReservedInputRecordConnection: {
     __assertStep: ConnectionStep,
-    nodes: ReservedInputRecordConnection_nodesPlan,
-    edges: ReservedInputRecordConnection_edgesPlan,
-    pageInfo: ReservedInputRecordConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35759,9 +32930,16 @@ export const plans = {
   },
   DefaultValueConnection: {
     __assertStep: ConnectionStep,
-    nodes: DefaultValueConnection_nodesPlan,
-    edges: DefaultValueConnection_edgesPlan,
-    pageInfo: DefaultValueConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -35930,9 +33108,16 @@ export const plans = {
   },
   NoPrimaryKeyConnection: {
     __assertStep: ConnectionStep,
-    nodes: NoPrimaryKeyConnection_nodesPlan,
-    edges: NoPrimaryKeyConnection_edgesPlan,
-    pageInfo: NoPrimaryKeyConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36069,9 +33254,16 @@ export const plans = {
   },
   TestviewConnection: {
     __assertStep: ConnectionStep,
-    nodes: TestviewConnection_nodesPlan,
-    edges: TestviewConnection_edgesPlan,
-    pageInfo: TestviewConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36277,9 +33469,16 @@ export const plans = {
   },
   UniqueForeignKeyConnection: {
     __assertStep: ConnectionStep,
-    nodes: UniqueForeignKeyConnection_nodesPlan,
-    edges: UniqueForeignKeyConnection_edgesPlan,
-    pageInfo: UniqueForeignKeyConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36416,9 +33615,16 @@ export const plans = {
   },
   CMyTableConnection: {
     __assertStep: ConnectionStep,
-    nodes: CMyTableConnection_nodesPlan,
-    edges: CMyTableConnection_edgesPlan,
-    pageInfo: CMyTableConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36587,9 +33793,16 @@ export const plans = {
   },
   CPersonSecretConnection: {
     __assertStep: ConnectionStep,
-    nodes: CPersonSecretConnection_nodesPlan,
-    edges: CPersonSecretConnection_edgesPlan,
-    pageInfo: CPersonSecretConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36758,9 +33971,16 @@ export const plans = {
   },
   ViewTableConnection: {
     __assertStep: ConnectionStep,
-    nodes: ViewTableConnection_nodesPlan,
-    edges: ViewTableConnection_edgesPlan,
-    pageInfo: ViewTableConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -36986,9 +34206,16 @@ export const plans = {
   },
   BUpdatableViewConnection: {
     __assertStep: ConnectionStep,
-    nodes: BUpdatableViewConnection_nodesPlan,
-    edges: BUpdatableViewConnection_edgesPlan,
-    pageInfo: BUpdatableViewConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37254,9 +34481,16 @@ export const plans = {
   },
   SimilarTable1Connection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable1Connection_nodesPlan,
-    edges: SimilarTable1Connection_edgesPlan,
-    pageInfo: SimilarTable1Connection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37539,9 +34773,16 @@ export const plans = {
   },
   SimilarTable2Connection: {
     __assertStep: ConnectionStep,
-    nodes: SimilarTable2Connection_nodesPlan,
-    edges: SimilarTable2Connection_edgesPlan,
-    pageInfo: SimilarTable2Connection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -37824,9 +35065,16 @@ export const plans = {
   },
   CNullTestRecordConnection: {
     __assertStep: ConnectionStep,
-    nodes: CNullTestRecordConnection_nodesPlan,
-    edges: CNullTestRecordConnection_edgesPlan,
-    pageInfo: CNullTestRecordConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38109,9 +35357,16 @@ export const plans = {
   },
   CEdgeCaseConnection: {
     __assertStep: ConnectionStep,
-    nodes: CEdgeCaseConnection_nodesPlan,
-    edges: CEdgeCaseConnection_edgesPlan,
-    pageInfo: CEdgeCaseConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38351,9 +35606,16 @@ export const plans = {
   },
   CLeftArmConnection: {
     __assertStep: ConnectionStep,
-    nodes: CLeftArmConnection_nodesPlan,
-    edges: CLeftArmConnection_edgesPlan,
-    pageInfo: CLeftArmConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -38636,9 +35898,16 @@ export const plans = {
   },
   CIssue756Connection: {
     __assertStep: ConnectionStep,
-    nodes: CIssue756Connection_nodesPlan,
-    edges: CIssue756Connection_edgesPlan,
-    pageInfo: CIssue756Connection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -39370,7 +36639,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39385,7 +36656,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39400,7 +36673,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39415,7 +36690,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cNoArgsMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39430,7 +36707,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_returnVoidMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39445,7 +36724,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalSet_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39460,7 +36741,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationInOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39475,7 +36758,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationReturnsTableOneCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39490,7 +36775,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cJsonIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39505,7 +36792,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cJsonbIdentityMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39520,7 +36809,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cJsonbIdentityMutationPlpgsql_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39535,7 +36826,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cJsonbIdentityMutationPlpgsqlWithDefault_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39550,7 +36843,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add1Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39565,7 +36860,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add2Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39580,7 +36877,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add3Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39595,7 +36894,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39610,7 +36911,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_add4MutationError_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39625,7 +36928,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bMult1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39640,7 +36945,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bMult2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39655,7 +36962,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bMult3_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39670,7 +36979,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bMult4_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39685,7 +36996,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationInInout_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39700,7 +37013,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutOut_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39715,7 +37030,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutOutSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39730,7 +37047,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39745,7 +37064,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cIntSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39760,7 +37081,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutUnnamedOutOutUnnamed_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39775,7 +37098,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationReturnsTableMultiCol_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39790,7 +37115,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bGuidFn_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39805,7 +37132,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationIntervalArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39820,7 +37149,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationTextArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39835,7 +37166,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bListBdeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39850,7 +37183,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bAuthenticateFail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39865,7 +37200,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bAuthenticate_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39880,7 +37217,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cLeftArmIdentity_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39895,7 +37234,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cIssue756Mutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39910,7 +37251,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cIssue756SetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39925,7 +37268,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bAuthenticateMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39940,7 +37285,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bAuthenticatePayload_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39955,7 +37302,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cTypesMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39970,7 +37319,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutOutCompoundType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -39985,7 +37336,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bCompoundTypeMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40000,7 +37353,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bCompoundTypeSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40015,7 +37370,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cTableMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40030,7 +37387,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postWithSuffix_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40045,7 +37404,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_mutationCompoundTypeArray_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40060,7 +37421,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bCompoundTypeArrayMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40075,7 +37438,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_postMany_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40090,7 +37455,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutComplex_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40105,7 +37472,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutComplexSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40120,7 +37489,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40135,7 +37506,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cMutationOutTableSetof_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40150,7 +37523,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_cTableSetMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40165,7 +37540,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bTypeFunctionConnectionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40180,7 +37557,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bTypeFunctionMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40195,7 +37574,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_bTypeFunctionListMutation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40210,7 +37591,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createInput_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40225,7 +37608,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPatch_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40240,7 +37625,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReserved_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40255,7 +37642,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedPatchRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40270,7 +37659,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createReservedInputRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40285,7 +37676,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createDefaultValue_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40300,7 +37693,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40315,7 +37710,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createNoPrimaryKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40330,7 +37727,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createTestview_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40345,7 +37744,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createUniqueForeignKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40360,7 +37761,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCMyTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40375,7 +37778,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCPersonSecret_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40390,7 +37795,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createViewTable_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40405,7 +37812,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBUpdatableView_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40420,7 +37829,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCCompoundKey_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40435,7 +37846,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable1_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40450,7 +37863,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSimilarTable2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40465,7 +37880,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCNullTestRecord_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40480,7 +37897,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCEdgeCase_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40495,7 +37914,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCLeftArm_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40510,7 +37931,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCIssue756_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40525,7 +37948,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPost_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40540,7 +37965,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createCPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40555,7 +37982,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createBType_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40571,7 +38000,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateInputByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40587,7 +38018,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePatchByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40603,7 +38036,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40619,7 +38054,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedPatchRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40635,7 +38072,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateReservedInputRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40651,7 +38090,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateDefaultValueByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40667,7 +38108,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateNoPrimaryKeyByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40684,7 +38127,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateUniqueForeignKeyByCompoundKey1AndCompoundKey2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40700,7 +38145,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCMyTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40716,7 +38163,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCPersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40732,7 +38181,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateViewTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40749,7 +38200,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40765,7 +38218,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable1ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40781,7 +38236,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSimilarTable2ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40797,7 +38254,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCNullTestRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40813,7 +38272,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCLeftArmByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40829,7 +38290,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40845,7 +38308,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCIssue756ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40861,7 +38326,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePostByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40877,7 +38344,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCPersonByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40893,7 +38362,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateCPersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40909,7 +38380,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateBTypeByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40925,7 +38398,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteInputByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40941,7 +38416,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePatchByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40957,7 +38434,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40973,7 +38452,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedPatchRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -40989,7 +38470,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteReservedInputRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41005,7 +38488,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteDefaultValueByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41021,7 +38506,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteNoPrimaryKeyByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41038,7 +38525,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteUniqueForeignKeyByCompoundKey1AndCompoundKey2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41054,7 +38543,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCMyTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41070,7 +38561,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCPersonSecretByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41086,7 +38579,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteViewTableByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41103,7 +38598,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCCompoundKeyByPersonId1AndPersonId2_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41119,7 +38616,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable1ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41135,7 +38634,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSimilarTable2ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41151,7 +38652,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCNullTestRecordByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41167,7 +38670,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCLeftArmByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41183,7 +38688,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCLeftArmByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41199,7 +38706,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCIssue756ByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41215,7 +38724,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePostByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41231,7 +38742,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCPersonByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41247,7 +38760,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteCPersonByEmail_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -41263,193 +38778,273 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteBTypeByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CMutationOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutInput: {
     clientMutationId: {
-      applyPlan: CMutationOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutSetofInput: {
     clientMutationId: {
-      applyPlan: CMutationOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: CMutationOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CNoArgsMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CNoArgsMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CNoArgsMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CNoArgsMutationInput: {
     clientMutationId: {
-      applyPlan: CNoArgsMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   ReturnVoidMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: ReturnVoidMutationPayload_clientMutationIdPlan,
-    query: ReturnVoidMutationPayload_queryPlan
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
+    query() {
+      return rootValue();
+    }
   },
   ReturnVoidMutationInput: {
     clientMutationId: {
-      applyPlan: ReturnVoidMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationIntervalSetPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalSetPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationIntervalSetPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalSetInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalSetInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationInOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationInOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationInOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationInOutInput: {
     clientMutationId: {
-      applyPlan: CMutationInOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   CMutationReturnsTableOneColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationReturnsTableOneColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationReturnsTableOneColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationReturnsTableOneColInput: {
     clientMutationId: {
-      applyPlan: CMutationReturnsTableOneColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   CJsonIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CJsonIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CJsonIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CJsonIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: CJsonIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   CJsonbIdentityMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CJsonbIdentityMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CJsonbIdentityMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CJsonbIdentityMutationInput: {
     clientMutationId: {
-      applyPlan: CJsonbIdentityMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     json: undefined
   },
   CJsonbIdentityMutationPlpgsqlPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CJsonbIdentityMutationPlpgsqlPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CJsonbIdentityMutationPlpgsqlPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CJsonbIdentityMutationPlpgsqlInput: {
     clientMutationId: {
-      applyPlan: CJsonbIdentityMutationPlpgsqlInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   CJsonbIdentityMutationPlpgsqlWithDefaultPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CJsonbIdentityMutationPlpgsqlWithDefaultPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CJsonbIdentityMutationPlpgsqlWithDefaultPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CJsonbIdentityMutationPlpgsqlWithDefaultInput: {
     clientMutationId: {
-      applyPlan: CJsonbIdentityMutationPlpgsqlWithDefaultInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     _theJson: undefined
   },
   Add1MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add1MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: Add1MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add1MutationInput: {
     clientMutationId: {
-      applyPlan: Add1MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41457,15 +39052,21 @@ export const plans = {
   },
   Add2MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add2MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: Add2MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add2MutationInput: {
     clientMutationId: {
-      applyPlan: Add2MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41473,15 +39074,21 @@ export const plans = {
   },
   Add3MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add3MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: Add3MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add3MutationInput: {
     clientMutationId: {
-      applyPlan: Add3MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41489,15 +39096,21 @@ export const plans = {
   },
   Add4MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: Add4MutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationInput: {
     clientMutationId: {
-      applyPlan: Add4MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41505,15 +39118,21 @@ export const plans = {
   },
   Add4MutationErrorPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: Add4MutationErrorPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: Add4MutationErrorPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   Add4MutationErrorInput: {
     clientMutationId: {
-      applyPlan: Add4MutationErrorInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41521,15 +39140,21 @@ export const plans = {
   },
   BMult1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: BMult1Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BMult1Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BMult1Input: {
     clientMutationId: {
-      applyPlan: BMult1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41537,15 +39162,21 @@ export const plans = {
   },
   BMult2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: BMult2Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BMult2Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BMult2Input: {
     clientMutationId: {
-      applyPlan: BMult2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41553,15 +39184,21 @@ export const plans = {
   },
   BMult3Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: BMult3Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BMult3Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BMult3Input: {
     clientMutationId: {
-      applyPlan: BMult3Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41569,15 +39206,21 @@ export const plans = {
   },
   BMult4Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: BMult4Payload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BMult4Payload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BMult4Input: {
     clientMutationId: {
-      applyPlan: BMult4Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     arg0: undefined,
@@ -41585,15 +39228,21 @@ export const plans = {
   },
   CMutationInInoutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationInInoutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationInInoutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationInInoutInput: {
     clientMutationId: {
-      applyPlan: CMutationInInoutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined,
@@ -41601,11 +39250,15 @@ export const plans = {
   },
   CMutationOutOutPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutOutPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutOutPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutOutRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41618,17 +39271,23 @@ export const plans = {
   },
   CMutationOutOutInput: {
     clientMutationId: {
-      applyPlan: CMutationOutOutInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationOutOutSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutOutSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutOutSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutOutSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41641,17 +39300,23 @@ export const plans = {
   },
   CMutationOutOutSetofInput: {
     clientMutationId: {
-      applyPlan: CMutationOutOutSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41664,21 +39329,29 @@ export const plans = {
   },
   CMutationOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: CMutationOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CIntSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CIntSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CIntSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CIntSetMutationInput: {
     clientMutationId: {
-      applyPlan: CIntSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     x: undefined,
@@ -41687,11 +39360,15 @@ export const plans = {
   },
   CMutationOutUnnamedOutOutUnnamedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutUnnamedOutOutUnnamedPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutUnnamedOutOutUnnamedPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutUnnamedOutOutUnnamedRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41707,17 +39384,23 @@ export const plans = {
   },
   CMutationOutUnnamedOutOutUnnamedInput: {
     clientMutationId: {
-      applyPlan: CMutationOutUnnamedOutOutUnnamedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationReturnsTableMultiColPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationReturnsTableMultiColPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationReturnsTableMultiColPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationReturnsTableMultiColRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -41730,65 +39413,91 @@ export const plans = {
   },
   CMutationReturnsTableMultiColInput: {
     clientMutationId: {
-      applyPlan: CMutationReturnsTableMultiColInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i: undefined
   },
   BGuidFnPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BGuidFnPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BGuidFnPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BGuidFnInput: {
     clientMutationId: {
-      applyPlan: BGuidFnInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     g: undefined
   },
   MutationIntervalArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationIntervalArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationIntervalArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationIntervalArrayInput: {
     clientMutationId: {
-      applyPlan: MutationIntervalArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   MutationTextArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationTextArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationTextArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationTextArrayInput: {
     clientMutationId: {
-      applyPlan: MutationTextArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   BListBdeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BListBdeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BListBdeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BListBdeMutationInput: {
     clientMutationId: {
-      applyPlan: BListBdeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     b: undefined,
@@ -41797,11 +39506,15 @@ export const plans = {
   },
   BAuthenticateFailPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BAuthenticateFailPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BAuthenticateFailPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BJwtToken: {
     __assertStep: assertPgClassSingleStep,
@@ -41823,21 +39536,29 @@ export const plans = {
   },
   BAuthenticateFailInput: {
     clientMutationId: {
-      applyPlan: BAuthenticateFailInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   BAuthenticatePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BAuthenticatePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BAuthenticatePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BAuthenticateInput: {
     clientMutationId: {
-      applyPlan: BAuthenticateInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41846,11 +39567,15 @@ export const plans = {
   },
   CLeftArmIdentityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CLeftArmIdentityPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CLeftArmIdentityPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     cLeftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41885,7 +39610,9 @@ export const plans = {
   },
   CLeftArmIdentityInput: {
     clientMutationId: {
-      applyPlan: CLeftArmIdentityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     leftArm: undefined
@@ -41922,11 +39649,15 @@ export const plans = {
   },
   CIssue756MutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CIssue756MutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CIssue756MutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     cIssue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -41961,35 +39692,49 @@ export const plans = {
   },
   CIssue756MutationInput: {
     clientMutationId: {
-      applyPlan: CIssue756MutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CIssue756SetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CIssue756SetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CIssue756SetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CIssue756SetMutationInput: {
     clientMutationId: {
-      applyPlan: CIssue756SetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   BAuthenticateManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BAuthenticateManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BAuthenticateManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BAuthenticateManyInput: {
     clientMutationId: {
-      applyPlan: BAuthenticateManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -41998,11 +39743,15 @@ export const plans = {
   },
   BAuthenticatePayloadPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BAuthenticatePayloadPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BAuthenticatePayloadPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BAuthPayload: {
     __assertStep: assertPgClassSingleStep,
@@ -42029,7 +39778,9 @@ export const plans = {
   },
   BAuthenticatePayloadInput: {
     clientMutationId: {
-      applyPlan: BAuthenticatePayloadInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42038,15 +39789,21 @@ export const plans = {
   },
   CTypesMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CTypesMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CTypesMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CTypesMutationInput: {
     clientMutationId: {
-      applyPlan: CTypesMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42058,11 +39815,15 @@ export const plans = {
   },
   CMutationOutOutCompoundTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutOutCompoundTypePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutOutCompoundTypePayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutOutCompoundTypeRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42081,48 +39842,66 @@ export const plans = {
   },
   CMutationOutOutCompoundTypeInput: {
     clientMutationId: {
-      applyPlan: CMutationOutOutCompoundTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     i1: undefined
   },
   BCompoundTypeMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BCompoundTypeMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BCompoundTypeMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BCompoundTypeMutationInput: {
     clientMutationId: {
-      applyPlan: BCompoundTypeMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   BCompoundTypeSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BCompoundTypeSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BCompoundTypeSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BCompoundTypeSetMutationInput: {
     clientMutationId: {
-      applyPlan: BCompoundTypeSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   CTableMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CTableMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CTableMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42157,18 +39936,24 @@ export const plans = {
   },
   CTableMutationInput: {
     clientMutationId: {
-      applyPlan: CTableMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   PostWithSuffixPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostWithSuffixPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: PostWithSuffixPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42203,7 +39988,9 @@ export const plans = {
   },
   PostWithSuffixInput: {
     clientMutationId: {
-      applyPlan: PostWithSuffixInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: undefined,
@@ -42271,56 +40058,78 @@ export const plans = {
   },
   MutationCompoundTypeArrayPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: MutationCompoundTypeArrayPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: MutationCompoundTypeArrayPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   MutationCompoundTypeArrayInput: {
     clientMutationId: {
-      applyPlan: MutationCompoundTypeArrayInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   BCompoundTypeArrayMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BCompoundTypeArrayMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BCompoundTypeArrayMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BCompoundTypeArrayMutationInput: {
     clientMutationId: {
-      applyPlan: BCompoundTypeArrayMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     object: undefined
   },
   PostManyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: PostManyPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: PostManyPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   PostManyInput: {
     clientMutationId: {
-      applyPlan: PostManyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     posts: undefined
   },
   CMutationOutComplexPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutComplexPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutComplexPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutComplexRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42348,7 +40157,9 @@ export const plans = {
   },
   CMutationOutComplexInput: {
     clientMutationId: {
-      applyPlan: CMutationOutComplexInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42356,11 +40167,15 @@ export const plans = {
   },
   CMutationOutComplexSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutComplexSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutComplexSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutComplexSetofRecord: {
     __assertStep: assertPgClassSingleStep,
@@ -42388,7 +40203,9 @@ export const plans = {
   },
   CMutationOutComplexSetofInput: {
     clientMutationId: {
-      applyPlan: CMutationOutComplexSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     a: undefined,
@@ -42396,11 +40213,15 @@ export const plans = {
   },
   CMutationOutTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutTablePayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutTablePayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     cPersonEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42435,59 +40256,83 @@ export const plans = {
   },
   CMutationOutTableInput: {
     clientMutationId: {
-      applyPlan: CMutationOutTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CMutationOutTableSetofPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CMutationOutTableSetofPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CMutationOutTableSetofPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CMutationOutTableSetofInput: {
     clientMutationId: {
-      applyPlan: CMutationOutTableSetofInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CTableSetMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: CTableSetMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: CTableSetMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   CTableSetMutationInput: {
     clientMutationId: {
-      applyPlan: CTableSetMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   BTypeFunctionConnectionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BTypeFunctionConnectionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BTypeFunctionConnectionMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BTypeFunctionConnectionMutationInput: {
     clientMutationId: {
-      applyPlan: BTypeFunctionConnectionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   BTypeFunctionMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BTypeFunctionMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BTypeFunctionMutationPayload_queryPlan,
+    query() {
+      return rootValue();
+    },
     bTypeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42522,30 +40367,44 @@ export const plans = {
   },
   BTypeFunctionMutationInput: {
     clientMutationId: {
-      applyPlan: BTypeFunctionMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     id: undefined
   },
   BTypeFunctionListMutationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: BTypeFunctionListMutationPayload_clientMutationIdPlan,
+    clientMutationId($object) {
+      return $object.getStepForKey("clientMutationId", true) ?? constant(undefined);
+    },
     result($object) {
       return $object.get("result");
     },
-    query: BTypeFunctionListMutationPayload_queryPlan
+    query() {
+      return rootValue();
+    }
   },
   BTypeFunctionListMutationInput: {
     clientMutationId: {
-      applyPlan: BTypeFunctionListMutationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateInputPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateInputPayload_clientMutationIdPlan,
-    input: CreateInputPayload_inputPlan,
-    query: CreateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42580,11 +40439,16 @@ export const plans = {
   },
   CreateInputInput: {
     clientMutationId: {
-      applyPlan: CreateInputInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     input: {
-      applyPlan: CreateInputInput_input_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42599,9 +40463,15 @@ export const plans = {
   },
   CreatePatchPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePatchPayload_clientMutationIdPlan,
-    patch: CreatePatchPayload_patchPlan,
-    query: CreatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42636,11 +40506,16 @@ export const plans = {
   },
   CreatePatchInput: {
     clientMutationId: {
-      applyPlan: CreatePatchInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     patch: {
-      applyPlan: CreatePatchInput_patch_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42655,9 +40530,15 @@ export const plans = {
   },
   CreateReservedPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPayload_clientMutationIdPlan,
-    reserved: CreateReservedPayload_reservedPlan,
-    query: CreateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42692,11 +40573,16 @@ export const plans = {
   },
   CreateReservedInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reserved: {
-      applyPlan: CreateReservedInput_reserved_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42711,9 +40597,15 @@ export const plans = {
   },
   CreateReservedPatchRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: CreateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: CreateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42748,11 +40640,16 @@ export const plans = {
   },
   CreateReservedPatchRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedPatchRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedPatchRecord: {
-      applyPlan: CreateReservedPatchRecordInput_reservedPatchRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42767,9 +40664,15 @@ export const plans = {
   },
   CreateReservedInputRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: CreateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: CreateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42804,11 +40707,16 @@ export const plans = {
   },
   CreateReservedInputRecordInput: {
     clientMutationId: {
-      applyPlan: CreateReservedInputRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     reservedInputRecord: {
-      applyPlan: CreateReservedInputRecordInput_reservedInputRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42823,9 +40731,15 @@ export const plans = {
   },
   CreateDefaultValuePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: CreateDefaultValuePayload_defaultValuePlan,
-    query: CreateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -42860,11 +40774,16 @@ export const plans = {
   },
   CreateDefaultValueInput: {
     clientMutationId: {
-      applyPlan: CreateDefaultValueInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     defaultValue: {
-      applyPlan: CreateDefaultValueInput_defaultValue_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42886,17 +40805,28 @@ export const plans = {
   },
   CreateForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateForeignKeyPayload_clientMutationIdPlan,
-    foreignKey: CreateForeignKeyPayload_foreignKeyPlan,
-    query: CreateForeignKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    foreignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     foreignKey: {
-      applyPlan: CreateForeignKeyInput_foreignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42925,17 +40855,28 @@ export const plans = {
   },
   CreateNoPrimaryKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: CreateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: CreateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateNoPrimaryKeyInput: {
     clientMutationId: {
-      applyPlan: CreateNoPrimaryKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     noPrimaryKey: {
-      applyPlan: CreateNoPrimaryKeyInput_noPrimaryKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42957,17 +40898,28 @@ export const plans = {
   },
   CreateTestviewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateTestviewPayload_clientMutationIdPlan,
-    testview: CreateTestviewPayload_testviewPlan,
-    query: CreateTestviewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    testview($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateTestviewInput: {
     clientMutationId: {
-      applyPlan: CreateTestviewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     testview: {
-      applyPlan: CreateTestviewInput_testview_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -42996,17 +40948,28 @@ export const plans = {
   },
   CreateUniqueForeignKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateUniqueForeignKeyPayload_clientMutationIdPlan,
-    uniqueForeignKey: CreateUniqueForeignKeyPayload_uniqueForeignKeyPlan,
-    query: CreateUniqueForeignKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    uniqueForeignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateUniqueForeignKeyInput: {
     clientMutationId: {
-      applyPlan: CreateUniqueForeignKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     uniqueForeignKey: {
-      applyPlan: CreateUniqueForeignKeyInput_uniqueForeignKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43028,9 +40991,15 @@ export const plans = {
   },
   CreateCMyTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCMyTablePayload_clientMutationIdPlan,
-    cMyTable: CreateCMyTablePayload_cMyTablePlan,
-    query: CreateCMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cMyTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cMyTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43065,11 +41034,16 @@ export const plans = {
   },
   CreateCMyTableInput: {
     clientMutationId: {
-      applyPlan: CreateCMyTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cMyTable: {
-      applyPlan: CreateCMyTableInput_cMyTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43091,9 +41065,15 @@ export const plans = {
   },
   CreateCPersonSecretPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCPersonSecretPayload_clientMutationIdPlan,
-    cPersonSecret: CreateCPersonSecretPayload_cPersonSecretPlan,
-    query: CreateCPersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPersonSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43128,11 +41108,16 @@ export const plans = {
   },
   CreateCPersonSecretInput: {
     clientMutationId: {
-      applyPlan: CreateCPersonSecretInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cPersonSecret: {
-      applyPlan: CreateCPersonSecretInput_cPersonSecret_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43154,9 +41139,15 @@ export const plans = {
   },
   CreateViewTablePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateViewTablePayload_clientMutationIdPlan,
-    viewTable: CreateViewTablePayload_viewTablePlan,
-    query: CreateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43191,11 +41182,16 @@ export const plans = {
   },
   CreateViewTableInput: {
     clientMutationId: {
-      applyPlan: CreateViewTableInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     viewTable: {
-      applyPlan: CreateViewTableInput_viewTable_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43224,17 +41220,28 @@ export const plans = {
   },
   CreateBUpdatableViewPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBUpdatableViewPayload_clientMutationIdPlan,
-    bUpdatableView: CreateBUpdatableViewPayload_bUpdatableViewPlan,
-    query: CreateBUpdatableViewPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    bUpdatableView($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateBUpdatableViewInput: {
     clientMutationId: {
-      applyPlan: CreateBUpdatableViewInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     bUpdatableView: {
-      applyPlan: CreateBUpdatableViewInput_bUpdatableView_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43270,9 +41277,15 @@ export const plans = {
   },
   CreateCCompoundKeyPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCCompoundKeyPayload_clientMutationIdPlan,
-    cCompoundKey: CreateCCompoundKeyPayload_cCompoundKeyPlan,
-    query: CreateCCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cCompoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cCompoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43307,11 +41320,16 @@ export const plans = {
   },
   CreateCCompoundKeyInput: {
     clientMutationId: {
-      applyPlan: CreateCCompoundKeyInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cCompoundKey: {
-      applyPlan: CreateCCompoundKeyInput_cCompoundKey_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43340,9 +41358,15 @@ export const plans = {
   },
   CreateSimilarTable1Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: CreateSimilarTable1Payload_similarTable1Plan,
-    query: CreateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43377,11 +41401,16 @@ export const plans = {
   },
   CreateSimilarTable1Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable1Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable1: {
-      applyPlan: CreateSimilarTable1Input_similarTable1_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43417,9 +41446,15 @@ export const plans = {
   },
   CreateSimilarTable2Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: CreateSimilarTable2Payload_similarTable2Plan,
-    query: CreateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43454,11 +41489,16 @@ export const plans = {
   },
   CreateSimilarTable2Input: {
     clientMutationId: {
-      applyPlan: CreateSimilarTable2Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     similarTable2: {
-      applyPlan: CreateSimilarTable2Input_similarTable2_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43494,9 +41534,15 @@ export const plans = {
   },
   CreateCNullTestRecordPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCNullTestRecordPayload_clientMutationIdPlan,
-    cNullTestRecord: CreateCNullTestRecordPayload_cNullTestRecordPlan,
-    query: CreateCNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cNullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cNullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43531,11 +41577,16 @@ export const plans = {
   },
   CreateCNullTestRecordInput: {
     clientMutationId: {
-      applyPlan: CreateCNullTestRecordInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cNullTestRecord: {
-      applyPlan: CreateCNullTestRecordInput_cNullTestRecord_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43571,17 +41622,28 @@ export const plans = {
   },
   CreateCEdgeCasePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCEdgeCasePayload_clientMutationIdPlan,
-    cEdgeCase: CreateCEdgeCasePayload_cEdgeCasePlan,
-    query: CreateCEdgeCasePayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cEdgeCase($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   CreateCEdgeCaseInput: {
     clientMutationId: {
-      applyPlan: CreateCEdgeCaseInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cEdgeCase: {
-      applyPlan: CreateCEdgeCaseInput_cEdgeCase_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43610,9 +41672,15 @@ export const plans = {
   },
   CreateCLeftArmPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCLeftArmPayload_clientMutationIdPlan,
-    cLeftArm: CreateCLeftArmPayload_cLeftArmPlan,
-    query: CreateCLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cLeftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cLeftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43647,11 +41715,16 @@ export const plans = {
   },
   CreateCLeftArmInput: {
     clientMutationId: {
-      applyPlan: CreateCLeftArmInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cLeftArm: {
-      applyPlan: CreateCLeftArmInput_cLeftArm_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43687,9 +41760,15 @@ export const plans = {
   },
   CreateCIssue756Payload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCIssue756Payload_clientMutationIdPlan,
-    cIssue756: CreateCIssue756Payload_cIssue756Plan,
-    query: CreateCIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cIssue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cIssue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43724,11 +41803,16 @@ export const plans = {
   },
   CreateCIssue756Input: {
     clientMutationId: {
-      applyPlan: CreateCIssue756Input_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cIssue756: {
-      applyPlan: CreateCIssue756Input_cIssue756_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43750,9 +41834,15 @@ export const plans = {
   },
   CreatePostPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePostPayload_clientMutationIdPlan,
-    post: CreatePostPayload_postPlan,
-    query: CreatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43787,19 +41877,30 @@ export const plans = {
   },
   CreatePostInput: {
     clientMutationId: {
-      applyPlan: CreatePostInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     post: {
-      applyPlan: CreatePostInput_post_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
   CreateCPersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateCPersonPayload_clientMutationIdPlan,
-    cPerson: CreateCPersonPayload_cPersonPlan,
-    query: CreateCPersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPerson($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43834,11 +41935,16 @@ export const plans = {
   },
   CreateCPersonInput: {
     clientMutationId: {
-      applyPlan: CreateCPersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     cPerson: {
-      applyPlan: CreateCPersonInput_cPerson_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -43932,9 +42038,15 @@ export const plans = {
   },
   CreateBTypePayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateBTypePayload_clientMutationIdPlan,
-    bType: CreateBTypePayload_bTypePlan,
-    query: CreateBTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    bType($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     bTypeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -43969,11 +42081,16 @@ export const plans = {
   },
   CreateBTypeInput: {
     clientMutationId: {
-      applyPlan: CreateBTypeInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     bType: {
-      applyPlan: CreateBTypeInput_bType_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -44371,9 +42488,15 @@ export const plans = {
   },
   UpdateInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateInputPayload_clientMutationIdPlan,
-    input: UpdateInputPayload_inputPlan,
-    query: UpdateInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44408,11 +42531,16 @@ export const plans = {
   },
   UpdateInputByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateInputByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     inputPatch: {
-      applyPlan: UpdateInputByRowIdInput_inputPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   InputPatch: {
@@ -44426,9 +42554,15 @@ export const plans = {
   },
   UpdatePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePatchPayload_clientMutationIdPlan,
-    patch: UpdatePatchPayload_patchPlan,
-    query: UpdatePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44463,11 +42597,16 @@ export const plans = {
   },
   UpdatePatchByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePatchByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     patchPatch: {
-      applyPlan: UpdatePatchByRowIdInput_patchPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PatchPatch: {
@@ -44481,9 +42620,15 @@ export const plans = {
   },
   UpdateReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPayload_clientMutationIdPlan,
-    reserved: UpdateReservedPayload_reservedPlan,
-    query: UpdateReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44518,11 +42663,16 @@ export const plans = {
   },
   UpdateReservedByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     reservedPatch: {
-      applyPlan: UpdateReservedByRowIdInput_reservedPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatch: {
@@ -44536,9 +42686,15 @@ export const plans = {
   },
   UpdateReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: UpdateReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: UpdateReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44573,11 +42729,16 @@ export const plans = {
   },
   UpdateReservedPatchRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedPatchRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     reservedPatchRecordPatch: {
-      applyPlan: UpdateReservedPatchRecordByRowIdInput_reservedPatchRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedPatchRecordPatch: {
@@ -44591,9 +42752,15 @@ export const plans = {
   },
   UpdateReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: UpdateReservedInputRecordPayload_reservedInputRecordPlan,
-    query: UpdateReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44628,11 +42795,16 @@ export const plans = {
   },
   UpdateReservedInputRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateReservedInputRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     reservedInputRecordPatch: {
-      applyPlan: UpdateReservedInputRecordByRowIdInput_reservedInputRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ReservedInputRecordPatch: {
@@ -44646,9 +42818,15 @@ export const plans = {
   },
   UpdateDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: UpdateDefaultValuePayload_defaultValuePlan,
-    query: UpdateDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44683,11 +42861,16 @@ export const plans = {
   },
   UpdateDefaultValueByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateDefaultValueByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     defaultValuePatch: {
-      applyPlan: UpdateDefaultValueByRowIdInput_defaultValuePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   DefaultValuePatch: {
@@ -44708,17 +42891,28 @@ export const plans = {
   },
   UpdateNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: UpdateNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: UpdateNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateNoPrimaryKeyByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateNoPrimaryKeyByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     noPrimaryKeyPatch: {
-      applyPlan: UpdateNoPrimaryKeyByRowIdInput_noPrimaryKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   NoPrimaryKeyPatch: {
@@ -44739,18 +42933,29 @@ export const plans = {
   },
   UpdateUniqueForeignKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateUniqueForeignKeyPayload_clientMutationIdPlan,
-    uniqueForeignKey: UpdateUniqueForeignKeyPayload_uniqueForeignKeyPlan,
-    query: UpdateUniqueForeignKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    uniqueForeignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   UpdateUniqueForeignKeyByCompoundKey1AndCompoundKey2Input: {
     clientMutationId: {
-      applyPlan: UpdateUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     compoundKey1: undefined,
     compoundKey2: undefined,
     uniqueForeignKeyPatch: {
-      applyPlan: UpdateUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_uniqueForeignKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UniqueForeignKeyPatch: {
@@ -44771,9 +42976,15 @@ export const plans = {
   },
   UpdateCMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCMyTablePayload_clientMutationIdPlan,
-    cMyTable: UpdateCMyTablePayload_cMyTablePlan,
-    query: UpdateCMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cMyTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cMyTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44808,11 +43019,16 @@ export const plans = {
   },
   UpdateCMyTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCMyTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     cMyTablePatch: {
-      applyPlan: UpdateCMyTableByRowIdInput_cMyTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CMyTablePatch: {
@@ -44833,9 +43049,15 @@ export const plans = {
   },
   UpdateCPersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCPersonSecretPayload_clientMutationIdPlan,
-    cPersonSecret: UpdateCPersonSecretPayload_cPersonSecretPlan,
-    query: UpdateCPersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPersonSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44870,11 +43092,16 @@ export const plans = {
   },
   UpdateCPersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCPersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     cPersonSecretPatch: {
-      applyPlan: UpdateCPersonSecretByPersonIdInput_cPersonSecretPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CPersonSecretPatch: {
@@ -44895,9 +43122,15 @@ export const plans = {
   },
   UpdateViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateViewTablePayload_clientMutationIdPlan,
-    viewTable: UpdateViewTablePayload_viewTablePlan,
-    query: UpdateViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -44932,11 +43165,16 @@ export const plans = {
   },
   UpdateViewTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateViewTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     viewTablePatch: {
-      applyPlan: UpdateViewTableByRowIdInput_viewTablePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ViewTablePatch: {
@@ -44964,9 +43202,15 @@ export const plans = {
   },
   UpdateCCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCCompoundKeyPayload_clientMutationIdPlan,
-    cCompoundKey: UpdateCCompoundKeyPayload_cCompoundKeyPlan,
-    query: UpdateCCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cCompoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cCompoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45001,12 +43245,17 @@ export const plans = {
   },
   UpdateCCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: UpdateCCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined,
     cCompoundKeyPatch: {
-      applyPlan: UpdateCCompoundKeyByPersonId1AndPersonId2Input_cCompoundKeyPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CCompoundKeyPatch: {
@@ -45034,9 +43283,15 @@ export const plans = {
   },
   UpdateSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: UpdateSimilarTable1Payload_similarTable1Plan,
-    query: UpdateSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45071,11 +43326,16 @@ export const plans = {
   },
   UpdateSimilarTable1ByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable1ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     similarTable1Patch: {
-      applyPlan: UpdateSimilarTable1ByRowIdInput_similarTable1Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable1Patch: {
@@ -45110,9 +43370,15 @@ export const plans = {
   },
   UpdateSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: UpdateSimilarTable2Payload_similarTable2Plan,
-    query: UpdateSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45147,11 +43413,16 @@ export const plans = {
   },
   UpdateSimilarTable2ByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSimilarTable2ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     similarTable2Patch: {
-      applyPlan: UpdateSimilarTable2ByRowIdInput_similarTable2Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SimilarTable2Patch: {
@@ -45186,9 +43457,15 @@ export const plans = {
   },
   UpdateCNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCNullTestRecordPayload_clientMutationIdPlan,
-    cNullTestRecord: UpdateCNullTestRecordPayload_cNullTestRecordPlan,
-    query: UpdateCNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cNullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cNullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45223,11 +43500,16 @@ export const plans = {
   },
   UpdateCNullTestRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCNullTestRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     cNullTestRecordPatch: {
-      applyPlan: UpdateCNullTestRecordByRowIdInput_cNullTestRecordPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CNullTestRecordPatch: {
@@ -45262,9 +43544,15 @@ export const plans = {
   },
   UpdateCLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCLeftArmPayload_clientMutationIdPlan,
-    cLeftArm: UpdateCLeftArmPayload_cLeftArmPlan,
-    query: UpdateCLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cLeftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cLeftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45299,11 +43587,16 @@ export const plans = {
   },
   UpdateCLeftArmByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCLeftArmByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     cLeftArmPatch: {
-      applyPlan: UpdateCLeftArmByRowIdInput_cLeftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CLeftArmPatch: {
@@ -45338,18 +43631,29 @@ export const plans = {
   },
   UpdateCLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     cLeftArmPatch: {
-      applyPlan: UpdateCLeftArmByPersonIdInput_cLeftArmPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateCIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCIssue756Payload_clientMutationIdPlan,
-    cIssue756: UpdateCIssue756Payload_cIssue756Plan,
-    query: UpdateCIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cIssue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cIssue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45384,11 +43688,16 @@ export const plans = {
   },
   UpdateCIssue756ByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCIssue756ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     cIssue756Patch: {
-      applyPlan: UpdateCIssue756ByRowIdInput_cIssue756Patch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CIssue756Patch: {
@@ -45409,9 +43718,15 @@ export const plans = {
   },
   UpdatePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePostPayload_clientMutationIdPlan,
-    post: UpdatePostPayload_postPlan,
-    query: UpdatePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45446,11 +43761,16 @@ export const plans = {
   },
   UpdatePostByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePostByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     postPatch: {
-      applyPlan: UpdatePostByRowIdInput_postPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PostPatch: {
@@ -45499,9 +43819,15 @@ export const plans = {
   },
   UpdateCPersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateCPersonPayload_clientMutationIdPlan,
-    cPerson: UpdateCPersonPayload_cPersonPlan,
-    query: UpdateCPersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPerson($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45536,11 +43862,16 @@ export const plans = {
   },
   UpdateCPersonByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateCPersonByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     cPersonPatch: {
-      applyPlan: UpdateCPersonByRowIdInput_cPersonPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   CPersonPatch: {
@@ -45624,18 +43955,29 @@ export const plans = {
   },
   UpdateCPersonByEmailInput: {
     clientMutationId: {
-      applyPlan: UpdateCPersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined,
     cPersonPatch: {
-      applyPlan: UpdateCPersonByEmailInput_cPersonPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateBTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateBTypePayload_clientMutationIdPlan,
-    bType: UpdateBTypePayload_bTypePlan,
-    query: UpdateBTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    bType($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     bTypeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -45670,11 +44012,16 @@ export const plans = {
   },
   UpdateBTypeByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateBTypeByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     bTypePatch: {
-      applyPlan: UpdateBTypeByRowIdInput_bTypePatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   BTypePatch: {
@@ -46024,9 +44371,15 @@ export const plans = {
   },
   DeleteInputPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteInputPayload_clientMutationIdPlan,
-    input: DeleteInputPayload_inputPlan,
-    query: DeleteInputPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    input($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     inputEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46061,15 +44414,23 @@ export const plans = {
   },
   DeleteInputByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteInputByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeletePatchPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePatchPayload_clientMutationIdPlan,
-    patch: DeletePatchPayload_patchPlan,
-    query: DeletePatchPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    patch($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     patchEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46104,15 +44465,23 @@ export const plans = {
   },
   DeletePatchByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeletePatchByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteReservedPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPayload_clientMutationIdPlan,
-    reserved: DeleteReservedPayload_reservedPlan,
-    query: DeleteReservedPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reserved($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46147,15 +44516,23 @@ export const plans = {
   },
   DeleteReservedByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteReservedPatchRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedPatchRecordPayload_clientMutationIdPlan,
-    reservedPatchRecord: DeleteReservedPatchRecordPayload_reservedPatchRecordPlan,
-    query: DeleteReservedPatchRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedPatchRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedPatchRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46190,15 +44567,23 @@ export const plans = {
   },
   DeleteReservedPatchRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedPatchRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteReservedInputRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteReservedInputRecordPayload_clientMutationIdPlan,
-    reservedInputRecord: DeleteReservedInputRecordPayload_reservedInputRecordPlan,
-    query: DeleteReservedInputRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    reservedInputRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     reservedInputRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46233,15 +44618,23 @@ export const plans = {
   },
   DeleteReservedInputRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteReservedInputRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteDefaultValuePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteDefaultValuePayload_clientMutationIdPlan,
-    defaultValue: DeleteDefaultValuePayload_defaultValuePlan,
-    query: DeleteDefaultValuePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    defaultValue($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     defaultValueEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46276,40 +44669,64 @@ export const plans = {
   },
   DeleteDefaultValueByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteDefaultValueByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteNoPrimaryKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteNoPrimaryKeyPayload_clientMutationIdPlan,
-    noPrimaryKey: DeleteNoPrimaryKeyPayload_noPrimaryKeyPlan,
-    query: DeleteNoPrimaryKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    noPrimaryKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteNoPrimaryKeyByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteNoPrimaryKeyByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteUniqueForeignKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteUniqueForeignKeyPayload_clientMutationIdPlan,
-    uniqueForeignKey: DeleteUniqueForeignKeyPayload_uniqueForeignKeyPlan,
-    query: DeleteUniqueForeignKeyPayload_queryPlan
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    uniqueForeignKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
   },
   DeleteUniqueForeignKeyByCompoundKey1AndCompoundKey2Input: {
     clientMutationId: {
-      applyPlan: DeleteUniqueForeignKeyByCompoundKey1AndCompoundKey2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     compoundKey1: undefined,
     compoundKey2: undefined
   },
   DeleteCMyTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCMyTablePayload_clientMutationIdPlan,
-    cMyTable: DeleteCMyTablePayload_cMyTablePlan,
-    query: DeleteCMyTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cMyTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cMyTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46344,15 +44761,23 @@ export const plans = {
   },
   DeleteCMyTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCMyTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCPersonSecretPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCPersonSecretPayload_clientMutationIdPlan,
-    cPersonSecret: DeleteCPersonSecretPayload_cPersonSecretPlan,
-    query: DeleteCPersonSecretPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPersonSecret($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonSecretEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46387,15 +44812,23 @@ export const plans = {
   },
   DeleteCPersonSecretByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCPersonSecretByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteViewTablePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteViewTablePayload_clientMutationIdPlan,
-    viewTable: DeleteViewTablePayload_viewTablePlan,
-    query: DeleteViewTablePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    viewTable($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     viewTableEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46430,15 +44863,23 @@ export const plans = {
   },
   DeleteViewTableByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteViewTableByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCCompoundKeyPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCCompoundKeyPayload_clientMutationIdPlan,
-    cCompoundKey: DeleteCCompoundKeyPayload_cCompoundKeyPlan,
-    query: DeleteCCompoundKeyPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cCompoundKey($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cCompoundKeyEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46473,16 +44914,24 @@ export const plans = {
   },
   DeleteCCompoundKeyByPersonId1AndPersonId2Input: {
     clientMutationId: {
-      applyPlan: DeleteCCompoundKeyByPersonId1AndPersonId2Input_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId1: undefined,
     personId2: undefined
   },
   DeleteSimilarTable1Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable1Payload_clientMutationIdPlan,
-    similarTable1: DeleteSimilarTable1Payload_similarTable1Plan,
-    query: DeleteSimilarTable1Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable1($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable1Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46517,15 +44966,23 @@ export const plans = {
   },
   DeleteSimilarTable1ByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable1ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteSimilarTable2Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSimilarTable2Payload_clientMutationIdPlan,
-    similarTable2: DeleteSimilarTable2Payload_similarTable2Plan,
-    query: DeleteSimilarTable2Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    similarTable2($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     similarTable2Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46560,15 +45017,23 @@ export const plans = {
   },
   DeleteSimilarTable2ByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSimilarTable2ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCNullTestRecordPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCNullTestRecordPayload_clientMutationIdPlan,
-    cNullTestRecord: DeleteCNullTestRecordPayload_cNullTestRecordPlan,
-    query: DeleteCNullTestRecordPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cNullTestRecord($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cNullTestRecordEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46603,15 +45068,23 @@ export const plans = {
   },
   DeleteCNullTestRecordByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCNullTestRecordByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCLeftArmPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCLeftArmPayload_clientMutationIdPlan,
-    cLeftArm: DeleteCLeftArmPayload_cLeftArmPlan,
-    query: DeleteCLeftArmPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cLeftArm($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cLeftArmEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46646,21 +45119,31 @@ export const plans = {
   },
   DeleteCLeftArmByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCLeftArmByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCLeftArmByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCLeftArmByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeleteCIssue756Payload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCIssue756Payload_clientMutationIdPlan,
-    cIssue756: DeleteCIssue756Payload_cIssue756Plan,
-    query: DeleteCIssue756Payload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cIssue756($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cIssue756Edge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46695,15 +45178,23 @@ export const plans = {
   },
   DeleteCIssue756ByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCIssue756ByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeletePostPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePostPayload_clientMutationIdPlan,
-    post: DeletePostPayload_postPlan,
-    query: DeletePostPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    post($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     postEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46738,15 +45229,23 @@ export const plans = {
   },
   DeletePostByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeletePostByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCPersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteCPersonPayload_clientMutationIdPlan,
-    cPerson: DeleteCPersonPayload_cPersonPlan,
-    query: DeleteCPersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    cPerson($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     cPersonEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46781,21 +45280,31 @@ export const plans = {
   },
   DeleteCPersonByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteCPersonByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteCPersonByEmailInput: {
     clientMutationId: {
-      applyPlan: DeleteCPersonByEmailInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     email: undefined
   },
   DeleteBTypePayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteBTypePayload_clientMutationIdPlan,
-    bType: DeleteBTypePayload_bTypePlan,
-    query: DeleteBTypePayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    bType($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     bTypeEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -46830,7 +45339,9 @@ export const plans = {
   },
   DeleteBTypeByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteBTypeByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -2,7 +2,7 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelec
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -39,7 +39,7 @@ const registryConfig_pgCodecs_CFuncOutOutRecord_CFuncOutOutRecord = recordCodec(
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord = recordCodec({
@@ -69,7 +69,7 @@ const registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord = re
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord = recordCodec({
@@ -99,7 +99,7 @@ const registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord 
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord = recordCodec({
@@ -129,7 +129,7 @@ const registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRecord = recordCodec({
@@ -159,7 +159,7 @@ const registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnnamedRecord = recordCodec({
@@ -189,7 +189,7 @@ const registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnname
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRecord = recordCodec({
@@ -219,7 +219,7 @@ const registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -257,7 +257,7 @@ const registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamed
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableMultiColRecord = recordCodec({
@@ -287,7 +287,7 @@ const registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableM
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOutUnnamedOutOutUnnamedRecord = recordCodec({
@@ -325,7 +325,7 @@ const registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationReturnsTableMultiColRecord = recordCodec({
@@ -355,7 +355,7 @@ const registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationRetur
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const bGuidCodec = domainOfCodec(TYPES.varchar, "bGuid", sql.identifier("b", "guid"), {
@@ -421,7 +421,7 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const inputsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -448,7 +448,7 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const patchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -475,7 +475,7 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedAttributes = Object.assign(Object.create(null), {
   id: {
@@ -502,7 +502,7 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -529,7 +529,7 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
@@ -556,7 +556,7 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
@@ -592,7 +592,7 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -637,7 +637,7 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
@@ -673,7 +673,7 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
@@ -718,7 +718,7 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
@@ -756,7 +756,7 @@ const uniqueForeignKeyCodec = recordCodec({
       omit: "create,update,delete,all,order,filter"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cMyTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -792,7 +792,7 @@ const cMyTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cPersonSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -832,7 +832,7 @@ const cPersonSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
@@ -877,7 +877,7 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bUpdatableViewAttributes = Object.assign(Object.create(null), {
   x: {
@@ -933,7 +933,7 @@ const bUpdatableViewCodec = recordCodec({
       uniqueKey: "x"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cCompoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
@@ -978,7 +978,7 @@ const cCompoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1032,7 +1032,7 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
@@ -1086,7 +1086,7 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cNullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1140,7 +1140,7 @@ const cNullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -1198,7 +1198,7 @@ const cEdgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cLeftArmAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1252,7 +1252,7 @@ const cLeftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bJwtTokenCodec = recordCodec({
   name: "bJwtToken",
@@ -1314,7 +1314,7 @@ const bJwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1362,7 +1362,7 @@ const cIssue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bAuthPayloadCodec = recordCodec({
   name: "bAuthPayload",
@@ -1408,7 +1408,7 @@ const bAuthPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const bColorCodec = enumCodec({
   name: "bColor",
@@ -1539,7 +1539,7 @@ const cCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord = recordCodec({
   name: "CFuncOutOutCompoundTypeRecord",
@@ -1568,7 +1568,7 @@ const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundT
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord = recordCodec({
@@ -1598,7 +1598,7 @@ const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutC
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const anEnumCodec = enumCodec({
@@ -1661,7 +1661,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1746,7 +1746,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord = recordCodec({
   name: "CQueryOutputTwoRowsRecord",
@@ -1783,7 +1783,7 @@ const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord = recordCodec({
@@ -1813,7 +1813,7 @@ const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutR
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord = recordCodec({
@@ -1843,7 +1843,7 @@ const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInout
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const bEmailCodec = domainOfCodec(TYPES.text, "bEmail", sql.identifier("b", "email"), {
@@ -1894,7 +1894,7 @@ const bWrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cPersonAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2015,7 +2015,7 @@ const cPersonCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "CPersonComputedFirstArgInoutOutRecord",
@@ -2044,7 +2044,7 @@ const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonCompu
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = recordCodec({
@@ -2082,7 +2082,7 @@ const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = reco
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRecord = recordCodec({
@@ -2120,7 +2120,7 @@ const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRec
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord = recordCodec({
@@ -2158,7 +2158,7 @@ const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecor
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord = recordCodec({
@@ -2196,7 +2196,7 @@ const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplex
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord = recordCodec({
@@ -2234,7 +2234,7 @@ const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComple
       pgProc.provolatile === "v" ? "mutation" : "query"
     }.`, */
   },
-  executor: executor_mainPgExecutor,
+  executor,
   isAnonymous: true
 });
 const bColorArrayCodec = listOfCodec(bColorCodec, {
@@ -2349,7 +2349,7 @@ const bNestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const cTextArrayDomainCodec = domainOfCodec(pgCatalogTextArrayCodec, "cTextArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2874,7 +2874,7 @@ const bTypesCodec = recordCodec({
   attributes: bTypesAttributes,
   description: undefined,
   extensions: extensions46,
-  executor: executor_mainPgExecutor
+  executor
 });
 const pgCatalogInt4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2913,70 +2913,70 @@ const postArrayCodec = listOfCodec(postCodec, {
   description: undefined,
   name: "postArray"
 });
-const sqlIdent9 = sql.identifier("c", "current_user_id");
-const sqlIdent10 = sql.identifier("c", "func_out");
-const sqlIdent11 = sql.identifier("c", "func_out_setof");
-const sqlIdent12 = sql.identifier("c", "func_out_unnamed");
-const sqlIdent13 = sql.identifier("c", "mutation_out");
-const sqlIdent14 = sql.identifier("c", "mutation_out_setof");
-const sqlIdent15 = sql.identifier("c", "mutation_out_unnamed");
-const sqlIdent16 = sql.identifier("c", "no_args_mutation");
-const sqlIdent17 = sql.identifier("c", "no_args_query");
-const sqlIdent18 = sql.identifier("a", "return_void_mutation");
-const sqlIdent19 = sql.identifier("a", "mutation_interval_set");
-const sqlIdent20 = sql.identifier("a", "query_interval_set");
-const sqlIdent21 = sql.identifier("a", "static_big_integer");
-const sqlIdent22 = sql.identifier("c", "func_in_out");
-const sqlIdent23 = sql.identifier("c", "func_returns_table_one_col");
-const sqlIdent24 = sql.identifier("c", "mutation_in_out");
-const sqlIdent25 = sql.identifier("c", "mutation_returns_table_one_col");
-const sqlIdent26 = sql.identifier("a", "assert_something");
-const sqlIdent27 = sql.identifier("a", "assert_something_nx");
-const sqlIdent28 = sql.identifier("c", "json_identity");
-const sqlIdent29 = sql.identifier("c", "json_identity_mutation");
-const sqlIdent30 = sql.identifier("c", "jsonb_identity");
-const sqlIdent31 = sql.identifier("c", "jsonb_identity_mutation");
-const sqlIdent32 = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
-const sqlIdent33 = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
-const sqlIdent34 = sql.identifier("a", "add_1_mutation");
-const sqlIdent35 = sql.identifier("a", "add_1_query");
-const sqlIdent36 = sql.identifier("a", "add_2_mutation");
-const sqlIdent37 = sql.identifier("a", "add_2_query");
-const sqlIdent38 = sql.identifier("a", "add_3_mutation");
-const sqlIdent39 = sql.identifier("a", "add_3_query");
-const sqlIdent40 = sql.identifier("a", "add_4_mutation");
-const sqlIdent41 = sql.identifier("a", "add_4_mutation_error");
-const sqlIdent42 = sql.identifier("a", "add_4_query");
-const sqlIdent43 = sql.identifier("b", "mult_1");
-const sqlIdent44 = sql.identifier("b", "mult_2");
-const sqlIdent45 = sql.identifier("b", "mult_3");
-const sqlIdent46 = sql.identifier("b", "mult_4");
-const sqlIdent47 = sql.identifier("c", "func_in_inout");
-const sqlIdent48 = sql.identifier("c", "func_out_out");
-const sqlIdent49 = sql.identifier("c", "func_out_out_setof");
-const sqlIdent50 = sql.identifier("c", "func_out_out_unnamed");
-const sqlIdent51 = sql.identifier("c", "mutation_in_inout");
-const sqlIdent52 = sql.identifier("c", "mutation_out_out");
-const sqlIdent53 = sql.identifier("c", "mutation_out_out_setof");
-const sqlIdent54 = sql.identifier("c", "mutation_out_out_unnamed");
-const sqlIdent55 = sql.identifier("c", "search_test_summaries");
-const sqlIdent56 = sql.identifier("a", "optional_missing_middle_1");
-const sqlIdent57 = sql.identifier("a", "optional_missing_middle_2");
-const sqlIdent58 = sql.identifier("a", "optional_missing_middle_3");
-const sqlIdent59 = sql.identifier("a", "optional_missing_middle_4");
-const sqlIdent60 = sql.identifier("a", "optional_missing_middle_5");
-const sqlIdent61 = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
-const sqlIdent62 = sql.identifier("c", "func_returns_table_multi_col");
-const sqlIdent63 = sql.identifier("c", "int_set_mutation");
-const sqlIdent64 = sql.identifier("c", "int_set_query");
-const sqlIdent65 = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
-const sqlIdent66 = sql.identifier("c", "mutation_returns_table_multi_col");
-const sqlIdent67 = sql.identifier("b", "guid_fn");
-const sqlIdent68 = sql.identifier("a", "mutation_interval_array");
-const sqlIdent69 = sql.identifier("a", "query_interval_array");
-const sqlIdent70 = sql.identifier("a", "mutation_text_array");
-const sqlIdent71 = sql.identifier("a", "query_text_array");
-const uniques2 = [{
+const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
+const func_outFunctionIdentifer = sql.identifier("c", "func_out");
+const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
+const func_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed");
+const mutation_outFunctionIdentifer = sql.identifier("c", "mutation_out");
+const mutation_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_setof");
+const mutation_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed");
+const no_args_mutationFunctionIdentifer = sql.identifier("c", "no_args_mutation");
+const no_args_queryFunctionIdentifer = sql.identifier("c", "no_args_query");
+const return_void_mutationFunctionIdentifer = sql.identifier("a", "return_void_mutation");
+const mutation_interval_setFunctionIdentifer = sql.identifier("a", "mutation_interval_set");
+const query_interval_setFunctionIdentifer = sql.identifier("a", "query_interval_set");
+const static_big_integerFunctionIdentifer = sql.identifier("a", "static_big_integer");
+const func_in_outFunctionIdentifer = sql.identifier("c", "func_in_out");
+const func_returns_table_one_colFunctionIdentifer = sql.identifier("c", "func_returns_table_one_col");
+const mutation_in_outFunctionIdentifer = sql.identifier("c", "mutation_in_out");
+const mutation_returns_table_one_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_one_col");
+const assert_somethingFunctionIdentifer = sql.identifier("a", "assert_something");
+const assert_something_nxFunctionIdentifer = sql.identifier("a", "assert_something_nx");
+const json_identityFunctionIdentifer = sql.identifier("c", "json_identity");
+const json_identity_mutationFunctionIdentifer = sql.identifier("c", "json_identity_mutation");
+const jsonb_identityFunctionIdentifer = sql.identifier("c", "jsonb_identity");
+const jsonb_identity_mutationFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation");
+const jsonb_identity_mutation_plpgsqlFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql");
+const jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer = sql.identifier("c", "jsonb_identity_mutation_plpgsql_with_default");
+const add_1_mutationFunctionIdentifer = sql.identifier("a", "add_1_mutation");
+const add_1_queryFunctionIdentifer = sql.identifier("a", "add_1_query");
+const add_2_mutationFunctionIdentifer = sql.identifier("a", "add_2_mutation");
+const add_2_queryFunctionIdentifer = sql.identifier("a", "add_2_query");
+const add_3_mutationFunctionIdentifer = sql.identifier("a", "add_3_mutation");
+const add_3_queryFunctionIdentifer = sql.identifier("a", "add_3_query");
+const add_4_mutationFunctionIdentifer = sql.identifier("a", "add_4_mutation");
+const add_4_mutation_errorFunctionIdentifer = sql.identifier("a", "add_4_mutation_error");
+const add_4_queryFunctionIdentifer = sql.identifier("a", "add_4_query");
+const mult_1FunctionIdentifer = sql.identifier("b", "mult_1");
+const mult_2FunctionIdentifer = sql.identifier("b", "mult_2");
+const mult_3FunctionIdentifer = sql.identifier("b", "mult_3");
+const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
+const func_in_inoutFunctionIdentifer = sql.identifier("c", "func_in_inout");
+const func_out_outFunctionIdentifer = sql.identifier("c", "func_out_out");
+const func_out_out_setofFunctionIdentifer = sql.identifier("c", "func_out_out_setof");
+const func_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_out_unnamed");
+const mutation_in_inoutFunctionIdentifer = sql.identifier("c", "mutation_in_inout");
+const mutation_out_outFunctionIdentifer = sql.identifier("c", "mutation_out_out");
+const mutation_out_out_setofFunctionIdentifer = sql.identifier("c", "mutation_out_out_setof");
+const mutation_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_out_unnamed");
+const search_test_summariesFunctionIdentifer = sql.identifier("c", "search_test_summaries");
+const optional_missing_middle_1FunctionIdentifer = sql.identifier("a", "optional_missing_middle_1");
+const optional_missing_middle_2FunctionIdentifer = sql.identifier("a", "optional_missing_middle_2");
+const optional_missing_middle_3FunctionIdentifer = sql.identifier("a", "optional_missing_middle_3");
+const optional_missing_middle_4FunctionIdentifer = sql.identifier("a", "optional_missing_middle_4");
+const optional_missing_middle_5FunctionIdentifer = sql.identifier("a", "optional_missing_middle_5");
+const func_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "func_out_unnamed_out_out_unnamed");
+const func_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "func_returns_table_multi_col");
+const int_set_mutationFunctionIdentifer = sql.identifier("c", "int_set_mutation");
+const int_set_queryFunctionIdentifer = sql.identifier("c", "int_set_query");
+const mutation_out_unnamed_out_out_unnamedFunctionIdentifer = sql.identifier("c", "mutation_out_unnamed_out_out_unnamed");
+const mutation_returns_table_multi_colFunctionIdentifer = sql.identifier("c", "mutation_returns_table_multi_col");
+const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
+const mutation_interval_arrayFunctionIdentifer = sql.identifier("a", "mutation_interval_array");
+const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interval_array");
+const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
+const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
+const inputsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2984,7 +2984,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const uniques3 = [{
+const patchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2992,7 +2992,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const uniques4 = [{
+const reservedUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3000,7 +3000,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const uniques5 = [{
+const reservedPatchsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3008,7 +3008,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const uniques6 = [{
+const reserved_inputUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3016,7 +3016,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const uniques7 = [{
+const default_valueUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3025,7 +3025,7 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
   from: foreignKeyCodec.sqlType,
@@ -3044,7 +3044,7 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
   from: uniqueForeignKeyCodec.sqlType,
@@ -3071,7 +3071,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     }
   }
 };
-const uniques12 = [{
+const c_my_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3079,7 +3079,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const uniques13 = [{
+const c_person_secretUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -3088,12 +3088,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_c_person_secret_c_person_secret = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_person_secret",
   identifier: "main.c.person_secret",
   from: cPersonSecretCodec.sqlType,
   codec: cPersonSecretCodec,
-  uniques: uniques13,
+  uniques: c_person_secretUniques,
   isVirtual: false,
   description: "Tracks the person's secret",
   extensions: {
@@ -3108,7 +3108,7 @@ const registryConfig_pgResources_c_person_secret_c_person_secret = {
     }
   }
 };
-const uniques14 = [{
+const view_tableUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3116,7 +3116,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const uniques16 = [{
+const c_compound_keyUniques = [{
   isPrimary: true,
   attributes: ["person_id_1", "person_id_2"],
   description: undefined,
@@ -3125,12 +3125,12 @@ const uniques16 = [{
   }
 }];
 const registryConfig_pgResources_c_compound_key_c_compound_key = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_compound_key",
   identifier: "main.c.compound_key",
   from: cCompoundKeyCodec.sqlType,
   codec: cCompoundKeyCodec,
-  uniques: uniques16,
+  uniques: c_compound_keyUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3143,7 +3143,7 @@ const registryConfig_pgResources_c_compound_key_c_compound_key = {
     tags: {}
   }
 };
-const uniques17 = [{
+const similar_table_1Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3151,7 +3151,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const uniques18 = [{
+const similar_table_2Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3159,7 +3159,7 @@ const uniques18 = [{
     tags: Object.create(null)
   }
 }];
-const uniques19 = [{
+const c_null_test_recordUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3167,10 +3167,10 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const sqlIdent72 = sql.identifier("c", "edge_case_computed");
-const sqlIdent73 = sql.identifier("c", "return_table_without_grants");
-const sqlIdent74 = sql.identifier("b", "list_bde_mutation");
-const uniques21 = [{
+const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_computed");
+const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
+const list_bde_mutationFunctionIdentifer = sql.identifier("b", "list_bde_mutation");
+const c_left_armUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3186,12 +3186,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_c_left_arm_c_left_arm = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_left_arm",
   identifier: "main.c.left_arm",
   from: cLeftArmCodec.sqlType,
   codec: cLeftArmCodec,
-  uniques: uniques21,
+  uniques: c_left_armUniques,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
   extensions: {
@@ -3204,9 +3204,9 @@ const registryConfig_pgResources_c_left_arm_c_left_arm = {
     tags: {}
   }
 };
-const sqlIdent75 = sql.identifier("b", "authenticate_fail");
+const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_b_jwt_token = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "b_jwt_token",
   identifier: "main.b.jwt_token",
   from: bJwtTokenCodec.sqlType,
@@ -3226,8 +3226,8 @@ const resourceConfig_b_jwt_token = {
     }
   }
 };
-const sqlIdent76 = sql.identifier("b", "authenticate");
-const uniques23 = [{
+const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
+const c_issue756Uniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3236,12 +3236,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_c_issue756_c_issue756 = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_issue756",
   identifier: "main.c.issue756",
   from: cIssue756Codec.sqlType,
   codec: cIssue756Codec,
-  uniques: uniques23,
+  uniques: c_issue756Uniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3254,26 +3254,26 @@ const registryConfig_pgResources_c_issue756_c_issue756 = {
     tags: {}
   }
 };
-const sqlIdent77 = sql.identifier("c", "left_arm_identity");
-const sqlIdent78 = sql.identifier("c", "issue756_mutation");
-const sqlIdent79 = sql.identifier("c", "issue756_set_mutation");
-const sqlIdent80 = sql.identifier("b", "authenticate_many");
-const sqlIdent81 = sql.identifier("b", "authenticate_payload");
-const sqlIdent82 = sql.identifier("c", "types_mutation");
-const sqlIdent83 = sql.identifier("c", "types_query");
-const sqlIdent84 = sql.identifier("c", "compound_type_computed_field");
-const sqlIdent85 = sql.identifier("a", "post_computed_interval_set");
-const sqlIdent86 = sql.identifier("a", "post_computed_interval_array");
-const sqlIdent87 = sql.identifier("a", "post_computed_text_array");
-const sqlIdent88 = sql.identifier("a", "post_computed_with_optional_arg");
-const sqlIdent89 = sql.identifier("a", "post_computed_with_required_arg");
-const sqlIdent90 = sql.identifier("c", "func_out_out_compound_type");
-const sqlIdent91 = sql.identifier("c", "mutation_out_out_compound_type");
-const sqlIdent92 = sql.identifier("a", "post_headline_trimmed");
-const sqlIdent93 = sql.identifier("a", "post_headline_trimmed_no_defaults");
-const sqlIdent94 = sql.identifier("a", "post_headline_trimmed_strict");
-const sqlIdent95 = sql.identifier("c", "query_output_two_rows");
-const uniques25 = [{
+const left_arm_identityFunctionIdentifer = sql.identifier("c", "left_arm_identity");
+const issue756_mutationFunctionIdentifer = sql.identifier("c", "issue756_mutation");
+const issue756_set_mutationFunctionIdentifer = sql.identifier("c", "issue756_set_mutation");
+const authenticate_manyFunctionIdentifer = sql.identifier("b", "authenticate_many");
+const authenticate_payloadFunctionIdentifer = sql.identifier("b", "authenticate_payload");
+const types_mutationFunctionIdentifer = sql.identifier("c", "types_mutation");
+const types_queryFunctionIdentifer = sql.identifier("c", "types_query");
+const compound_type_computed_fieldFunctionIdentifer = sql.identifier("c", "compound_type_computed_field");
+const post_computed_interval_setFunctionIdentifer = sql.identifier("a", "post_computed_interval_set");
+const post_computed_interval_arrayFunctionIdentifer = sql.identifier("a", "post_computed_interval_array");
+const post_computed_text_arrayFunctionIdentifer = sql.identifier("a", "post_computed_text_array");
+const post_computed_with_optional_argFunctionIdentifer = sql.identifier("a", "post_computed_with_optional_arg");
+const post_computed_with_required_argFunctionIdentifer = sql.identifier("a", "post_computed_with_required_arg");
+const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_out_out_compound_type");
+const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
+const post_headline_trimmedFunctionIdentifer = sql.identifier("a", "post_headline_trimmed");
+const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_no_defaults");
+const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
+const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
+const postUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3282,12 +3282,12 @@ const uniques25 = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "post",
   identifier: "main.a.post",
   from: postCodec.sqlType,
   codec: postCodec,
-  uniques: uniques25,
+  uniques: postUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3300,9 +3300,9 @@ const registryConfig_pgResources_post_post = {
     tags: {}
   }
 };
-const sqlIdent96 = sql.identifier("c", "compound_type_set_query");
+const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_c_compound_type = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_compound_type",
   identifier: "main.c.compound_type",
   from: cCompoundTypeCodec.sqlType,
@@ -3322,32 +3322,32 @@ const resourceConfig_c_compound_type = {
     }
   }
 };
-const sqlIdent97 = sql.identifier("b", "compound_type_mutation");
-const sqlIdent98 = sql.identifier("b", "compound_type_query");
-const sqlIdent99 = sql.identifier("b", "compound_type_set_mutation");
-const sqlIdent100 = sql.identifier("c", "table_mutation");
-const sqlIdent101 = sql.identifier("c", "table_query");
-const sqlIdent102 = sql.identifier("a", "post_with_suffix");
-const sqlIdent103 = sql.identifier("a", "mutation_compound_type_array");
-const sqlIdent104 = sql.identifier("a", "query_compound_type_array");
-const sqlIdent105 = sql.identifier("b", "compound_type_array_mutation");
-const sqlIdent106 = sql.identifier("b", "compound_type_array_query");
-const sqlIdent107 = sql.identifier("a", "post_computed_compound_type_array");
-const sqlIdent108 = sql.identifier("a", "post_many");
-const sqlIdent109 = sql.identifier("c", "person_computed_out");
-const sqlIdent110 = sql.identifier("c", "person_first_name");
-const sqlIdent111 = sql.identifier("c", "person_computed_out_out");
-const sqlIdent112 = sql.identifier("c", "person_computed_inout");
-const sqlIdent113 = sql.identifier("c", "person_computed_inout_out");
-const sqlIdent114 = sql.identifier("c", "person_exists");
-const sqlIdent115 = sql.identifier("c", "person_computed_first_arg_inout_out");
-const sqlIdent116 = sql.identifier("c", "func_out_complex");
-const sqlIdent117 = sql.identifier("c", "func_out_complex_setof");
-const sqlIdent118 = sql.identifier("c", "mutation_out_complex");
-const sqlIdent119 = sql.identifier("c", "mutation_out_complex_setof");
-const sqlIdent120 = sql.identifier("c", "person_computed_complex");
-const sqlIdent121 = sql.identifier("c", "person_first_post");
-const uniques27 = [{
+const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
+const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
+const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
+const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
+const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
+const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
+const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
+const compound_type_array_queryFunctionIdentifer = sql.identifier("b", "compound_type_array_query");
+const post_computed_compound_type_arrayFunctionIdentifer = sql.identifier("a", "post_computed_compound_type_array");
+const post_manyFunctionIdentifer = sql.identifier("a", "post_many");
+const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
+const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
+const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
+const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_computed_inout");
+const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
+const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
+const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
+const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
+const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
+const mutation_out_complex_setofFunctionIdentifer = sql.identifier("c", "mutation_out_complex_setof");
+const person_computed_complexFunctionIdentifer = sql.identifier("c", "person_computed_complex");
+const person_first_postFunctionIdentifer = sql.identifier("c", "person_first_post");
+const c_personUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3363,12 +3363,12 @@ const uniques27 = [{
   }
 }];
 const registryConfig_pgResources_c_person_c_person = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "c_person",
   identifier: "main.c.person",
   from: cPersonCodec.sqlType,
   codec: cPersonCodec,
-  uniques: uniques27,
+  uniques: c_personUniques,
   isVirtual: false,
   description: "Person test comment",
   extensions: {
@@ -3381,17 +3381,17 @@ const registryConfig_pgResources_c_person_c_person = {
     tags: {}
   }
 };
-const sqlIdent122 = sql.identifier("c", "badly_behaved_function");
-const sqlIdent123 = sql.identifier("c", "func_out_table");
-const sqlIdent124 = sql.identifier("c", "func_out_table_setof");
-const sqlIdent125 = sql.identifier("c", "mutation_out_table");
-const sqlIdent126 = sql.identifier("c", "mutation_out_table_setof");
-const sqlIdent127 = sql.identifier("c", "table_set_mutation");
-const sqlIdent128 = sql.identifier("c", "table_set_query");
-const sqlIdent129 = sql.identifier("c", "table_set_query_plpgsql");
-const sqlIdent130 = sql.identifier("c", "person_computed_first_arg_inout");
-const sqlIdent131 = sql.identifier("c", "person_friends");
-const uniques28 = [{
+const badly_behaved_functionFunctionIdentifer = sql.identifier("c", "badly_behaved_function");
+const func_out_tableFunctionIdentifer = sql.identifier("c", "func_out_table");
+const func_out_table_setofFunctionIdentifer = sql.identifier("c", "func_out_table_setof");
+const mutation_out_tableFunctionIdentifer = sql.identifier("c", "mutation_out_table");
+const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_out_table_setof");
+const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
+const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
+const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
+const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
+const b_typesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -3400,12 +3400,12 @@ const uniques28 = [{
   }
 }];
 const registryConfig_pgResources_b_types_b_types = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "b_types",
   identifier: "main.b.types",
   from: bTypesCodec.sqlType,
   codec: bTypesCodec,
-  uniques: uniques28,
+  uniques: b_typesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -3420,15 +3420,15 @@ const registryConfig_pgResources_b_types_b_types = {
     }
   }
 };
-const sqlIdent132 = sql.identifier("b", "type_function_connection");
-const sqlIdent133 = sql.identifier("b", "type_function_connection_mutation");
-const sqlIdent134 = sql.identifier("b", "type_function");
-const sqlIdent135 = sql.identifier("b", "type_function_mutation");
-const sqlIdent136 = sql.identifier("c", "person_type_function_connection");
-const sqlIdent137 = sql.identifier("c", "person_type_function");
-const sqlIdent138 = sql.identifier("b", "type_function_list");
-const sqlIdent139 = sql.identifier("b", "type_function_list_mutation");
-const sqlIdent140 = sql.identifier("c", "person_type_function_list");
+const type_function_connectionFunctionIdentifer = sql.identifier("b", "type_function_connection");
+const type_function_connection_mutationFunctionIdentifer = sql.identifier("b", "type_function_connection_mutation");
+const type_functionFunctionIdentifer = sql.identifier("b", "type_function");
+const type_function_mutationFunctionIdentifer = sql.identifier("b", "type_function_mutation");
+const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
+const person_type_functionFunctionIdentifer = sql.identifier("c", "person_type_function");
+const type_function_listFunctionIdentifer = sql.identifier("b", "type_function_list");
+const type_function_list_mutationFunctionIdentifer = sql.identifier("b", "type_function_list_mutation");
+const person_type_function_listFunctionIdentifer = sql.identifier("c", "person_type_function_list");
 const registry = makeRegistry({
   pgCodecs: Object.assign(Object.create(null), {
     int4: TYPES.int,
@@ -3627,7 +3627,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3680,7 +3680,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3742,16 +3742,16 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
     c_current_user_id: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
+        return sql`${current_user_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3771,11 +3771,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out",
       identifier: "main.c.func_out(int4)",
       from(...args) {
-        return sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
+        return sql`${func_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3796,11 +3796,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_setof",
       identifier: "main.c.func_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3821,11 +3821,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_unnamed",
       identifier: "main.c.func_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3845,11 +3845,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out",
       identifier: "main.c.mutation_out(int4)",
       from(...args) {
-        return sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3870,11 +3870,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_setof",
       identifier: "main.c.mutation_out_setof(int4)",
       from(...args) {
-        return sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -3895,11 +3895,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_unnamed",
       identifier: "main.c.mutation_out_unnamed(int4)",
       from(...args) {
-        return sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3919,11 +3919,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_no_args_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_no_args_mutation",
       identifier: "main.c.no_args_mutation()",
       from(...args) {
-        return sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3943,11 +3943,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_no_args_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_no_args_query",
       identifier: "main.c.no_args_query()",
       from(...args) {
-        return sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
+        return sql`${no_args_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3967,11 +3967,11 @@ const registry = makeRegistry({
       description: undefined
     },
     return_void_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "return_void_mutation",
       identifier: "main.a.return_void_mutation()",
       from(...args) {
-        return sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
+        return sql`${return_void_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -3991,11 +3991,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_set",
       identifier: "main.a.mutation_interval_set()",
       from(...args) {
-        return sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4015,11 +4015,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_set",
       identifier: "main.a.query_interval_set()",
       from(...args) {
-        return sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4039,11 +4039,11 @@ const registry = makeRegistry({
       description: undefined
     },
     static_big_integer: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "static_big_integer",
       identifier: "main.a.static_big_integer()",
       from(...args) {
-        return sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
+        return sql`${static_big_integerFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4063,11 +4063,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_in_out",
       identifier: "main.c.func_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4093,11 +4093,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_returns_table_one_col",
       identifier: "main.c.func_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4123,11 +4123,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_in_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_in_out",
       identifier: "main.c.mutation_in_out(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4153,11 +4153,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_returns_table_one_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_returns_table_one_col",
       identifier: "main.c.mutation_returns_table_one_col(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_one_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4183,11 +4183,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something",
       identifier: "main.a.assert_something(text)",
       from(...args) {
-        return sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_somethingFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4212,11 +4212,11 @@ const registry = makeRegistry({
       description: undefined
     },
     assert_something_nx: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "assert_something_nx",
       identifier: "main.a.assert_something_nx(text)",
       from(...args) {
-        return sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
+        return sql`${assert_something_nxFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "in_arg",
@@ -4242,11 +4242,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_json_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_json_identity",
       identifier: "main.c.json_identity(json)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4271,11 +4271,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_json_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_json_identity_mutation",
       identifier: "main.c.json_identity_mutation(json)",
       from(...args) {
-        return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+        return sql`${json_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4300,11 +4300,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_jsonb_identity: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_jsonb_identity",
       identifier: "main.c.jsonb_identity(jsonb)",
       from(...args) {
-        return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4329,11 +4329,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_jsonb_identity_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_jsonb_identity_mutation",
       identifier: "main.c.jsonb_identity_mutation(jsonb)",
       from(...args) {
-        return sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "json",
@@ -4358,11 +4358,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_jsonb_identity_mutation_plpgsql",
       identifier: "main.c.jsonb_identity_mutation_plpgsql(jsonb)",
       from(...args) {
-        return sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4387,11 +4387,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql_with_default: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_jsonb_identity_mutation_plpgsql_with_default",
       identifier: "main.c.jsonb_identity_mutation_plpgsql_with_default(jsonb)",
       from(...args) {
-        return sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
+        return sql`${jsonb_identity_mutation_plpgsql_with_defaultFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "_the_json",
@@ -4416,11 +4416,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_1_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_mutation",
       identifier: "main.a.add_1_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4450,11 +4450,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_1_query",
       identifier: "main.a.add_1_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
+        return sql`${add_1_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4484,11 +4484,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_mutation",
       identifier: "main.a.add_2_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4518,11 +4518,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_2_query",
       identifier: "main.a.add_2_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
+        return sql`${add_2_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4552,11 +4552,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_mutation",
       identifier: "main.a.add_3_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4586,11 +4586,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_3_query",
       identifier: "main.a.add_3_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
+        return sql`${add_3_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -4620,11 +4620,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation",
       identifier: "main.a.add_4_mutation(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4654,11 +4654,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_mutation_error",
       identifier: "main.a.add_4_mutation_error(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_mutation_errorFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4688,11 +4688,11 @@ const registry = makeRegistry({
       description: undefined
     },
     add_4_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "add_4_query",
       identifier: "main.a.add_4_query(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
+        return sql`${add_4_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -4722,11 +4722,11 @@ const registry = makeRegistry({
       description: "lol, add some stuff 4 query"
     },
     b_mult_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_mult_1",
       identifier: "main.b.mult_1(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4756,11 +4756,11 @@ const registry = makeRegistry({
       description: undefined
     },
     b_mult_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_mult_2",
       identifier: "main.b.mult_2(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4790,11 +4790,11 @@ const registry = makeRegistry({
       description: undefined
     },
     b_mult_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_mult_3",
       identifier: "main.b.mult_3(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4824,11 +4824,11 @@ const registry = makeRegistry({
       description: undefined
     },
     b_mult_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_mult_4",
       identifier: "main.b.mult_4(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
+        return sql`${mult_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: null,
@@ -4858,11 +4858,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_in_inout",
       identifier: "main.c.func_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
+        return sql`${func_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -4893,11 +4893,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_out",
       identifier: "main.c.func_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4917,11 +4917,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_out_setof",
       identifier: "main.c.func_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -4941,11 +4941,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_out_unnamed",
       identifier: "main.c.func_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -4965,11 +4965,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_in_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_in_inout",
       identifier: "main.c.mutation_in_inout(int4,int4)",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_in_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5000,11 +5000,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_out",
       identifier: "main.c.mutation_out_out(int4,text)",
       from(...args) {
-        return sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5024,11 +5024,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_out_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_out_setof",
       identifier: "main.c.mutation_out_out_setof(int4,text)",
       from(...args) {
-        return sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5048,11 +5048,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_out_unnamed",
       identifier: "main.c.mutation_out_out_unnamed(int4,text)",
       from(...args) {
-        return sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5072,11 +5072,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_search_test_summaries: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_search_test_summaries",
       identifier: "main.c.search_test_summaries(int4,interval)",
       from(...args) {
-        return sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+        return sql`${search_test_summariesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !true,
@@ -5097,11 +5097,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_1",
       identifier: "main.a.optional_missing_middle_1(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5136,11 +5136,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_2",
       identifier: "main.a.optional_missing_middle_2(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5175,11 +5175,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_3: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_3",
       identifier: "main.a.optional_missing_middle_3(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5214,11 +5214,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_4: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_4",
       identifier: "main.a.optional_missing_middle_4(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "",
@@ -5253,11 +5253,11 @@ const registry = makeRegistry({
       description: undefined
     },
     optional_missing_middle_5: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "optional_missing_middle_5",
       identifier: "main.a.optional_missing_middle_5(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+        return sql`${optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -5292,11 +5292,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_unnamed_out_out_unnamed",
       identifier: "main.c.func_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5316,11 +5316,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_returns_table_multi_col",
       identifier: "main.c.func_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+        return sql`${func_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5345,11 +5345,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_int_set_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_int_set_mutation",
       identifier: "main.c.int_set_mutation(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5384,11 +5384,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_int_set_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_int_set_query",
       identifier: "main.c.int_set_query(int4,int4,int4)",
       from(...args) {
-        return sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+        return sql`${int_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "x",
@@ -5423,11 +5423,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_unnamed_out_out_unnamed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_unnamed_out_out_unnamed",
       identifier: "main.c.mutation_out_unnamed_out_out_unnamed(int4,text,int4)",
       from(...args) {
-        return sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_unnamed_out_out_unnamedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5447,11 +5447,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_returns_table_multi_col: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_returns_table_multi_col",
       identifier: "main.c.mutation_returns_table_multi_col(int4,int4,text)",
       from(...args) {
-        return sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_returns_table_multi_colFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i",
@@ -5476,11 +5476,11 @@ const registry = makeRegistry({
       description: undefined
     },
     b_guid_fn: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_guid_fn",
       identifier: "main.b.guid_fn(b.guid)",
       from(...args) {
-        return sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+        return sql`${guid_fnFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "g",
@@ -5505,11 +5505,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_interval_array",
       identifier: "main.a.mutation_interval_array()",
       from(...args) {
-        return sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5529,11 +5529,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_interval_array",
       identifier: "main.a.query_interval_array()",
       from(...args) {
-        return sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+        return sql`${query_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5553,11 +5553,11 @@ const registry = makeRegistry({
       description: undefined
     },
     mutation_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "mutation_text_array",
       identifier: "main.a.mutation_text_array()",
       from(...args) {
-        return sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5577,11 +5577,11 @@ const registry = makeRegistry({
       description: undefined
     },
     query_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "query_text_array",
       identifier: "main.a.query_text_array()",
       from(...args) {
-        return sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+        return sql`${query_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
@@ -5601,7 +5601,7 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
       from: nonUpdatableViewCodec.sqlType,
@@ -5622,12 +5622,12 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "inputs",
       identifier: "main.a.inputs",
       from: inputsCodec.sqlType,
       codec: inputsCodec,
-      uniques: uniques2,
+      uniques: inputsUniques,
       isVirtual: false,
       description: "Should output as Input",
       extensions: {
@@ -5641,12 +5641,12 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "patchs",
       identifier: "main.a.patchs",
       from: patchsCodec.sqlType,
       codec: patchsCodec,
-      uniques: uniques3,
+      uniques: patchsUniques,
       isVirtual: false,
       description: "Should output as Patch",
       extensions: {
@@ -5660,12 +5660,12 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved",
       identifier: "main.a.reserved",
       from: reservedCodec.sqlType,
       codec: reservedCodec,
-      uniques: uniques4,
+      uniques: reservedUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5679,12 +5679,12 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
       from: reservedPatchsCodec.sqlType,
       codec: reservedPatchsCodec,
-      uniques: uniques5,
+      uniques: reservedPatchsUniques,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
       extensions: {
@@ -5698,12 +5698,12 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
       from: reservedInputCodec.sqlType,
       codec: reservedInputCodec,
-      uniques: uniques6,
+      uniques: reserved_inputUniques,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
       extensions: {
@@ -5717,12 +5717,12 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "default_value",
       identifier: "main.a.default_value",
       from: defaultValueCodec.sqlType,
       codec: defaultValueCodec,
-      uniques: uniques7,
+      uniques: default_valueUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5737,7 +5737,7 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
       from: noPrimaryKeyCodec.sqlType,
@@ -5763,7 +5763,7 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "testview",
       identifier: "main.a.testview",
       from: testviewCodec.sqlType,
@@ -5783,12 +5783,12 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     c_my_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_my_table",
       identifier: "main.c.my_table",
       from: cMyTableCodec.sqlType,
       codec: cMyTableCodec,
-      uniques: uniques12,
+      uniques: c_my_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5803,12 +5803,12 @@ const registry = makeRegistry({
     },
     c_person_secret: registryConfig_pgResources_c_person_secret_c_person_secret,
     view_table: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "view_table",
       identifier: "main.a.view_table",
       from: viewTableCodec.sqlType,
       codec: viewTableCodec,
-      uniques: uniques14,
+      uniques: view_tableUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5822,7 +5822,7 @@ const registry = makeRegistry({
       }
     },
     b_updatable_view: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_updatable_view",
       identifier: "main.b.updatable_view",
       from: bUpdatableViewCodec.sqlType,
@@ -5844,12 +5844,12 @@ const registry = makeRegistry({
     },
     c_compound_key: registryConfig_pgResources_c_compound_key_c_compound_key,
     similar_table_1: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
       from: similarTable1Codec.sqlType,
       codec: similarTable1Codec,
-      uniques: uniques17,
+      uniques: similar_table_1Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5863,12 +5863,12 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
       from: similarTable2Codec.sqlType,
       codec: similarTable2Codec,
-      uniques: uniques18,
+      uniques: similar_table_2Uniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5882,12 +5882,12 @@ const registry = makeRegistry({
       }
     },
     c_null_test_record: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_null_test_record",
       identifier: "main.c.null_test_record",
       from: cNullTestRecordCodec.sqlType,
       codec: cNullTestRecordCodec,
-      uniques: uniques19,
+      uniques: c_null_test_recordUniques,
       isVirtual: false,
       description: undefined,
       extensions: {
@@ -5901,11 +5901,11 @@ const registry = makeRegistry({
       }
     },
     c_edge_case_computed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_edge_case_computed",
       identifier: "main.c.edge_case_computed(c.edge_case)",
       from(...args) {
-        return sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+        return sql`${edge_case_computedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "edge_case",
@@ -5933,7 +5933,7 @@ const registry = makeRegistry({
       name: "c_return_table_without_grants",
       identifier: "main.c.return_table_without_grants()",
       from(...args) {
-        return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+        return sql`${return_table_without_grantsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -5952,11 +5952,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     b_list_bde_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_list_bde_mutation",
       identifier: "main.b.list_bde_mutation(_text,text,text)",
       from(...args) {
-        return sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+        return sql`${list_bde_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "b",
@@ -5991,7 +5991,7 @@ const registry = makeRegistry({
       description: undefined
     },
     c_edge_case: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_edge_case",
       identifier: "main.c.edge_case",
       from: cEdgeCaseCodec.sqlType,
@@ -6014,7 +6014,7 @@ const registry = makeRegistry({
       name: "b_authenticate_fail",
       identifier: "main.b.authenticate_fail()",
       from(...args) {
-        return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_failFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6036,7 +6036,7 @@ const registry = makeRegistry({
       name: "b_authenticate",
       identifier: "main.b.authenticate(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticateFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6074,7 +6074,7 @@ const registry = makeRegistry({
       name: "c_left_arm_identity",
       identifier: "main.c.left_arm_identity(c.left_arm)",
       from(...args) {
-        return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+        return sql`${left_arm_identityFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm",
@@ -6106,7 +6106,7 @@ const registry = makeRegistry({
       name: "c_issue756_mutation",
       identifier: "main.c.issue756_mutation()",
       from(...args) {
-        return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6128,7 +6128,7 @@ const registry = makeRegistry({
       name: "c_issue756_set_mutation",
       identifier: "main.c.issue756_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+        return sql`${issue756_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6150,7 +6150,7 @@ const registry = makeRegistry({
       name: "b_authenticate_many",
       identifier: "main.b.authenticate_many(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6184,7 +6184,7 @@ const registry = makeRegistry({
       description: undefined
     }),
     b_authenticate_payload: PgResource.functionResourceOptions({
-      executor: executor_mainPgExecutor,
+      executor,
       name: "b_auth_payload",
       identifier: "main.b.auth_payload",
       from: bAuthPayloadCodec.sqlType,
@@ -6208,7 +6208,7 @@ const registry = makeRegistry({
       name: "b_authenticate_payload",
       identifier: "main.b.authenticate_payload(int4,numeric,int8)",
       from(...args) {
-        return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+        return sql`${authenticate_payloadFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6242,11 +6242,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     c_types_mutation: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_types_mutation",
       identifier: "main.c.types_mutation(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+        return sql`${types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6296,11 +6296,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_types_query: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_types_query",
       identifier: "main.c.types_query(int8,bool,varchar,_int4,json,c.floatrange)",
       from(...args) {
-        return sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+        return sql`${types_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -6350,11 +6350,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_compound_type_computed_field: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_compound_type_computed_field",
       identifier: "main.c.compound_type_computed_field(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_computed_fieldFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "compound_type",
@@ -6379,11 +6379,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_set: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_set",
       identifier: "main.a.post_computed_interval_set(a.post)",
       from(...args) {
-        return sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_setFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6408,11 +6408,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_interval_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_interval_array",
       identifier: "main.a.post_computed_interval_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_interval_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6437,11 +6437,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_text_array: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_text_array",
       identifier: "main.a.post_computed_text_array(a.post)",
       from(...args) {
-        return sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_text_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6466,11 +6466,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_optional_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_optional_arg",
       identifier: "main.a.post_computed_with_optional_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_optional_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6502,11 +6502,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_computed_with_required_arg: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_computed_with_required_arg",
       identifier: "main.a.post_computed_with_required_arg(a.post,int4)",
       from(...args) {
-        return sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_with_required_argFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6538,11 +6538,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_out_compound_type",
       identifier: "main.c.func_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6567,11 +6567,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_out_compound_type: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_out_compound_type",
       identifier: "main.c.mutation_out_out_compound_type(int4,int4,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_out_compound_typeFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "i1",
@@ -6596,11 +6596,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed",
       identifier: "main.a.post_headline_trimmed(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmedFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6635,11 +6635,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_no_defaults",
       identifier: "main.a.post_headline_trimmed_no_defaults(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_no_defaultsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6674,11 +6674,11 @@ const registry = makeRegistry({
       description: undefined
     },
     post_headline_trimmed_strict: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "post_headline_trimmed_strict",
       identifier: "main.a.post_headline_trimmed_strict(a.post,int4,text)",
       from(...args) {
-        return sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+        return sql`${post_headline_trimmed_strictFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6713,11 +6713,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_query_output_two_rows: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_query_output_two_rows",
       identifier: "main.c.query_output_two_rows(int4,int4,text,c.left_arm,a.post)",
       from(...args) {
-        return sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+        return sql`${query_output_two_rowsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "left_arm_id",
@@ -6756,7 +6756,7 @@ const registry = makeRegistry({
       name: "c_compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
-        return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -6778,7 +6778,7 @@ const registry = makeRegistry({
       name: "b_compound_type_mutation",
       identifier: "main.b.compound_type_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6805,7 +6805,7 @@ const registry = makeRegistry({
       name: "b_compound_type_query",
       identifier: "main.b.compound_type_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6832,7 +6832,7 @@ const registry = makeRegistry({
       name: "b_compound_type_set_mutation",
       identifier: "main.b.compound_type_set_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6859,7 +6859,7 @@ const registry = makeRegistry({
       name: "c_table_mutation",
       identifier: "main.c.table_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+        return sql`${table_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6886,7 +6886,7 @@ const registry = makeRegistry({
       name: "c_table_query",
       identifier: "main.c.table_query(int4)",
       from(...args) {
-        return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+        return sql`${table_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -6913,7 +6913,7 @@ const registry = makeRegistry({
       name: "post_with_suffix",
       identifier: "main.a.post_with_suffix(a.post,text)",
       from(...args) {
-        return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+        return sql`${post_with_suffixFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -6946,7 +6946,7 @@ const registry = makeRegistry({
       name: "mutation_compound_type_array",
       identifier: "main.a.mutation_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -6973,7 +6973,7 @@ const registry = makeRegistry({
       name: "query_compound_type_array",
       identifier: "main.a.query_compound_type_array(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+        return sql`${query_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7000,7 +7000,7 @@ const registry = makeRegistry({
       name: "b_compound_type_array_mutation",
       identifier: "main.b.compound_type_array_mutation(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7027,7 +7027,7 @@ const registry = makeRegistry({
       name: "b_compound_type_array_query",
       identifier: "main.b.compound_type_array_query(c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+        return sql`${compound_type_array_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "object",
@@ -7054,7 +7054,7 @@ const registry = makeRegistry({
       name: "post_computed_compound_type_array",
       identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
       from(...args) {
-        return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+        return sql`${post_computed_compound_type_arrayFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "post",
@@ -7086,7 +7086,7 @@ const registry = makeRegistry({
       name: "post_many",
       identifier: "main.a.post_many(a._post)",
       from(...args) {
-        return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+        return sql`${post_manyFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "posts",
@@ -7110,11 +7110,11 @@ const registry = makeRegistry({
       description: undefined
     }),
     c_person_computed_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_out",
       identifier: "main.c.person_computed_out(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7143,11 +7143,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_first_name: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_first_name",
       identifier: "main.c.person_first_name(c.person)",
       from(...args) {
-        return sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_nameFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7173,11 +7173,11 @@ const registry = makeRegistry({
       description: "The first name of the person."
     },
     c_person_computed_out_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_out_out",
       identifier: "main.c.person_computed_out_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_out_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7202,11 +7202,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_computed_inout: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_inout",
       identifier: "main.c.person_computed_inout(c.person,text)",
       from(...args) {
-        return sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7237,11 +7237,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_computed_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_inout_out",
       identifier: "main.c.person_computed_inout_out(c.person,text,text)",
       from(...args) {
-        return sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7271,11 +7271,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_exists: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_exists",
       identifier: "main.c.person_exists(c.person,b.email)",
       from(...args) {
-        return sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+        return sql`${person_existsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7306,11 +7306,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_computed_first_arg_inout_out: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_first_arg_inout_out",
       identifier: "main.c.person_computed_first_arg_inout_out(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inout_outFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7335,11 +7335,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_complex",
       identifier: "main.c.func_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7369,11 +7369,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_func_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_func_out_complex_setof",
       identifier: "main.c.func_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7403,11 +7403,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_complex",
       identifier: "main.c.mutation_out_complex(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7437,11 +7437,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_mutation_out_complex_setof: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_mutation_out_complex_setof",
       identifier: "main.c.mutation_out_complex_setof(int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_complex_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "a",
@@ -7471,11 +7471,11 @@ const registry = makeRegistry({
       description: undefined
     },
     c_person_computed_complex: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "c_person_computed_complex",
       identifier: "main.c.person_computed_complex(c.person,int4,text,int4,c.compound_type,c.person)",
       from(...args) {
-        return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_complexFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7513,7 +7513,7 @@ const registry = makeRegistry({
       name: "c_person_first_post",
       identifier: "main.c.person_first_post(c.person)",
       from(...args) {
-        return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+        return sql`${person_first_postFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7541,7 +7541,7 @@ const registry = makeRegistry({
       name: "c_badly_behaved_function",
       identifier: "main.c.badly_behaved_function()",
       from(...args) {
-        return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+        return sql`${badly_behaved_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7564,7 +7564,7 @@ const registry = makeRegistry({
       name: "c_func_out_table",
       identifier: "main.c.func_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7586,7 +7586,7 @@ const registry = makeRegistry({
       name: "c_func_out_table_setof",
       identifier: "main.c.func_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+        return sql`${func_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7608,7 +7608,7 @@ const registry = makeRegistry({
       name: "c_mutation_out_table",
       identifier: "main.c.mutation_out_table(c.person)",
       from(...args) {
-        return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_tableFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7630,7 +7630,7 @@ const registry = makeRegistry({
       name: "c_mutation_out_table_setof",
       identifier: "main.c.mutation_out_table_setof(c.person)",
       from(...args) {
-        return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+        return sql`${mutation_out_table_setofFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7652,7 +7652,7 @@ const registry = makeRegistry({
       name: "c_table_set_mutation",
       identifier: "main.c.table_set_mutation()",
       from(...args) {
-        return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7674,7 +7674,7 @@ const registry = makeRegistry({
       name: "c_table_set_query",
       identifier: "main.c.table_set_query()",
       from(...args) {
-        return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_queryFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7698,7 +7698,7 @@ const registry = makeRegistry({
       name: "c_table_set_query_plpgsql",
       identifier: "main.c.table_set_query_plpgsql()",
       from(...args) {
-        return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+        return sql`${table_set_query_plpgsqlFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7720,7 +7720,7 @@ const registry = makeRegistry({
       name: "c_person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
       from(...args) {
-        return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+        return sql`${person_computed_first_arg_inoutFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7748,7 +7748,7 @@ const registry = makeRegistry({
       name: "c_person_friends",
       identifier: "main.c.person_friends(c.person)",
       from(...args) {
-        return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+        return sql`${person_friendsFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "person",
@@ -7777,7 +7777,7 @@ const registry = makeRegistry({
       name: "b_type_function_connection",
       identifier: "main.b.type_function_connection()",
       from(...args) {
-        return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7799,7 +7799,7 @@ const registry = makeRegistry({
       name: "b_type_function_connection_mutation",
       identifier: "main.b.type_function_connection_mutation()",
       from(...args) {
-        return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_connection_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -7821,7 +7821,7 @@ const registry = makeRegistry({
       name: "b_type_function",
       identifier: "main.b.type_function(int4)",
       from(...args) {
-        return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+        return sql`${type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7848,7 +7848,7 @@ const registry = makeRegistry({
       name: "b_type_function_mutation",
       identifier: "main.b.type_function_mutation(int4)",
       from(...args) {
-        return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -7875,7 +7875,7 @@ const registry = makeRegistry({
       name: "c_person_type_function_connection",
       identifier: "main.c.person_type_function_connection(c.person)",
       from(...args) {
-        return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_connectionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7902,7 +7902,7 @@ const registry = makeRegistry({
       name: "c_person_type_function",
       identifier: "main.c.person_type_function(c.person,int4)",
       from(...args) {
-        return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_functionFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -7934,7 +7934,7 @@ const registry = makeRegistry({
       name: "b_type_function_list",
       identifier: "main.b.type_function_list()",
       from(...args) {
-        return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -7956,7 +7956,7 @@ const registry = makeRegistry({
       name: "b_type_function_list_mutation",
       identifier: "main.b.type_function_list_mutation()",
       from(...args) {
-        return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+        return sql`${type_function_list_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: true,
@@ -7978,7 +7978,7 @@ const registry = makeRegistry({
       name: "c_person_type_function_list",
       identifier: "main.c.person_type_function_list(c.person)",
       from(...args) {
-        return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+        return sql`${person_type_function_listFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "p",
@@ -29015,7 +29015,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        b_typesUniques[0].attributes.forEach(attributeName => {
           const attribute = bTypesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29031,7 +29031,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques28[0].attributes.forEach(attributeName => {
+        b_typesUniques[0].attributes.forEach(attributeName => {
           const attribute = bTypesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30995,7 +30995,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31011,7 +31011,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques25[0].attributes.forEach(attributeName => {
+        postUniques[0].attributes.forEach(attributeName => {
           const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31547,7 +31547,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        c_compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = cCompoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31563,7 +31563,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        c_compound_keyUniques[0].attributes.forEach(attributeName => {
           const attribute = cCompoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32354,7 +32354,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32370,7 +32370,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        inputsUniques[0].attributes.forEach(attributeName => {
           const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32475,7 +32475,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32491,7 +32491,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        patchsUniques[0].attributes.forEach(attributeName => {
           const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32596,7 +32596,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32612,7 +32612,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        reservedUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32717,7 +32717,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32733,7 +32733,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        reservedPatchsUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32838,7 +32838,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32854,7 +32854,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        reserved_inputUniques[0].attributes.forEach(attributeName => {
           const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32959,7 +32959,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -32975,7 +32975,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        default_valueUniques[0].attributes.forEach(attributeName => {
           const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33644,7 +33644,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        c_my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = cMyTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33660,7 +33660,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        c_my_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = cMyTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33822,7 +33822,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        c_person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = cPersonSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -33838,7 +33838,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        c_person_secretUniques[0].attributes.forEach(attributeName => {
           const attribute = cPersonSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34000,7 +34000,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34016,7 +34016,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        view_tableUniques[0].attributes.forEach(attributeName => {
           const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34510,7 +34510,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34526,7 +34526,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        similar_table_1Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34802,7 +34802,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -34818,7 +34818,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        similar_table_2Uniques[0].attributes.forEach(attributeName => {
           const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35094,7 +35094,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        c_null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = cNullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35110,7 +35110,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        c_null_test_recordUniques[0].attributes.forEach(attributeName => {
           const attribute = cNullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35635,7 +35635,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        c_left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = cLeftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35651,7 +35651,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        c_left_armUniques[0].attributes.forEach(attributeName => {
           const attribute = cLeftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35927,7 +35927,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        c_issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = cIssue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -35943,7 +35943,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        c_issue756Uniques[0].attributes.forEach(attributeName => {
           const attribute = cIssue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36080,7 +36080,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        c_personUniques[0].attributes.forEach(attributeName => {
           const attribute = cPersonCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -36096,7 +36096,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques27[0].attributes.forEach(attributeName => {
+        c_personUniques[0].attributes.forEach(attributeName => {
           const attribute = cPersonCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -39586,7 +39586,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39668,7 +39668,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39912,7 +39912,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -39964,7 +39964,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40232,7 +40232,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40343,7 +40343,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = b_typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40415,7 +40415,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40482,7 +40482,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40549,7 +40549,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40616,7 +40616,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40683,7 +40683,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -40750,7 +40750,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41010,7 +41010,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41084,7 +41084,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41158,7 +41158,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41296,7 +41296,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41377,7 +41377,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41465,7 +41465,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41553,7 +41553,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41691,7 +41691,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41779,7 +41779,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41853,7 +41853,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -41911,7 +41911,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42057,7 +42057,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = b_typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42507,7 +42507,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42573,7 +42573,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42639,7 +42639,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42705,7 +42705,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42771,7 +42771,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42837,7 +42837,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -42995,7 +42995,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43068,7 +43068,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43141,7 +43141,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43221,7 +43221,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43302,7 +43302,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43389,7 +43389,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43476,7 +43476,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43563,7 +43563,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43664,7 +43664,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43737,7 +43737,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43838,7 +43838,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -43988,7 +43988,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = b_typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44390,7 +44390,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = inputsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44441,7 +44441,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = patchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44492,7 +44492,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44543,7 +44543,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = reservedPatchsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44594,7 +44594,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = reserved_inputUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44645,7 +44645,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = default_valueUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44737,7 +44737,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques12[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_my_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44788,7 +44788,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques13[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_person_secretUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44839,7 +44839,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = view_tableUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44890,7 +44890,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_compound_keyUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44942,7 +44942,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques17[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_1Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -44993,7 +44993,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = similar_table_2Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45044,7 +45044,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_null_test_recordUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45095,7 +45095,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_left_armUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45154,7 +45154,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques23[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_issue756Uniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45205,7 +45205,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques25[0].attributes.reduce((memo, attributeName) => {
+            const spec = postUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45256,7 +45256,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques27[0].attributes.reduce((memo, attributeName) => {
+            const spec = c_personUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -45315,7 +45315,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques28[0].attributes.reduce((memo, attributeName) => {
+            const spec = b_typesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -371,8 +371,8 @@ const registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationRetur
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const sqlIdent = sql.identifier(...["b", "guid"]);
-const registryConfig_pgCodecs_bGuid_bGuid = domainOfCodec(TYPES.varchar, "bGuid", sqlIdent, {
+const bGuidIdentifier = sql.identifier(...["b", "guid"]);
+const bGuidCodec = domainOfCodec(TYPES.varchar, "bGuid", bGuidIdentifier, {
   description: undefined,
   extensions: {
     pg: {
@@ -384,7 +384,7 @@ const registryConfig_pgCodecs_bGuid_bGuid = domainOfCodec(TYPES.varchar, "bGuid"
   },
   notNull: false
 });
-const extensions2 = {
+const pgCatalogIntervalArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -392,13 +392,13 @@ const extensions2 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray = listOfCodec(TYPES.interval, {
-  extensions: extensions2,
+const pgCatalogIntervalArrayCodec = listOfCodec(TYPES.interval, {
+  extensions: pgCatalogIntervalArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogIntervalArray"
 });
-const extensions3 = {
+const pgCatalogTextArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -406,13 +406,13 @@ const extensions3 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray = listOfCodec(TYPES.text, {
-  extensions: extensions3,
+const pgCatalogTextArrayCodec = listOfCodec(TYPES.text, {
+  extensions: pgCatalogTextArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogTextArray"
 });
-const attributes12 = Object.assign(Object.create(null), {
+const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
   "?column?": {
     description: undefined,
     codec: TYPES.int,
@@ -423,7 +423,7 @@ const attributes12 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions4 = {
+const extensions2 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -433,17 +433,79 @@ const extensions4 = {
   tags: Object.create(null)
 };
 const parts2 = ["a", "non_updatable_view"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_nonUpdatableView = {
+const nonUpdatableViewIdentifier = sql.identifier(...parts2);
+const nonUpdatableViewCodecSpec = {
   name: "nonUpdatableView",
-  identifier: sqlIdent2,
-  attributes: attributes12,
+  identifier: nonUpdatableViewIdentifier,
+  attributes: nonUpdatableViewAttributes,
   description: undefined,
+  extensions: extensions2,
+  executor: executor_mainPgExecutor
+};
+const nonUpdatableViewCodec = recordCodec(nonUpdatableViewCodecSpec);
+const inputsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions3 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "inputs"
+  },
+  tags: Object.create(null)
+};
+const parts3 = ["a", "inputs"];
+const inputsIdentifier = sql.identifier(...parts3);
+const inputsCodecSpec = {
+  name: "inputs",
+  identifier: inputsIdentifier,
+  attributes: inputsAttributes,
+  description: "Should output as Input",
+  extensions: extensions3,
+  executor: executor_mainPgExecutor
+};
+const inputsCodec = recordCodec(inputsCodecSpec);
+const patchsAttributes = Object.assign(Object.create(null), {
+  id: {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }
+});
+const extensions4 = {
+  isTableLike: true,
+  pg: {
+    serviceName: "main",
+    schemaName: "a",
+    name: "patchs"
+  },
+  tags: Object.create(null)
+};
+const parts4 = ["a", "patchs"];
+const patchsIdentifier = sql.identifier(...parts4);
+const patchsCodecSpec = {
+  name: "patchs",
+  identifier: patchsIdentifier,
+  attributes: patchsAttributes,
+  description: "Should output as Patch",
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView = recordCodec(spec_nonUpdatableView);
-const attributes13 = Object.assign(Object.create(null), {
+const patchsCodec = recordCodec(patchsCodecSpec);
+const reservedAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -459,22 +521,22 @@ const extensions5 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "inputs"
+    name: "reserved"
   },
   tags: Object.create(null)
 };
-const parts3 = ["a", "inputs"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_inputs = {
-  name: "inputs",
-  identifier: sqlIdent3,
-  attributes: attributes13,
-  description: "Should output as Input",
+const parts5 = ["a", "reserved"];
+const reservedIdentifier = sql.identifier(...parts5);
+const reservedCodecSpec = {
+  name: "reserved",
+  identifier: reservedIdentifier,
+  attributes: reservedAttributes,
+  description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_inputs_inputs = recordCodec(spec_inputs);
-const attributes14 = Object.assign(Object.create(null), {
+const reservedCodec = recordCodec(reservedCodecSpec);
+const reservedPatchsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -490,22 +552,22 @@ const extensions6 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "patchs"
+    name: "reservedPatchs"
   },
   tags: Object.create(null)
 };
-const parts4 = ["a", "patchs"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_patchs = {
-  name: "patchs",
-  identifier: sqlIdent4,
-  attributes: attributes14,
-  description: "Should output as Patch",
+const parts6 = ["a", "reservedPatchs"];
+const reservedPatchsIdentifier = sql.identifier(...parts6);
+const reservedPatchsCodecSpec = {
+  name: "reservedPatchs",
+  identifier: reservedPatchsIdentifier,
+  attributes: reservedPatchsAttributes,
+  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_patchs_patchs = recordCodec(spec_patchs);
-const attributes15 = Object.assign(Object.create(null), {
+const reservedPatchsCodec = recordCodec(reservedPatchsCodecSpec);
+const reservedInputAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -521,84 +583,22 @@ const extensions7 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
-    name: "reserved"
-  },
-  tags: Object.create(null)
-};
-const parts5 = ["a", "reserved"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_reserved = {
-  name: "reserved",
-  identifier: sqlIdent5,
-  attributes: attributes15,
-  description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reserved_reserved = recordCodec(spec_reserved);
-const attributes16 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "reservedPatchs"
-  },
-  tags: Object.create(null)
-};
-const parts6 = ["a", "reservedPatchs"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_reservedPatchs = {
-  name: "reservedPatchs",
-  identifier: sqlIdent6,
-  attributes: attributes16,
-  description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-  extensions: extensions8,
-  executor: executor_mainPgExecutor
-};
-const registryConfig_pgCodecs_reservedPatchs_reservedPatchs = recordCodec(spec_reservedPatchs);
-const attributes17 = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
     name: "reserved_input"
   },
   tags: Object.create(null)
 };
 const parts7 = ["a", "reserved_input"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_reservedInput = {
+const reservedInputIdentifier = sql.identifier(...parts7);
+const reservedInputCodecSpec = {
   name: "reservedInput",
-  identifier: sqlIdent7,
-  attributes: attributes17,
+  identifier: reservedInputIdentifier,
+  attributes: reservedInputAttributes,
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-  extensions: extensions9,
+  extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_reservedInput_reservedInput = recordCodec(spec_reservedInput);
-const attributes18 = Object.assign(Object.create(null), {
+const reservedInputCodec = recordCodec(reservedInputCodecSpec);
+const defaultValueAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -618,7 +618,7 @@ const attributes18 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions10 = {
+const extensions8 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -628,17 +628,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts8 = ["a", "default_value"];
-const sqlIdent8 = sql.identifier(...parts8);
-const spec_defaultValue = {
+const defaultValueIdentifier = sql.identifier(...parts8);
+const defaultValueCodecSpec = {
   name: "defaultValue",
-  identifier: sqlIdent8,
-  attributes: attributes18,
+  identifier: defaultValueIdentifier,
+  attributes: defaultValueAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: extensions8,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_defaultValue_defaultValue = recordCodec(spec_defaultValue);
-const attributes19 = Object.assign(Object.create(null), {
+const defaultValueCodec = recordCodec(defaultValueCodecSpec);
+const foreignKeyAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -667,7 +667,7 @@ const attributes19 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
+const extensions9 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -677,17 +677,17 @@ const extensions11 = {
   tags: Object.create(null)
 };
 const parts9 = ["a", "foreign_key"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_foreignKey = {
+const foreignKeyIdentifier = sql.identifier(...parts9);
+const foreignKeyCodecSpec = {
   name: "foreignKey",
-  identifier: sqlIdent9,
-  attributes: attributes19,
+  identifier: foreignKeyIdentifier,
+  attributes: foreignKeyAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_foreignKey_foreignKey = recordCodec(spec_foreignKey);
-const attributes20 = Object.assign(Object.create(null), {
+const foreignKeyCodec = recordCodec(foreignKeyCodecSpec);
+const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -707,7 +707,7 @@ const attributes20 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions12 = {
+const extensions10 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -717,17 +717,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts10 = ["a", "no_primary_key"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_noPrimaryKey = {
+const noPrimaryKeyIdentifier = sql.identifier(...parts10);
+const noPrimaryKeyCodecSpec = {
   name: "noPrimaryKey",
-  identifier: sqlIdent10,
-  attributes: attributes20,
+  identifier: noPrimaryKeyIdentifier,
+  attributes: noPrimaryKeyAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey = recordCodec(spec_noPrimaryKey);
-const attributes21 = Object.assign(Object.create(null), {
+const noPrimaryKeyCodec = recordCodec(noPrimaryKeyCodecSpec);
+const testviewAttributes = Object.assign(Object.create(null), {
   testviewid: {
     description: undefined,
     codec: TYPES.int,
@@ -756,7 +756,7 @@ const attributes21 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
+const extensions11 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -766,17 +766,17 @@ const extensions13 = {
   tags: Object.create(null)
 };
 const parts11 = ["a", "testview"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_testview = {
+const testviewIdentifier = sql.identifier(...parts11);
+const testviewCodecSpec = {
   name: "testview",
-  identifier: sqlIdent11,
-  attributes: attributes21,
+  identifier: testviewIdentifier,
+  attributes: testviewAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_testview_testview = recordCodec(spec_testview);
-const attributes22 = Object.assign(Object.create(null), {
+const testviewCodec = recordCodec(testviewCodecSpec);
+const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
   compound_key_1: {
     description: undefined,
     codec: TYPES.int,
@@ -796,7 +796,7 @@ const attributes22 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
+const extensions12 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -808,17 +808,17 @@ const extensions14 = {
   })
 };
 const parts12 = ["a", "unique_foreign_key"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_uniqueForeignKey = {
+const uniqueForeignKeyIdentifier = sql.identifier(...parts12);
+const uniqueForeignKeyCodecSpec = {
   name: "uniqueForeignKey",
-  identifier: sqlIdent12,
-  attributes: attributes22,
+  identifier: uniqueForeignKeyIdentifier,
+  attributes: uniqueForeignKeyAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey = recordCodec(spec_uniqueForeignKey);
-const attributes23 = Object.assign(Object.create(null), {
+const uniqueForeignKeyCodec = recordCodec(uniqueForeignKeyCodecSpec);
+const cMyTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -838,7 +838,7 @@ const attributes23 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
+const extensions13 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -848,17 +848,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts13 = ["c", "my_table"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_cMyTable = {
+const cMyTableIdentifier = sql.identifier(...parts13);
+const cMyTableCodecSpec = {
   name: "cMyTable",
-  identifier: sqlIdent13,
-  attributes: attributes23,
+  identifier: cMyTableIdentifier,
+  attributes: cMyTableAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cMyTable_cMyTable = recordCodec(spec_cMyTable);
-const attributes24 = Object.assign(Object.create(null), {
+const cMyTableCodec = recordCodec(cMyTableCodecSpec);
+const cPersonSecretAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -880,7 +880,7 @@ const attributes24 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
+const extensions14 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -892,17 +892,17 @@ const extensions16 = {
   })
 };
 const parts14 = ["c", "person_secret"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_cPersonSecret = {
+const cPersonSecretIdentifier = sql.identifier(...parts14);
+const cPersonSecretCodecSpec = {
   name: "cPersonSecret",
-  identifier: sqlIdent14,
-  attributes: attributes24,
+  identifier: cPersonSecretIdentifier,
+  attributes: cPersonSecretAttributes,
   description: "Tracks the person's secret",
-  extensions: extensions16,
+  extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cPersonSecret_cPersonSecret = recordCodec(spec_cPersonSecret);
-const attributes25 = Object.assign(Object.create(null), {
+const cPersonSecretCodec = recordCodec(cPersonSecretCodecSpec);
+const viewTableAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -931,7 +931,7 @@ const attributes25 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions17 = {
+const extensions15 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -941,17 +941,17 @@ const extensions17 = {
   tags: Object.create(null)
 };
 const parts15 = ["a", "view_table"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_viewTable = {
+const viewTableIdentifier = sql.identifier(...parts15);
+const viewTableCodecSpec = {
   name: "viewTable",
-  identifier: sqlIdent15,
-  attributes: attributes25,
+  identifier: viewTableIdentifier,
+  attributes: viewTableAttributes,
   description: undefined,
-  extensions: extensions17,
+  extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_viewTable_viewTable = recordCodec(spec_viewTable);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const viewTableCodec = recordCodec(viewTableCodecSpec);
+const bUpdatableViewAttributes = Object.assign(Object.create(null), {
   x: {
     description: undefined,
     codec: TYPES.int,
@@ -989,7 +989,7 @@ const attributes_object_Object_ = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
+const extensions16 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1001,17 +1001,17 @@ const extensions18 = {
   })
 };
 const parts16 = ["b", "updatable_view"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_bUpdatableView = {
+const bUpdatableViewIdentifier = sql.identifier(...parts16);
+const bUpdatableViewCodecSpec = {
   name: "bUpdatableView",
-  identifier: sqlIdent16,
-  attributes: attributes_object_Object_,
+  identifier: bUpdatableViewIdentifier,
+  attributes: bUpdatableViewAttributes,
   description: "YOYOYO!!",
-  extensions: extensions18,
+  extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_bUpdatableView_bUpdatableView = recordCodec(spec_bUpdatableView);
-const attributes26 = Object.assign(Object.create(null), {
+const bUpdatableViewCodec = recordCodec(bUpdatableViewCodecSpec);
+const cCompoundKeyAttributes = Object.assign(Object.create(null), {
   person_id_2: {
     description: undefined,
     codec: TYPES.int,
@@ -1040,7 +1040,7 @@ const attributes26 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions19 = {
+const extensions17 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1050,17 +1050,17 @@ const extensions19 = {
   tags: Object.create(null)
 };
 const parts17 = ["c", "compound_key"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_cCompoundKey = {
+const cCompoundKeyIdentifier = sql.identifier(...parts17);
+const cCompoundKeyCodecSpec = {
   name: "cCompoundKey",
-  identifier: sqlIdent17,
-  attributes: attributes26,
+  identifier: cCompoundKeyIdentifier,
+  attributes: cCompoundKeyAttributes,
   description: undefined,
-  extensions: extensions19,
+  extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cCompoundKey_cCompoundKey = recordCodec(spec_cCompoundKey);
-const attributes27 = Object.assign(Object.create(null), {
+const cCompoundKeyCodec = recordCodec(cCompoundKeyCodecSpec);
+const similarTable1Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1098,7 +1098,7 @@ const attributes27 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions20 = {
+const extensions18 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1108,17 +1108,17 @@ const extensions20 = {
   tags: Object.create(null)
 };
 const parts18 = ["a", "similar_table_1"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_similarTable1 = {
+const similarTable1Identifier = sql.identifier(...parts18);
+const similarTable1CodecSpec = {
   name: "similarTable1",
-  identifier: sqlIdent18,
-  attributes: attributes27,
+  identifier: similarTable1Identifier,
+  attributes: similarTable1Attributes,
   description: undefined,
-  extensions: extensions20,
+  extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable1_similarTable1 = recordCodec(spec_similarTable1);
-const attributes28 = Object.assign(Object.create(null), {
+const similarTable1Codec = recordCodec(similarTable1CodecSpec);
+const similarTable2Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1156,7 +1156,7 @@ const attributes28 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions21 = {
+const extensions19 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1166,17 +1166,17 @@ const extensions21 = {
   tags: Object.create(null)
 };
 const parts19 = ["a", "similar_table_2"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_similarTable2 = {
+const similarTable2Identifier = sql.identifier(...parts19);
+const similarTable2CodecSpec = {
   name: "similarTable2",
-  identifier: sqlIdent19,
-  attributes: attributes28,
+  identifier: similarTable2Identifier,
+  attributes: similarTable2Attributes,
   description: undefined,
-  extensions: extensions21,
+  extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_similarTable2_similarTable2 = recordCodec(spec_similarTable2);
-const attributes29 = Object.assign(Object.create(null), {
+const similarTable2Codec = recordCodec(similarTable2CodecSpec);
+const cNullTestRecordAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1214,7 +1214,7 @@ const attributes29 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions22 = {
+const extensions20 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1224,17 +1224,17 @@ const extensions22 = {
   tags: Object.create(null)
 };
 const parts20 = ["c", "null_test_record"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_cNullTestRecord = {
+const cNullTestRecordIdentifier = sql.identifier(...parts20);
+const cNullTestRecordCodecSpec = {
   name: "cNullTestRecord",
-  identifier: sqlIdent20,
-  attributes: attributes29,
+  identifier: cNullTestRecordIdentifier,
+  attributes: cNullTestRecordAttributes,
   description: undefined,
-  extensions: extensions22,
+  extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord = recordCodec(spec_cNullTestRecord);
-const extensions23 = {
+const cNullTestRecordCodec = recordCodec(cNullTestRecordCodecSpec);
+const pgCatalogUuidArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -1242,13 +1242,13 @@ const extensions23 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_pgCatalogUuidArray_pgCatalogUuidArray = listOfCodec(TYPES.uuid, {
-  extensions: extensions23,
+const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
+  extensions: pgCatalogUuidArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogUuidArray"
 });
-const attributes30 = Object.assign(Object.create(null), {
+const cEdgeCaseAttributes = Object.assign(Object.create(null), {
   not_null_has_default: {
     description: undefined,
     codec: TYPES.boolean,
@@ -1277,7 +1277,7 @@ const attributes30 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions24 = {
+const extensions21 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1287,17 +1287,17 @@ const extensions24 = {
   tags: Object.create(null)
 };
 const parts21 = ["c", "edge_case"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_cEdgeCase = {
+const cEdgeCaseIdentifier = sql.identifier(...parts21);
+const cEdgeCaseCodecSpec = {
   name: "cEdgeCase",
-  identifier: sqlIdent21,
-  attributes: attributes30,
+  identifier: cEdgeCaseIdentifier,
+  attributes: cEdgeCaseAttributes,
   description: undefined,
-  extensions: extensions24,
+  extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cEdgeCase_cEdgeCase = recordCodec(spec_cEdgeCase);
-const attributes31 = Object.assign(Object.create(null), {
+const cEdgeCaseCodec = recordCodec(cEdgeCaseCodecSpec);
+const cLeftArmAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1335,7 +1335,7 @@ const attributes31 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
+const extensions22 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1345,17 +1345,17 @@ const extensions25 = {
   tags: Object.create(null)
 };
 const parts22 = ["c", "left_arm"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_cLeftArm = {
+const cLeftArmIdentifier = sql.identifier(...parts22);
+const cLeftArmCodecSpec = {
   name: "cLeftArm",
-  identifier: sqlIdent22,
-  attributes: attributes31,
+  identifier: cLeftArmIdentifier,
+  attributes: cLeftArmAttributes,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions25,
+  extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cLeftArm_cLeftArm = recordCodec(spec_cLeftArm);
-const attributes32 = Object.assign(Object.create(null), {
+const cLeftArmCodec = recordCodec(cLeftArmCodecSpec);
+const bJwtTokenAttributes = Object.assign(Object.create(null), {
   role: {
     description: undefined,
     codec: TYPES.text,
@@ -1402,7 +1402,7 @@ const attributes32 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
+const extensions23 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1412,17 +1412,17 @@ const extensions26 = {
   tags: Object.create(null)
 };
 const parts23 = ["b", "jwt_token"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_bJwtToken = {
+const bJwtTokenIdentifier = sql.identifier(...parts23);
+const bJwtTokenCodecSpec = {
   name: "bJwtToken",
-  identifier: sqlIdent23,
-  attributes: attributes32,
+  identifier: bJwtTokenIdentifier,
+  attributes: bJwtTokenAttributes,
   description: undefined,
-  extensions: extensions26,
+  extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_bJwtToken_bJwtToken = recordCodec(spec_bJwtToken);
-const extensions27 = {
+const bJwtTokenCodec = recordCodec(bJwtTokenCodecSpec);
+const extensions24 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -1431,13 +1431,13 @@ const extensions27 = {
   tags: Object.create(null)
 };
 const parts24 = ["c", "not_null_timestamp"];
-const sqlIdent24 = sql.identifier(...parts24);
-const attributes_ts_codec_cNotNullTimestamp = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", sqlIdent24, {
+const cNotNullTimestampIdentifier = sql.identifier(...parts24);
+const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", cNotNullTimestampIdentifier, {
   description: undefined,
-  extensions: extensions27,
+  extensions: extensions24,
   notNull: true
 });
-const attributes33 = Object.assign(Object.create(null), {
+const cIssue756Attributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1449,7 +1449,7 @@ const attributes33 = Object.assign(Object.create(null), {
   },
   ts: {
     description: undefined,
-    codec: attributes_ts_codec_cNotNullTimestamp,
+    codec: cNotNullTimestampCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1457,7 +1457,7 @@ const attributes33 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions28 = {
+const extensions25 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1467,20 +1467,20 @@ const extensions28 = {
   tags: Object.create(null)
 };
 const parts25 = ["c", "issue756"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_cIssue756 = {
+const cIssue756Identifier = sql.identifier(...parts25);
+const cIssue756CodecSpec = {
   name: "cIssue756",
-  identifier: sqlIdent25,
-  attributes: attributes33,
+  identifier: cIssue756Identifier,
+  attributes: cIssue756Attributes,
   description: undefined,
-  extensions: extensions28,
+  extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_cIssue756_cIssue756 = recordCodec(spec_cIssue756);
-const attributes34 = Object.assign(Object.create(null), {
+const cIssue756Codec = recordCodec(cIssue756CodecSpec);
+const bAuthPayloadAttributes = Object.assign(Object.create(null), {
   jwt: {
     description: undefined,
-    codec: registryConfig_pgCodecs_bJwtToken_bJwtToken,
+    codec: bJwtTokenCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1506,7 +1506,7 @@ const attributes34 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions29 = {
+const extensions26 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1518,17 +1518,17 @@ const extensions29 = {
   })
 };
 const parts26 = ["b", "auth_payload"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_bAuthPayload = {
+const bAuthPayloadIdentifier = sql.identifier(...parts26);
+const bAuthPayloadCodecSpec = {
   name: "bAuthPayload",
-  identifier: sqlIdent26,
-  attributes: attributes34,
+  identifier: bAuthPayloadIdentifier,
+  attributes: bAuthPayloadAttributes,
   description: undefined,
-  extensions: extensions29,
+  extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_bAuthPayload_bAuthPayload = recordCodec(spec_bAuthPayload);
-const extensions30 = {
+const bAuthPayloadCodec = recordCodec(bAuthPayloadCodecSpec);
+const extensions27 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1537,16 +1537,15 @@ const extensions30 = {
   tags: Object.create(null)
 };
 const parts27 = ["b", "color"];
-const sqlIdent27 = sql.identifier(...parts27);
-const attributes_c_codec_bColor = enumCodec({
+const bColorCodec = enumCodec({
   name: "bColor",
-  identifier: sqlIdent27,
+  identifier: sql.identifier(...parts27),
   values: ["red", "green", "blue"],
   description: undefined,
-  extensions: extensions30
+  extensions: extensions27
 });
 const enumLabels2 = ["FOO_BAR", "BAR_FOO", "BAZ_QUX", "0_BAR"];
-const extensions31 = {
+const extensions28 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1555,16 +1554,16 @@ const extensions31 = {
   tags: Object.create(null)
 };
 const parts28 = ["b", "enum_caps"];
-const sqlIdent28 = sql.identifier(...parts28);
-const attributes_e_codec_bEnumCaps = enumCodec({
+const sqlIdent2 = sql.identifier(...parts28);
+const bEnumCapsCodec = enumCodec({
   name: "bEnumCaps",
-  identifier: sqlIdent28,
+  identifier: sqlIdent2,
   values: enumLabels2,
   description: undefined,
-  extensions: extensions31
+  extensions: extensions28
 });
 const enumLabels3 = ["", "one", "two"];
-const extensions32 = {
+const extensions29 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -1573,15 +1572,15 @@ const extensions32 = {
   tags: Object.create(null)
 };
 const parts29 = ["b", "enum_with_empty_string"];
-const sqlIdent29 = sql.identifier(...parts29);
-const attributes_f_codec_bEnumWithEmptyString = enumCodec({
+const sqlIdent3 = sql.identifier(...parts29);
+const bEnumWithEmptyStringCodec = enumCodec({
   name: "bEnumWithEmptyString",
-  identifier: sqlIdent29,
+  identifier: sqlIdent3,
   values: enumLabels3,
   description: undefined,
-  extensions: extensions32
+  extensions: extensions29
 });
-const attributes36 = Object.assign(Object.create(null), {
+const cCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
     codec: TYPES.int,
@@ -1602,7 +1601,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   c: {
     description: undefined,
-    codec: attributes_c_codec_bColor,
+    codec: bColorCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1620,7 +1619,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   e: {
     description: undefined,
-    codec: attributes_e_codec_bEnumCaps,
+    codec: bEnumCapsCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1629,7 +1628,7 @@ const attributes36 = Object.assign(Object.create(null), {
   },
   f: {
     description: undefined,
-    codec: attributes_f_codec_bEnumWithEmptyString,
+    codec: bEnumWithEmptyStringCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1655,7 +1654,7 @@ const attributes36 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions33 = {
+const extensions30 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1665,17 +1664,17 @@ const extensions33 = {
   tags: Object.create(null)
 };
 const parts30 = ["c", "compound_type"];
-const sqlIdent30 = sql.identifier(...parts30);
-const spec_cCompoundType = {
+const cCompoundTypeIdentifier = sql.identifier(...parts30);
+const cCompoundTypeCodecSpec = {
   name: "cCompoundType",
-  identifier: sqlIdent30,
-  attributes: attributes36,
+  identifier: cCompoundTypeIdentifier,
+  attributes: cCompoundTypeAttributes,
   description: "Awesome feature!",
-  extensions: extensions33,
+  extensions: extensions30,
   executor: executor_mainPgExecutor
 };
-const attributes_o2_codec_cCompoundType = recordCodec(spec_cCompoundType);
-const attributes35 = Object.assign(Object.create(null), {
+const cCompoundTypeCodec = recordCodec(cCompoundTypeCodecSpec);
+const attributes12 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1686,7 +1685,7 @@ const attributes35 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1696,7 +1695,7 @@ const attributes35 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord = recordCodec({
   name: "CFuncOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes35,
+  attributes: attributes12,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1706,7 +1705,7 @@ const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundT
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes37 = Object.assign(Object.create(null), {
+const attributes13 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.int,
@@ -1717,7 +1716,7 @@ const attributes37 = Object.assign(Object.create(null), {
   },
   o2: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 2,
       argName: "o2"
@@ -1727,7 +1726,7 @@ const attributes37 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord = recordCodec({
   name: "CMutationOutOutCompoundTypeRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes37,
+  attributes: attributes13,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1737,7 +1736,7 @@ const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutC
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions34 = {
+const anEnumArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1746,7 +1745,7 @@ const extensions34 = {
   tags: Object.create(null)
 };
 const enumLabels4 = ["awaiting", "rejected", "published", "*", "**", "***", "foo*", "foo*_", "_foo*", "*bar", "*bar_", "_*bar_", "*baz*", "_*baz*_", "%", ">=", "~~", "$"];
-const extensions35 = {
+const extensions31 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1755,21 +1754,21 @@ const extensions35 = {
   tags: Object.create(null)
 };
 const parts31 = ["a", "an_enum"];
-const sqlIdent31 = sql.identifier(...parts31);
-const innerCodec_anEnum = enumCodec({
+const sqlIdent4 = sql.identifier(...parts31);
+const anEnumCodec = enumCodec({
   name: "anEnum",
-  identifier: sqlIdent31,
+  identifier: sqlIdent4,
   values: enumLabels4,
   description: undefined,
-  extensions: extensions35
+  extensions: extensions31
 });
-const attributes_enums_codec_anEnumArray = listOfCodec(innerCodec_anEnum, {
-  extensions: extensions34,
+const anEnumArrayCodec = listOfCodec(anEnumCodec, {
+  extensions: anEnumArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "anEnumArray"
 });
-const extensions36 = {
+const comptypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -1777,7 +1776,7 @@ const extensions36 = {
   },
   tags: Object.create(null)
 };
-const attributes40 = Object.assign(Object.create(null), {
+const comptypeAttributes = Object.assign(Object.create(null), {
   schedule: {
     description: undefined,
     codec: TYPES.timestamptz,
@@ -1797,7 +1796,7 @@ const attributes40 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions37 = {
+const extensions32 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -1807,23 +1806,23 @@ const extensions37 = {
   tags: Object.create(null)
 };
 const parts32 = ["a", "comptype"];
-const sqlIdent32 = sql.identifier(...parts32);
-const spec_comptype = {
+const comptypeIdentifier = sql.identifier(...parts32);
+const comptypeCodecSpec = {
   name: "comptype",
-  identifier: sqlIdent32,
-  attributes: attributes40,
+  identifier: comptypeIdentifier,
+  attributes: comptypeAttributes,
   description: undefined,
-  extensions: extensions37,
+  extensions: extensions32,
   executor: executor_mainPgExecutor
 };
-const innerCodec_comptype = recordCodec(spec_comptype);
-const attributes_comptypes_codec_comptypeArray = listOfCodec(innerCodec_comptype, {
-  extensions: extensions36,
+const comptypeCodec = recordCodec(comptypeCodecSpec);
+const comptypeArrayCodec = listOfCodec(comptypeCodec, {
+  extensions: comptypeArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "comptypeArray"
 });
-const attributes39 = Object.assign(Object.create(null), {
+const postAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1862,7 +1861,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   enums: {
     description: undefined,
-    codec: attributes_enums_codec_anEnumArray,
+    codec: anEnumArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1871,7 +1870,7 @@ const attributes39 = Object.assign(Object.create(null), {
   },
   comptypes: {
     description: undefined,
-    codec: attributes_comptypes_codec_comptypeArray,
+    codec: comptypeArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -1879,7 +1878,7 @@ const attributes39 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions38 = {
+const extensions33 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -1889,17 +1888,17 @@ const extensions38 = {
   tags: Object.create(null)
 };
 const parts33 = ["a", "post"];
-const sqlIdent33 = sql.identifier(...parts33);
-const spec_post = {
+const postIdentifier = sql.identifier(...parts33);
+const postCodecSpec = {
   name: "post",
-  identifier: sqlIdent33,
-  attributes: attributes39,
+  identifier: postIdentifier,
+  attributes: postAttributes,
   description: undefined,
-  extensions: extensions38,
+  extensions: extensions33,
   executor: executor_mainPgExecutor
 };
-const attributes_post_codec_post = recordCodec(spec_post);
-const attributes38 = Object.assign(Object.create(null), {
+const postCodec = recordCodec(postCodecSpec);
+const attributes14 = Object.assign(Object.create(null), {
   txt: {
     notNull: false,
     codec: TYPES.text,
@@ -1910,7 +1909,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   left_arm: {
     notNull: false,
-    codec: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+    codec: cLeftArmCodec,
     extensions: {
       argIndex: 3,
       argName: "left_arm"
@@ -1918,7 +1917,7 @@ const attributes38 = Object.assign(Object.create(null), {
   },
   post: {
     notNull: false,
-    codec: attributes_post_codec_post,
+    codec: postCodec,
     extensions: {
       argIndex: 4,
       argName: "post"
@@ -1928,7 +1927,7 @@ const attributes38 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord = recordCodec({
   name: "CQueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes38,
+  attributes: attributes14,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1938,7 +1937,7 @@ const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes41 = Object.assign(Object.create(null), {
+const attributes15 = Object.assign(Object.create(null), {
   o1: {
     notNull: false,
     codec: TYPES.text,
@@ -1959,7 +1958,7 @@ const attributes41 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord = recordCodec({
   name: "CPersonComputedOutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes41,
+  attributes: attributes15,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -1969,7 +1968,7 @@ const registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutR
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes42 = Object.assign(Object.create(null), {
+const attributes16 = Object.assign(Object.create(null), {
   ino: {
     notNull: false,
     codec: TYPES.text,
@@ -1990,7 +1989,7 @@ const attributes42 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord = recordCodec({
   name: "CPersonComputedInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes42,
+  attributes: attributes16,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2000,7 +1999,7 @@ const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInout
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions39 = {
+const extensions34 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2009,13 +2008,13 @@ const extensions39 = {
   tags: Object.create(null)
 };
 const parts34 = ["b", "email"];
-const sqlIdent34 = sql.identifier(...parts34);
-const attributes_email_codec_bEmail = domainOfCodec(TYPES.text, "bEmail", sqlIdent34, {
+const bEmailIdentifier = sql.identifier(...parts34);
+const bEmailCodec = domainOfCodec(TYPES.text, "bEmail", bEmailIdentifier, {
   description: undefined,
-  extensions: extensions39,
+  extensions: extensions34,
   notNull: false
 });
-const extensions40 = {
+const extensions35 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2024,16 +2023,16 @@ const extensions40 = {
   tags: Object.create(null)
 };
 const parts35 = ["b", "not_null_url"];
-const sqlIdent35 = sql.identifier(...parts35);
-const attributes_url_codec_bNotNullUrl = domainOfCodec(TYPES.varchar, "bNotNullUrl", sqlIdent35, {
+const bNotNullUrlIdentifier = sql.identifier(...parts35);
+const bNotNullUrlCodec = domainOfCodec(TYPES.varchar, "bNotNullUrl", bNotNullUrlIdentifier, {
   description: undefined,
-  extensions: extensions40,
+  extensions: extensions35,
   notNull: true
 });
-const attributes45 = Object.assign(Object.create(null), {
+const bWrappedUrlAttributes = Object.assign(Object.create(null), {
   url: {
     description: undefined,
-    codec: attributes_url_codec_bNotNullUrl,
+    codec: bNotNullUrlCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2041,7 +2040,7 @@ const attributes45 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions41 = {
+const extensions36 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2051,17 +2050,17 @@ const extensions41 = {
   tags: Object.create(null)
 };
 const parts36 = ["b", "wrapped_url"];
-const sqlIdent36 = sql.identifier(...parts36);
-const spec_bWrappedUrl = {
+const bWrappedUrlIdentifier = sql.identifier(...parts36);
+const bWrappedUrlCodecSpec = {
   name: "bWrappedUrl",
-  identifier: sqlIdent36,
-  attributes: attributes45,
+  identifier: bWrappedUrlIdentifier,
+  attributes: bWrappedUrlAttributes,
   description: undefined,
-  extensions: extensions41,
+  extensions: extensions36,
   executor: executor_mainPgExecutor
 };
-const attributes_site_codec_bWrappedUrl = recordCodec(spec_bWrappedUrl);
-const attributes44 = Object.assign(Object.create(null), {
+const bWrappedUrlCodec = recordCodec(bWrappedUrlCodecSpec);
+const cPersonAttributes = Object.assign(Object.create(null), {
   id: {
     description: "The primary unique identifier for the person",
     codec: TYPES.int,
@@ -2084,7 +2083,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   aliases: {
     description: undefined,
-    codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+    codec: pgCatalogTextArrayCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -2102,7 +2101,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   email: {
     description: undefined,
-    codec: attributes_email_codec_bEmail,
+    codec: bEmailCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2111,7 +2110,7 @@ const attributes44 = Object.assign(Object.create(null), {
   },
   site: {
     description: undefined,
-    codec: attributes_site_codec_bWrappedUrl,
+    codec: bWrappedUrlCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2166,7 +2165,7 @@ const attributes44 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions42 = {
+const extensions37 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -2176,20 +2175,20 @@ const extensions42 = {
   tags: Object.create(null)
 };
 const parts37 = ["c", "person"];
-const sqlIdent37 = sql.identifier(...parts37);
-const spec_cPerson = {
+const cPersonIdentifier = sql.identifier(...parts37);
+const cPersonCodecSpec = {
   name: "cPerson",
-  identifier: sqlIdent37,
-  attributes: attributes44,
+  identifier: cPersonIdentifier,
+  attributes: cPersonAttributes,
   description: "Person test comment",
-  extensions: extensions42,
+  extensions: extensions37,
   executor: executor_mainPgExecutor
 };
-const attributes_person_codec_cPerson = recordCodec(spec_cPerson);
-const attributes43 = Object.assign(Object.create(null), {
+const cPersonCodec = recordCodec(cPersonCodecSpec);
+const attributes17 = Object.assign(Object.create(null), {
   person: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 0,
       argName: "person"
@@ -2207,7 +2206,7 @@ const attributes43 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "CPersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes43,
+  attributes: attributes17,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2217,7 +2216,7 @@ const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonCompu
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes46 = Object.assign(Object.create(null), {
+const attributes18 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2228,7 +2227,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2236,7 +2235,7 @@ const attributes46 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2246,7 +2245,7 @@ const attributes46 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = recordCodec({
   name: "CFuncOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes46,
+  attributes: attributes18,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2256,7 +2255,7 @@ const registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord = reco
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes47 = Object.assign(Object.create(null), {
+const attributes19 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2267,7 +2266,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2275,7 +2274,7 @@ const attributes47 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2285,7 +2284,7 @@ const attributes47 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRecord = recordCodec({
   name: "CFuncOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes47,
+  attributes: attributes19,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2295,7 +2294,7 @@ const registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRec
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes48 = Object.assign(Object.create(null), {
+const attributes20 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2306,7 +2305,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2314,7 +2313,7 @@ const attributes48 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2324,7 +2323,7 @@ const attributes48 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord = recordCodec({
   name: "CMutationOutComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes48,
+  attributes: attributes20,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2334,7 +2333,7 @@ const registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecor
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes49 = Object.assign(Object.create(null), {
+const attributes21 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2345,7 +2344,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 3,
       argName: "y"
@@ -2353,7 +2352,7 @@ const attributes49 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 4,
       argName: "z"
@@ -2363,7 +2362,7 @@ const attributes49 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord = recordCodec({
   name: "CMutationOutComplexSetofRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes49,
+  attributes: attributes21,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2373,7 +2372,7 @@ const registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplex
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const attributes50 = Object.assign(Object.create(null), {
+const attributes22 = Object.assign(Object.create(null), {
   x: {
     notNull: false,
     codec: TYPES.int,
@@ -2384,7 +2383,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   y: {
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     extensions: {
       argIndex: 4,
       argName: "y"
@@ -2392,7 +2391,7 @@ const attributes50 = Object.assign(Object.create(null), {
   },
   z: {
     notNull: false,
-    codec: attributes_person_codec_cPerson,
+    codec: cPersonCodec,
     extensions: {
       argIndex: 5,
       argName: "z"
@@ -2402,7 +2401,7 @@ const attributes50 = Object.assign(Object.create(null), {
 const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord = recordCodec({
   name: "CPersonComputedComplexRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
-  attributes: attributes50,
+  attributes: attributes22,
   description: undefined,
   extensions: {
     /* `The return type of our \`${name}\` ${
@@ -2412,7 +2411,7 @@ const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComple
   executor: executor_mainPgExecutor,
   isAnonymous: true
 });
-const extensions43 = {
+const bColorArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2420,13 +2419,13 @@ const extensions43 = {
   },
   tags: Object.create(null)
 };
-const attributes_enum_array_codec_bColorArray = listOfCodec(attributes_c_codec_bColor, {
-  extensions: extensions43,
+const bColorArrayCodec = listOfCodec(bColorCodec, {
+  extensions: bColorArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "bColorArray"
 });
-const extensions44 = {
+const extensions38 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2435,13 +2434,13 @@ const extensions44 = {
   tags: Object.create(null)
 };
 const parts38 = ["a", "an_int"];
-const sqlIdent38 = sql.identifier(...parts38);
-const attributes_domain_codec_anInt = domainOfCodec(TYPES.int, "anInt", sqlIdent38, {
+const anIntIdentifier = sql.identifier(...parts38);
+const anIntCodec = domainOfCodec(TYPES.int, "anInt", anIntIdentifier, {
   description: undefined,
-  extensions: extensions44,
+  extensions: extensions38,
   notNull: false
 });
-const extensions45 = {
+const extensions39 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -2450,13 +2449,13 @@ const extensions45 = {
   tags: Object.create(null)
 };
 const parts39 = ["b", "another_int"];
-const sqlIdent39 = sql.identifier(...parts39);
-const attributes_domain2_codec_bAnotherInt = domainOfCodec(attributes_domain_codec_anInt, "bAnotherInt", sqlIdent39, {
+const bAnotherIntIdentifier = sql.identifier(...parts39);
+const bAnotherIntCodec = domainOfCodec(anIntCodec, "bAnotherInt", bAnotherIntIdentifier, {
   description: undefined,
-  extensions: extensions45,
+  extensions: extensions39,
   notNull: false
 });
-const extensions46 = {
+const extensions40 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2465,12 +2464,12 @@ const extensions46 = {
   tags: Object.create(null)
 };
 const parts40 = ["pg_catalog", "numrange"];
-const sqlIdent40 = sql.identifier(...parts40);
-const attributes_nullable_range_codec_pgCatalogNumrange = rangeOfCodec(TYPES.numeric, "pgCatalogNumrange", sqlIdent40, {
+const sqlIdent5 = sql.identifier(...parts40);
+const pgCatalogNumrangeCodec = rangeOfCodec(TYPES.numeric, "pgCatalogNumrange", sqlIdent5, {
   description: "range of numerics",
-  extensions: extensions46
+  extensions: extensions40
 });
-const extensions47 = {
+const extensions41 = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2479,12 +2478,12 @@ const extensions47 = {
   tags: Object.create(null)
 };
 const parts41 = ["pg_catalog", "daterange"];
-const sqlIdent41 = sql.identifier(...parts41);
-const attributes_daterange_codec_pgCatalogDaterange = rangeOfCodec(TYPES.date, "pgCatalogDaterange", sqlIdent41, {
+const sqlIdent6 = sql.identifier(...parts41);
+const pgCatalogDaterangeCodec = rangeOfCodec(TYPES.date, "pgCatalogDaterange", sqlIdent6, {
   description: "range of dates",
-  extensions: extensions47
+  extensions: extensions41
 });
-const extensions48 = {
+const extensions42 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -2493,15 +2492,15 @@ const extensions48 = {
   tags: Object.create(null)
 };
 const parts42 = ["a", "an_int_range"];
-const sqlIdent42 = sql.identifier(...parts42);
-const attributes_an_int_range_codec_anIntRange = rangeOfCodec(attributes_domain_codec_anInt, "anIntRange", sqlIdent42, {
+const sqlIdent7 = sql.identifier(...parts42);
+const anIntRangeCodec = rangeOfCodec(anIntCodec, "anIntRange", sqlIdent7, {
   description: undefined,
-  extensions: extensions48
+  extensions: extensions42
 });
-const attributes52 = Object.assign(Object.create(null), {
+const bNestedCompoundTypeAttributes = Object.assign(Object.create(null), {
   a: {
     description: undefined,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2510,7 +2509,7 @@ const attributes52 = Object.assign(Object.create(null), {
   },
   b: {
     description: undefined,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2527,7 +2526,7 @@ const attributes52 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions49 = {
+const extensions43 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -2537,17 +2536,17 @@ const extensions49 = {
   tags: Object.create(null)
 };
 const parts43 = ["b", "nested_compound_type"];
-const sqlIdent43 = sql.identifier(...parts43);
-const spec_bNestedCompoundType = {
+const bNestedCompoundTypeIdentifier = sql.identifier(...parts43);
+const bNestedCompoundTypeCodecSpec = {
   name: "bNestedCompoundType",
-  identifier: sqlIdent43,
-  attributes: attributes52,
+  identifier: bNestedCompoundTypeIdentifier,
+  attributes: bNestedCompoundTypeAttributes,
   description: undefined,
-  extensions: extensions49,
+  extensions: extensions43,
   executor: executor_mainPgExecutor
 };
-const attributes_nested_compound_type_codec_bNestedCompoundType = recordCodec(spec_bNestedCompoundType);
-const extensions50 = {
+const bNestedCompoundTypeCodec = recordCodec(bNestedCompoundTypeCodecSpec);
+const extensions44 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2556,13 +2555,13 @@ const extensions50 = {
   tags: Object.create(null)
 };
 const parts44 = ["c", "text_array_domain"];
-const sqlIdent44 = sql.identifier(...parts44);
-const attributes_text_array_domain_codec_cTextArrayDomain = domainOfCodec(registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray, "cTextArrayDomain", sqlIdent44, {
+const cTextArrayDomainIdentifier = sql.identifier(...parts44);
+const cTextArrayDomainCodec = domainOfCodec(pgCatalogTextArrayCodec, "cTextArrayDomain", cTextArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions50,
+  extensions: extensions44,
   notNull: false
 });
-const extensions51 = {
+const extensions45 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -2570,7 +2569,7 @@ const extensions51 = {
   },
   tags: Object.create(null)
 };
-const extensions52 = {
+const pgCatalogInt8ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2578,20 +2577,20 @@ const extensions52 = {
   },
   tags: Object.create(null)
 };
-const innerCodec_pgCatalogInt8Array = listOfCodec(TYPES.bigint, {
-  extensions: extensions52,
+const pgCatalogInt8ArrayCodec = listOfCodec(TYPES.bigint, {
+  extensions: pgCatalogInt8ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogInt8Array"
 });
 const parts45 = ["c", "int8_array_domain"];
-const sqlIdent45 = sql.identifier(...parts45);
-const attributes_int8_array_domain_codec_cInt8ArrayDomain = domainOfCodec(innerCodec_pgCatalogInt8Array, "cInt8ArrayDomain", sqlIdent45, {
+const cInt8ArrayDomainIdentifier = sql.identifier(...parts45);
+const cInt8ArrayDomainCodec = domainOfCodec(pgCatalogInt8ArrayCodec, "cInt8ArrayDomain", cInt8ArrayDomainIdentifier, {
   description: undefined,
-  extensions: extensions51,
+  extensions: extensions45,
   notNull: false
 });
-const extensions53 = {
+const pgCatalogByteaArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -2599,13 +2598,13 @@ const extensions53 = {
   },
   tags: Object.create(null)
 };
-const attributes_bytea_array_codec_pgCatalogByteaArray = listOfCodec(TYPES.bytea, {
-  extensions: extensions53,
+const pgCatalogByteaArrayCodec = listOfCodec(TYPES.bytea, {
+  extensions: pgCatalogByteaArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogByteaArray"
 });
-const attributes_ltree_codec_ltree = {
+const bTypesAttributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2617,8 +2616,8 @@ const attributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const attributes_ltree_array_codec_ltree_ = listOfCodec(attributes_ltree_codec_ltree);
-const attributes51 = Object.assign(Object.create(null), {
+const bTypesAttributes_ltree_array_codec_ltree_ = listOfCodec(bTypesAttributes_ltree_codec_ltree);
+const bTypesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2684,7 +2683,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum: {
     description: undefined,
-    codec: attributes_c_codec_bColor,
+    codec: bColorCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2693,7 +2692,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   enum_array: {
     description: undefined,
-    codec: attributes_enum_array_codec_bColorArray,
+    codec: bColorArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2702,7 +2701,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain: {
     description: undefined,
-    codec: attributes_domain_codec_anInt,
+    codec: anIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2711,7 +2710,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   domain2: {
     description: undefined,
-    codec: attributes_domain2_codec_bAnotherInt,
+    codec: bAnotherIntCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2720,7 +2719,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+    codec: pgCatalogTextArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2747,7 +2746,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_range: {
     description: undefined,
-    codec: attributes_nullable_range_codec_pgCatalogNumrange,
+    codec: pgCatalogNumrangeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2756,7 +2755,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   numrange: {
     description: undefined,
-    codec: attributes_nullable_range_codec_pgCatalogNumrange,
+    codec: pgCatalogNumrangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2765,7 +2764,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   daterange: {
     description: undefined,
-    codec: attributes_daterange_codec_pgCatalogDaterange,
+    codec: pgCatalogDaterangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2774,7 +2773,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   an_int_range: {
     description: undefined,
-    codec: attributes_an_int_range_codec_anIntRange,
+    codec: anIntRangeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2837,7 +2836,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   interval_array: {
     description: undefined,
-    codec: registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray,
+    codec: pgCatalogIntervalArrayCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2855,7 +2854,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2864,7 +2863,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_bNestedCompoundType,
+    codec: bNestedCompoundTypeCodec,
     notNull: true,
     hasDefault: false,
     extensions: {
@@ -2873,7 +2872,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_compound_type: {
     description: undefined,
-    codec: attributes_o2_codec_cCompoundType,
+    codec: cCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -2882,7 +2881,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   nullable_nested_compound_type: {
     description: undefined,
-    codec: attributes_nested_compound_type_codec_bNestedCompoundType,
+    codec: bNestedCompoundTypeCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3008,7 +3007,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   text_array_domain: {
     description: undefined,
-    codec: attributes_text_array_domain_codec_cTextArrayDomain,
+    codec: cTextArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3017,7 +3016,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   int8_array_domain: {
     description: undefined,
-    codec: attributes_int8_array_domain_codec_cInt8ArrayDomain,
+    codec: cInt8ArrayDomainCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3035,7 +3034,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   bytea_array: {
     description: undefined,
-    codec: attributes_bytea_array_codec_pgCatalogByteaArray,
+    codec: pgCatalogByteaArrayCodec,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3044,7 +3043,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree: {
     description: undefined,
-    codec: attributes_ltree_codec_ltree,
+    codec: bTypesAttributes_ltree_codec_ltree,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3053,7 +3052,7 @@ const attributes51 = Object.assign(Object.create(null), {
   },
   ltree_array: {
     description: undefined,
-    codec: attributes_ltree_array_codec_ltree_,
+    codec: bTypesAttributes_ltree_array_codec_ltree_,
     notNull: false,
     hasDefault: false,
     extensions: {
@@ -3061,7 +3060,7 @@ const attributes51 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions54 = {
+const extensions46 = {
   isTableLike: true,
   pg: {
     serviceName: "main",
@@ -3073,17 +3072,17 @@ const extensions54 = {
   })
 };
 const parts46 = ["b", "types"];
-const sqlIdent46 = sql.identifier(...parts46);
-const spec_bTypes = {
+const bTypesIdentifier = sql.identifier(...parts46);
+const bTypesCodecSpec = {
   name: "bTypes",
-  identifier: sqlIdent46,
-  attributes: attributes51,
+  identifier: bTypesIdentifier,
+  attributes: bTypesAttributes,
   description: undefined,
-  extensions: extensions54,
+  extensions: extensions46,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_bTypes_bTypes = recordCodec(spec_bTypes);
-const extensions55 = {
+const bTypesCodec = recordCodec(bTypesCodecSpec);
+const cCompoundTypeArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3091,7 +3090,7 @@ const extensions55 = {
   },
   tags: Object.create(null)
 };
-const extensions56 = {
+const bJwtTokenArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3099,7 +3098,7 @@ const extensions56 = {
   },
   tags: Object.create(null)
 };
-const extensions57 = {
+const bTypesArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3107,7 +3106,7 @@ const extensions57 = {
   },
   tags: Object.create(null)
 };
-const extensions58 = {
+const pgCatalogInt4ArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "pg_catalog",
@@ -3115,13 +3114,13 @@ const extensions58 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array = listOfCodec(TYPES.int, {
-  extensions: extensions58,
+const pgCatalogInt4ArrayCodec = listOfCodec(TYPES.int, {
+  extensions: pgCatalogInt4ArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "pgCatalogInt4Array"
 });
-const extensions59 = {
+const extensions47 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3130,12 +3129,12 @@ const extensions59 = {
   tags: Object.create(null)
 };
 const parts47 = ["c", "floatrange"];
-const sqlIdent47 = sql.identifier(...parts47);
-const registryConfig_pgCodecs_cFloatrange_cFloatrange = rangeOfCodec(TYPES.float, "cFloatrange", sqlIdent47, {
+const sqlIdent8 = sql.identifier(...parts47);
+const cFloatrangeCodec = rangeOfCodec(TYPES.float, "cFloatrange", sqlIdent8, {
   description: undefined,
-  extensions: extensions59
+  extensions: extensions47
 });
-const extensions60 = {
+const postArrayCodecExtensions = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3143,13 +3142,13 @@ const extensions60 = {
   },
   tags: Object.create(null)
 };
-const registryConfig_pgCodecs_postArray_postArray = listOfCodec(attributes_post_codec_post, {
-  extensions: extensions60,
+const postArrayCodec = listOfCodec(postCodec, {
+  extensions: postArrayCodecExtensions,
   typeDelim: ",",
   description: undefined,
   name: "postArray"
 });
-const attributes53 = Object.assign(Object.create(null), {
+const tablefuncCrosstab2Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3178,7 +3177,7 @@ const attributes53 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions61 = {
+const extensions48 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3188,16 +3187,16 @@ const extensions61 = {
   tags: Object.create(null)
 };
 const parts48 = ["a", "tablefunc_crosstab_2"];
-const sqlIdent48 = sql.identifier(...parts48);
-const spec_tablefuncCrosstab2 = {
+const tablefuncCrosstab2Identifier = sql.identifier(...parts48);
+const tablefuncCrosstab2CodecSpec = {
   name: "tablefuncCrosstab2",
-  identifier: sqlIdent48,
-  attributes: attributes53,
+  identifier: tablefuncCrosstab2Identifier,
+  attributes: tablefuncCrosstab2Attributes,
   description: undefined,
-  extensions: extensions61,
+  extensions: extensions48,
   executor: executor_mainPgExecutor
 };
-const attributes54 = Object.assign(Object.create(null), {
+const tablefuncCrosstab3Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3235,7 +3234,7 @@ const attributes54 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions62 = {
+const extensions49 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3245,16 +3244,16 @@ const extensions62 = {
   tags: Object.create(null)
 };
 const parts49 = ["a", "tablefunc_crosstab_3"];
-const sqlIdent49 = sql.identifier(...parts49);
-const spec_tablefuncCrosstab3 = {
+const tablefuncCrosstab3Identifier = sql.identifier(...parts49);
+const tablefuncCrosstab3CodecSpec = {
   name: "tablefuncCrosstab3",
-  identifier: sqlIdent49,
-  attributes: attributes54,
+  identifier: tablefuncCrosstab3Identifier,
+  attributes: tablefuncCrosstab3Attributes,
   description: undefined,
-  extensions: extensions62,
+  extensions: extensions49,
   executor: executor_mainPgExecutor
 };
-const attributes55 = Object.assign(Object.create(null), {
+const tablefuncCrosstab4Attributes = Object.assign(Object.create(null), {
   row_name: {
     description: undefined,
     codec: TYPES.text,
@@ -3301,7 +3300,7 @@ const attributes55 = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions63 = {
+const extensions50 = {
   isTableLike: false,
   pg: {
     serviceName: "main",
@@ -3311,16 +3310,16 @@ const extensions63 = {
   tags: Object.create(null)
 };
 const parts50 = ["a", "tablefunc_crosstab_4"];
-const sqlIdent50 = sql.identifier(...parts50);
-const spec_tablefuncCrosstab4 = {
+const tablefuncCrosstab4Identifier = sql.identifier(...parts50);
+const tablefuncCrosstab4CodecSpec = {
   name: "tablefuncCrosstab4",
-  identifier: sqlIdent50,
-  attributes: attributes55,
+  identifier: tablefuncCrosstab4Identifier,
+  attributes: tablefuncCrosstab4Attributes,
   description: undefined,
-  extensions: extensions63,
+  extensions: extensions50,
   executor: executor_mainPgExecutor
 };
-const extensions64 = {
+const extensions51 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3331,8 +3330,8 @@ const extensions64 = {
   }
 };
 const parts51 = ["c", "current_user_id"];
-const sqlIdent51 = sql.identifier(...parts51);
-const extensions65 = {
+const sqlIdent9 = sql.identifier(...parts51);
+const extensions52 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3344,10 +3343,10 @@ const extensions65 = {
   singleOutputParameterName: "o"
 };
 const parts52 = ["c", "func_out"];
-const sqlIdent52 = sql.identifier(...parts52);
-const fromCallback2 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
+const sqlIdent10 = sql.identifier(...parts52);
+const fromCallback2 = (...args) => sql`${sqlIdent10}(${sqlFromArgDigests(args)})`;
 const parameters2 = [];
-const extensions66 = {
+const extensions53 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3359,10 +3358,10 @@ const extensions66 = {
   singleOutputParameterName: "o"
 };
 const parts53 = ["c", "func_out_setof"];
-const sqlIdent53 = sql.identifier(...parts53);
-const fromCallback3 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
+const sqlIdent11 = sql.identifier(...parts53);
+const fromCallback3 = (...args) => sql`${sqlIdent11}(${sqlFromArgDigests(args)})`;
 const parameters3 = [];
-const extensions67 = {
+const extensions54 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3373,10 +3372,10 @@ const extensions67 = {
   }
 };
 const parts54 = ["c", "func_out_unnamed"];
-const sqlIdent54 = sql.identifier(...parts54);
-const fromCallback4 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
+const sqlIdent12 = sql.identifier(...parts54);
+const fromCallback4 = (...args) => sql`${sqlIdent12}(${sqlFromArgDigests(args)})`;
 const parameters4 = [];
-const extensions68 = {
+const extensions55 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3388,10 +3387,10 @@ const extensions68 = {
   singleOutputParameterName: "o"
 };
 const parts55 = ["c", "mutation_out"];
-const sqlIdent55 = sql.identifier(...parts55);
-const fromCallback5 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
+const sqlIdent13 = sql.identifier(...parts55);
+const fromCallback5 = (...args) => sql`${sqlIdent13}(${sqlFromArgDigests(args)})`;
 const parameters5 = [];
-const extensions69 = {
+const extensions56 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3403,10 +3402,10 @@ const extensions69 = {
   singleOutputParameterName: "o"
 };
 const parts56 = ["c", "mutation_out_setof"];
-const sqlIdent56 = sql.identifier(...parts56);
-const fromCallback6 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
+const sqlIdent14 = sql.identifier(...parts56);
+const fromCallback6 = (...args) => sql`${sqlIdent14}(${sqlFromArgDigests(args)})`;
 const parameters6 = [];
-const extensions70 = {
+const extensions57 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3417,10 +3416,10 @@ const extensions70 = {
   }
 };
 const parts57 = ["c", "mutation_out_unnamed"];
-const sqlIdent57 = sql.identifier(...parts57);
-const fromCallback7 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
+const sqlIdent15 = sql.identifier(...parts57);
+const fromCallback7 = (...args) => sql`${sqlIdent15}(${sqlFromArgDigests(args)})`;
 const parameters7 = [];
-const extensions71 = {
+const extensions58 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3431,10 +3430,10 @@ const extensions71 = {
   }
 };
 const parts58 = ["c", "no_args_mutation"];
-const sqlIdent58 = sql.identifier(...parts58);
-const fromCallback8 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
+const sqlIdent16 = sql.identifier(...parts58);
+const fromCallback8 = (...args) => sql`${sqlIdent16}(${sqlFromArgDigests(args)})`;
 const parameters8 = [];
-const extensions72 = {
+const extensions59 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3445,10 +3444,10 @@ const extensions72 = {
   }
 };
 const parts59 = ["c", "no_args_query"];
-const sqlIdent59 = sql.identifier(...parts59);
-const fromCallback9 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
+const sqlIdent17 = sql.identifier(...parts59);
+const fromCallback9 = (...args) => sql`${sqlIdent17}(${sqlFromArgDigests(args)})`;
 const parameters9 = [];
-const extensions73 = {
+const extensions60 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3459,10 +3458,10 @@ const extensions73 = {
   }
 };
 const parts60 = ["a", "return_void_mutation"];
-const sqlIdent60 = sql.identifier(...parts60);
-const fromCallback10 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
+const sqlIdent18 = sql.identifier(...parts60);
+const fromCallback10 = (...args) => sql`${sqlIdent18}(${sqlFromArgDigests(args)})`;
 const parameters10 = [];
-const extensions74 = {
+const extensions61 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3473,10 +3472,10 @@ const extensions74 = {
   }
 };
 const parts61 = ["a", "mutation_interval_set"];
-const sqlIdent61 = sql.identifier(...parts61);
-const fromCallback11 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
+const sqlIdent19 = sql.identifier(...parts61);
+const fromCallback11 = (...args) => sql`${sqlIdent19}(${sqlFromArgDigests(args)})`;
 const parameters11 = [];
-const extensions75 = {
+const extensions62 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3487,10 +3486,10 @@ const extensions75 = {
   }
 };
 const parts62 = ["a", "query_interval_set"];
-const sqlIdent62 = sql.identifier(...parts62);
-const fromCallback12 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
+const sqlIdent20 = sql.identifier(...parts62);
+const fromCallback12 = (...args) => sql`${sqlIdent20}(${sqlFromArgDigests(args)})`;
 const parameters12 = [];
-const extensions76 = {
+const extensions63 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3501,10 +3500,10 @@ const extensions76 = {
   }
 };
 const parts63 = ["a", "static_big_integer"];
-const sqlIdent63 = sql.identifier(...parts63);
-const fromCallback13 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
+const sqlIdent21 = sql.identifier(...parts63);
+const fromCallback13 = (...args) => sql`${sqlIdent21}(${sqlFromArgDigests(args)})`;
 const parameters13 = [];
-const extensions77 = {
+const extensions64 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3516,15 +3515,15 @@ const extensions77 = {
   singleOutputParameterName: "o"
 };
 const parts64 = ["c", "func_in_out"];
-const sqlIdent64 = sql.identifier(...parts64);
-const fromCallback14 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
+const sqlIdent22 = sql.identifier(...parts64);
+const fromCallback14 = (...args) => sql`${sqlIdent22}(${sqlFromArgDigests(args)})`;
 const parameters14 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions78 = {
+const extensions65 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3536,15 +3535,15 @@ const extensions78 = {
   singleOutputParameterName: "col1"
 };
 const parts65 = ["c", "func_returns_table_one_col"];
-const sqlIdent65 = sql.identifier(...parts65);
-const fromCallback15 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
+const sqlIdent23 = sql.identifier(...parts65);
+const fromCallback15 = (...args) => sql`${sqlIdent23}(${sqlFromArgDigests(args)})`;
 const parameters15 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions79 = {
+const extensions66 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3556,15 +3555,15 @@ const extensions79 = {
   singleOutputParameterName: "o"
 };
 const parts66 = ["c", "mutation_in_out"];
-const sqlIdent66 = sql.identifier(...parts66);
-const fromCallback16 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
+const sqlIdent24 = sql.identifier(...parts66);
+const fromCallback16 = (...args) => sql`${sqlIdent24}(${sqlFromArgDigests(args)})`;
 const parameters16 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions80 = {
+const extensions67 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3576,15 +3575,15 @@ const extensions80 = {
   singleOutputParameterName: "col1"
 };
 const parts67 = ["c", "mutation_returns_table_one_col"];
-const sqlIdent67 = sql.identifier(...parts67);
-const fromCallback17 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
+const sqlIdent25 = sql.identifier(...parts67);
+const fromCallback17 = (...args) => sql`${sqlIdent25}(${sqlFromArgDigests(args)})`;
 const parameters17 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions81 = {
+const extensions68 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3595,15 +3594,15 @@ const extensions81 = {
   }
 };
 const parts68 = ["a", "assert_something"];
-const sqlIdent68 = sql.identifier(...parts68);
-const fromCallback18 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
+const sqlIdent26 = sql.identifier(...parts68);
+const fromCallback18 = (...args) => sql`${sqlIdent26}(${sqlFromArgDigests(args)})`;
 const parameters18 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions82 = {
+const extensions69 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3615,15 +3614,15 @@ const extensions82 = {
   }
 };
 const parts69 = ["a", "assert_something_nx"];
-const sqlIdent69 = sql.identifier(...parts69);
-const fromCallback19 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
+const sqlIdent27 = sql.identifier(...parts69);
+const fromCallback19 = (...args) => sql`${sqlIdent27}(${sqlFromArgDigests(args)})`;
 const parameters19 = [{
   name: "in_arg",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions83 = {
+const extensions70 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3634,15 +3633,15 @@ const extensions83 = {
   }
 };
 const parts70 = ["c", "json_identity"];
-const sqlIdent70 = sql.identifier(...parts70);
-const fromCallback20 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
+const sqlIdent28 = sql.identifier(...parts70);
+const fromCallback20 = (...args) => sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
 const parameters20 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions84 = {
+const extensions71 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3653,15 +3652,15 @@ const extensions84 = {
   }
 };
 const parts71 = ["c", "json_identity_mutation"];
-const sqlIdent71 = sql.identifier(...parts71);
-const fromCallback21 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
+const sqlIdent29 = sql.identifier(...parts71);
+const fromCallback21 = (...args) => sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
 const parameters21 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.json
 }];
-const extensions85 = {
+const extensions72 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3672,15 +3671,15 @@ const extensions85 = {
   }
 };
 const parts72 = ["c", "jsonb_identity"];
-const sqlIdent72 = sql.identifier(...parts72);
-const fromCallback22 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
+const sqlIdent30 = sql.identifier(...parts72);
+const fromCallback22 = (...args) => sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
 const parameters22 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions86 = {
+const extensions73 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3691,15 +3690,15 @@ const extensions86 = {
   }
 };
 const parts73 = ["c", "jsonb_identity_mutation"];
-const sqlIdent73 = sql.identifier(...parts73);
-const fromCallback23 = (...args) => sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
+const sqlIdent31 = sql.identifier(...parts73);
+const fromCallback23 = (...args) => sql`${sqlIdent31}(${sqlFromArgDigests(args)})`;
 const parameters23 = [{
   name: "json",
   required: true,
   notNull: false,
   codec: TYPES.jsonb
 }];
-const extensions87 = {
+const extensions74 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3710,15 +3709,15 @@ const extensions87 = {
   }
 };
 const parts74 = ["c", "jsonb_identity_mutation_plpgsql"];
-const sqlIdent74 = sql.identifier(...parts74);
-const fromCallback24 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
+const sqlIdent32 = sql.identifier(...parts74);
+const fromCallback24 = (...args) => sql`${sqlIdent32}(${sqlFromArgDigests(args)})`;
 const parameters24 = [{
   name: "_the_json",
   required: true,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions88 = {
+const extensions75 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -3729,15 +3728,15 @@ const extensions88 = {
   }
 };
 const parts75 = ["c", "jsonb_identity_mutation_plpgsql_with_default"];
-const sqlIdent75 = sql.identifier(...parts75);
-const fromCallback25 = (...args) => sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
+const sqlIdent33 = sql.identifier(...parts75);
+const fromCallback25 = (...args) => sql`${sqlIdent33}(${sqlFromArgDigests(args)})`;
 const parameters25 = [{
   name: "_the_json",
   required: false,
   notNull: true,
   codec: TYPES.jsonb
 }];
-const extensions89 = {
+const extensions76 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3748,8 +3747,8 @@ const extensions89 = {
   }
 };
 const parts76 = ["a", "add_1_mutation"];
-const sqlIdent76 = sql.identifier(...parts76);
-const fromCallback26 = (...args) => sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
+const sqlIdent34 = sql.identifier(...parts76);
+const fromCallback26 = (...args) => sql`${sqlIdent34}(${sqlFromArgDigests(args)})`;
 const parameters26 = [{
   name: null,
   required: true,
@@ -3761,7 +3760,7 @@ const parameters26 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions90 = {
+const extensions77 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3772,8 +3771,8 @@ const extensions90 = {
   }
 };
 const parts77 = ["a", "add_1_query"];
-const sqlIdent77 = sql.identifier(...parts77);
-const fromCallback27 = (...args) => sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
+const sqlIdent35 = sql.identifier(...parts77);
+const fromCallback27 = (...args) => sql`${sqlIdent35}(${sqlFromArgDigests(args)})`;
 const parameters27 = [{
   name: null,
   required: true,
@@ -3785,7 +3784,7 @@ const parameters27 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions91 = {
+const extensions78 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3796,8 +3795,8 @@ const extensions91 = {
   }
 };
 const parts78 = ["a", "add_2_mutation"];
-const sqlIdent78 = sql.identifier(...parts78);
-const fromCallback28 = (...args) => sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
+const sqlIdent36 = sql.identifier(...parts78);
+const fromCallback28 = (...args) => sql`${sqlIdent36}(${sqlFromArgDigests(args)})`;
 const parameters28 = [{
   name: "a",
   required: true,
@@ -3809,7 +3808,7 @@ const parameters28 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions92 = {
+const extensions79 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3820,8 +3819,8 @@ const extensions92 = {
   }
 };
 const parts79 = ["a", "add_2_query"];
-const sqlIdent79 = sql.identifier(...parts79);
-const fromCallback29 = (...args) => sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
+const sqlIdent37 = sql.identifier(...parts79);
+const fromCallback29 = (...args) => sql`${sqlIdent37}(${sqlFromArgDigests(args)})`;
 const parameters29 = [{
   name: "a",
   required: true,
@@ -3833,7 +3832,7 @@ const parameters29 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions93 = {
+const extensions80 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3844,8 +3843,8 @@ const extensions93 = {
   }
 };
 const parts80 = ["a", "add_3_mutation"];
-const sqlIdent80 = sql.identifier(...parts80);
-const fromCallback30 = (...args) => sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
+const sqlIdent38 = sql.identifier(...parts80);
+const fromCallback30 = (...args) => sql`${sqlIdent38}(${sqlFromArgDigests(args)})`;
 const parameters30 = [{
   name: "a",
   required: true,
@@ -3857,7 +3856,7 @@ const parameters30 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions94 = {
+const extensions81 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3868,8 +3867,8 @@ const extensions94 = {
   }
 };
 const parts81 = ["a", "add_3_query"];
-const sqlIdent81 = sql.identifier(...parts81);
-const fromCallback31 = (...args) => sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
+const sqlIdent39 = sql.identifier(...parts81);
+const fromCallback31 = (...args) => sql`${sqlIdent39}(${sqlFromArgDigests(args)})`;
 const parameters31 = [{
   name: "a",
   required: true,
@@ -3881,7 +3880,7 @@ const parameters31 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions95 = {
+const extensions82 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3892,8 +3891,8 @@ const extensions95 = {
   }
 };
 const parts82 = ["a", "add_4_mutation"];
-const sqlIdent82 = sql.identifier(...parts82);
-const fromCallback32 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
+const sqlIdent40 = sql.identifier(...parts82);
+const fromCallback32 = (...args) => sql`${sqlIdent40}(${sqlFromArgDigests(args)})`;
 const parameters32 = [{
   name: "",
   required: true,
@@ -3905,7 +3904,7 @@ const parameters32 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions96 = {
+const extensions83 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3916,8 +3915,8 @@ const extensions96 = {
   }
 };
 const parts83 = ["a", "add_4_mutation_error"];
-const sqlIdent83 = sql.identifier(...parts83);
-const fromCallback33 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
+const sqlIdent41 = sql.identifier(...parts83);
+const fromCallback33 = (...args) => sql`${sqlIdent41}(${sqlFromArgDigests(args)})`;
 const parameters33 = [{
   name: "",
   required: true,
@@ -3929,7 +3928,7 @@ const parameters33 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions97 = {
+const extensions84 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -3940,8 +3939,8 @@ const extensions97 = {
   }
 };
 const parts84 = ["a", "add_4_query"];
-const sqlIdent84 = sql.identifier(...parts84);
-const fromCallback34 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
+const sqlIdent42 = sql.identifier(...parts84);
+const fromCallback34 = (...args) => sql`${sqlIdent42}(${sqlFromArgDigests(args)})`;
 const parameters34 = [{
   name: "",
   required: true,
@@ -3953,7 +3952,7 @@ const parameters34 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions98 = {
+const extensions85 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3964,8 +3963,8 @@ const extensions98 = {
   }
 };
 const parts85 = ["b", "mult_1"];
-const sqlIdent85 = sql.identifier(...parts85);
-const fromCallback35 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
+const sqlIdent43 = sql.identifier(...parts85);
+const fromCallback35 = (...args) => sql`${sqlIdent43}(${sqlFromArgDigests(args)})`;
 const parameters35 = [{
   name: null,
   required: true,
@@ -3977,7 +3976,7 @@ const parameters35 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions99 = {
+const extensions86 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -3988,8 +3987,8 @@ const extensions99 = {
   }
 };
 const parts86 = ["b", "mult_2"];
-const sqlIdent86 = sql.identifier(...parts86);
-const fromCallback36 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
+const sqlIdent44 = sql.identifier(...parts86);
+const fromCallback36 = (...args) => sql`${sqlIdent44}(${sqlFromArgDigests(args)})`;
 const parameters36 = [{
   name: null,
   required: true,
@@ -4001,7 +4000,7 @@ const parameters36 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions100 = {
+const extensions87 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4012,8 +4011,8 @@ const extensions100 = {
   }
 };
 const parts87 = ["b", "mult_3"];
-const sqlIdent87 = sql.identifier(...parts87);
-const fromCallback37 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
+const sqlIdent45 = sql.identifier(...parts87);
+const fromCallback37 = (...args) => sql`${sqlIdent45}(${sqlFromArgDigests(args)})`;
 const parameters37 = [{
   name: null,
   required: true,
@@ -4025,7 +4024,7 @@ const parameters37 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions101 = {
+const extensions88 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4036,8 +4035,8 @@ const extensions101 = {
   }
 };
 const parts88 = ["b", "mult_4"];
-const sqlIdent88 = sql.identifier(...parts88);
-const fromCallback38 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
+const sqlIdent46 = sql.identifier(...parts88);
+const fromCallback38 = (...args) => sql`${sqlIdent46}(${sqlFromArgDigests(args)})`;
 const parameters38 = [{
   name: null,
   required: true,
@@ -4049,7 +4048,7 @@ const parameters38 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions102 = {
+const extensions89 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4061,8 +4060,8 @@ const extensions102 = {
   singleOutputParameterName: "ino"
 };
 const parts89 = ["c", "func_in_inout"];
-const sqlIdent89 = sql.identifier(...parts89);
-const fromCallback39 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
+const sqlIdent47 = sql.identifier(...parts89);
+const fromCallback39 = (...args) => sql`${sqlIdent47}(${sqlFromArgDigests(args)})`;
 const parameters39 = [{
   name: "i",
   required: true,
@@ -4074,7 +4073,7 @@ const parameters39 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions103 = {
+const extensions90 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4085,10 +4084,10 @@ const extensions103 = {
   }
 };
 const parts90 = ["c", "func_out_out"];
-const sqlIdent90 = sql.identifier(...parts90);
-const fromCallback40 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
+const sqlIdent48 = sql.identifier(...parts90);
+const fromCallback40 = (...args) => sql`${sqlIdent48}(${sqlFromArgDigests(args)})`;
 const parameters40 = [];
-const extensions104 = {
+const extensions91 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4099,10 +4098,10 @@ const extensions104 = {
   }
 };
 const parts91 = ["c", "func_out_out_setof"];
-const sqlIdent91 = sql.identifier(...parts91);
-const fromCallback41 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
+const sqlIdent49 = sql.identifier(...parts91);
+const fromCallback41 = (...args) => sql`${sqlIdent49}(${sqlFromArgDigests(args)})`;
 const parameters41 = [];
-const extensions105 = {
+const extensions92 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4113,10 +4112,10 @@ const extensions105 = {
   }
 };
 const parts92 = ["c", "func_out_out_unnamed"];
-const sqlIdent92 = sql.identifier(...parts92);
-const fromCallback42 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
+const sqlIdent50 = sql.identifier(...parts92);
+const fromCallback42 = (...args) => sql`${sqlIdent50}(${sqlFromArgDigests(args)})`;
 const parameters42 = [];
-const extensions106 = {
+const extensions93 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4128,8 +4127,8 @@ const extensions106 = {
   singleOutputParameterName: "ino"
 };
 const parts93 = ["c", "mutation_in_inout"];
-const sqlIdent93 = sql.identifier(...parts93);
-const fromCallback43 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
+const sqlIdent51 = sql.identifier(...parts93);
+const fromCallback43 = (...args) => sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
 const parameters43 = [{
   name: "i",
   required: true,
@@ -4141,7 +4140,7 @@ const parameters43 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions107 = {
+const extensions94 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4152,10 +4151,10 @@ const extensions107 = {
   }
 };
 const parts94 = ["c", "mutation_out_out"];
-const sqlIdent94 = sql.identifier(...parts94);
-const fromCallback44 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
+const sqlIdent52 = sql.identifier(...parts94);
+const fromCallback44 = (...args) => sql`${sqlIdent52}(${sqlFromArgDigests(args)})`;
 const parameters44 = [];
-const extensions108 = {
+const extensions95 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4166,10 +4165,10 @@ const extensions108 = {
   }
 };
 const parts95 = ["c", "mutation_out_out_setof"];
-const sqlIdent95 = sql.identifier(...parts95);
-const fromCallback45 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
+const sqlIdent53 = sql.identifier(...parts95);
+const fromCallback45 = (...args) => sql`${sqlIdent53}(${sqlFromArgDigests(args)})`;
 const parameters45 = [];
-const extensions109 = {
+const extensions96 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4180,10 +4179,10 @@ const extensions109 = {
   }
 };
 const parts96 = ["c", "mutation_out_out_unnamed"];
-const sqlIdent96 = sql.identifier(...parts96);
-const fromCallback46 = (...args) => sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
+const sqlIdent54 = sql.identifier(...parts96);
+const fromCallback46 = (...args) => sql`${sqlIdent54}(${sqlFromArgDigests(args)})`;
 const parameters46 = [];
-const extensions110 = {
+const extensions97 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4195,10 +4194,10 @@ const extensions110 = {
   }
 };
 const parts97 = ["c", "search_test_summaries"];
-const sqlIdent97 = sql.identifier(...parts97);
-const fromCallback47 = (...args) => sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
+const sqlIdent55 = sql.identifier(...parts97);
+const fromCallback47 = (...args) => sql`${sqlIdent55}(${sqlFromArgDigests(args)})`;
 const parameters47 = [];
-const extensions111 = {
+const extensions98 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4209,8 +4208,8 @@ const extensions111 = {
   }
 };
 const parts98 = ["a", "optional_missing_middle_1"];
-const sqlIdent98 = sql.identifier(...parts98);
-const fromCallback48 = (...args) => sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
+const sqlIdent56 = sql.identifier(...parts98);
+const fromCallback48 = (...args) => sql`${sqlIdent56}(${sqlFromArgDigests(args)})`;
 const parameters48 = [{
   name: "",
   required: true,
@@ -4227,7 +4226,7 @@ const parameters48 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions112 = {
+const extensions99 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4238,8 +4237,8 @@ const extensions112 = {
   }
 };
 const parts99 = ["a", "optional_missing_middle_2"];
-const sqlIdent99 = sql.identifier(...parts99);
-const fromCallback49 = (...args) => sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
+const sqlIdent57 = sql.identifier(...parts99);
+const fromCallback49 = (...args) => sql`${sqlIdent57}(${sqlFromArgDigests(args)})`;
 const parameters49 = [{
   name: "a",
   required: true,
@@ -4256,7 +4255,7 @@ const parameters49 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions113 = {
+const extensions100 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4267,8 +4266,8 @@ const extensions113 = {
   }
 };
 const parts100 = ["a", "optional_missing_middle_3"];
-const sqlIdent100 = sql.identifier(...parts100);
-const fromCallback50 = (...args) => sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
+const sqlIdent58 = sql.identifier(...parts100);
+const fromCallback50 = (...args) => sql`${sqlIdent58}(${sqlFromArgDigests(args)})`;
 const parameters50 = [{
   name: "a",
   required: true,
@@ -4285,7 +4284,7 @@ const parameters50 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions114 = {
+const extensions101 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4296,8 +4295,8 @@ const extensions114 = {
   }
 };
 const parts101 = ["a", "optional_missing_middle_4"];
-const sqlIdent101 = sql.identifier(...parts101);
-const fromCallback51 = (...args) => sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
+const sqlIdent59 = sql.identifier(...parts101);
+const fromCallback51 = (...args) => sql`${sqlIdent59}(${sqlFromArgDigests(args)})`;
 const parameters51 = [{
   name: "",
   required: true,
@@ -4314,7 +4313,7 @@ const parameters51 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions115 = {
+const extensions102 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4325,8 +4324,8 @@ const extensions115 = {
   }
 };
 const parts102 = ["a", "optional_missing_middle_5"];
-const sqlIdent102 = sql.identifier(...parts102);
-const fromCallback52 = (...args) => sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
+const sqlIdent60 = sql.identifier(...parts102);
+const fromCallback52 = (...args) => sql`${sqlIdent60}(${sqlFromArgDigests(args)})`;
 const parameters52 = [{
   name: "a",
   required: true,
@@ -4343,7 +4342,7 @@ const parameters52 = [{
   notNull: true,
   codec: TYPES.int
 }];
-const extensions116 = {
+const extensions103 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4354,10 +4353,10 @@ const extensions116 = {
   }
 };
 const parts103 = ["c", "func_out_unnamed_out_out_unnamed"];
-const sqlIdent103 = sql.identifier(...parts103);
-const fromCallback53 = (...args) => sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
+const sqlIdent61 = sql.identifier(...parts103);
+const fromCallback53 = (...args) => sql`${sqlIdent61}(${sqlFromArgDigests(args)})`;
 const parameters53 = [];
-const extensions117 = {
+const extensions104 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4368,15 +4367,15 @@ const extensions117 = {
   }
 };
 const parts104 = ["c", "func_returns_table_multi_col"];
-const sqlIdent104 = sql.identifier(...parts104);
-const fromCallback54 = (...args) => sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
+const sqlIdent62 = sql.identifier(...parts104);
+const fromCallback54 = (...args) => sql`${sqlIdent62}(${sqlFromArgDigests(args)})`;
 const parameters54 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions118 = {
+const extensions105 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4387,8 +4386,8 @@ const extensions118 = {
   }
 };
 const parts105 = ["c", "int_set_mutation"];
-const sqlIdent105 = sql.identifier(...parts105);
-const fromCallback55 = (...args) => sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
+const sqlIdent63 = sql.identifier(...parts105);
+const fromCallback55 = (...args) => sql`${sqlIdent63}(${sqlFromArgDigests(args)})`;
 const parameters55 = [{
   name: "x",
   required: true,
@@ -4405,7 +4404,7 @@ const parameters55 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions119 = {
+const extensions106 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4416,8 +4415,8 @@ const extensions119 = {
   }
 };
 const parts106 = ["c", "int_set_query"];
-const sqlIdent106 = sql.identifier(...parts106);
-const fromCallback56 = (...args) => sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
+const sqlIdent64 = sql.identifier(...parts106);
+const fromCallback56 = (...args) => sql`${sqlIdent64}(${sqlFromArgDigests(args)})`;
 const parameters56 = [{
   name: "x",
   required: true,
@@ -4434,7 +4433,7 @@ const parameters56 = [{
   notNull: false,
   codec: TYPES.int
 }];
-const extensions120 = {
+const extensions107 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4445,10 +4444,10 @@ const extensions120 = {
   }
 };
 const parts107 = ["c", "mutation_out_unnamed_out_out_unnamed"];
-const sqlIdent107 = sql.identifier(...parts107);
-const fromCallback57 = (...args) => sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
+const sqlIdent65 = sql.identifier(...parts107);
+const fromCallback57 = (...args) => sql`${sqlIdent65}(${sqlFromArgDigests(args)})`;
 const parameters57 = [];
-const extensions121 = {
+const extensions108 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4459,15 +4458,15 @@ const extensions121 = {
   }
 };
 const parts108 = ["c", "mutation_returns_table_multi_col"];
-const sqlIdent108 = sql.identifier(...parts108);
-const fromCallback58 = (...args) => sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
+const sqlIdent66 = sql.identifier(...parts108);
+const fromCallback58 = (...args) => sql`${sqlIdent66}(${sqlFromArgDigests(args)})`;
 const parameters58 = [{
   name: "i",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions122 = {
+const extensions109 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4478,15 +4477,15 @@ const extensions122 = {
   }
 };
 const parts109 = ["b", "guid_fn"];
-const sqlIdent109 = sql.identifier(...parts109);
-const fromCallback59 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
+const sqlIdent67 = sql.identifier(...parts109);
+const fromCallback59 = (...args) => sql`${sqlIdent67}(${sqlFromArgDigests(args)})`;
 const parameters59 = [{
   name: "g",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_bGuid_bGuid
+  codec: bGuidCodec
 }];
-const extensions123 = {
+const extensions110 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4497,10 +4496,10 @@ const extensions123 = {
   }
 };
 const parts110 = ["a", "mutation_interval_array"];
-const sqlIdent110 = sql.identifier(...parts110);
-const fromCallback60 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
+const sqlIdent68 = sql.identifier(...parts110);
+const fromCallback60 = (...args) => sql`${sqlIdent68}(${sqlFromArgDigests(args)})`;
 const parameters60 = [];
-const extensions124 = {
+const extensions111 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4511,10 +4510,10 @@ const extensions124 = {
   }
 };
 const parts111 = ["a", "query_interval_array"];
-const sqlIdent111 = sql.identifier(...parts111);
-const fromCallback61 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
+const sqlIdent69 = sql.identifier(...parts111);
+const fromCallback61 = (...args) => sql`${sqlIdent69}(${sqlFromArgDigests(args)})`;
 const parameters61 = [];
-const extensions125 = {
+const extensions112 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4525,10 +4524,10 @@ const extensions125 = {
   }
 };
 const parts112 = ["a", "mutation_text_array"];
-const sqlIdent112 = sql.identifier(...parts112);
-const fromCallback62 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
+const sqlIdent70 = sql.identifier(...parts112);
+const fromCallback62 = (...args) => sql`${sqlIdent70}(${sqlFromArgDigests(args)})`;
 const parameters62 = [];
-const extensions126 = {
+const extensions113 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -4539,10 +4538,10 @@ const extensions126 = {
   }
 };
 const parts113 = ["a", "query_text_array"];
-const sqlIdent113 = sql.identifier(...parts113);
-const fromCallback63 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
+const sqlIdent71 = sql.identifier(...parts113);
+const fromCallback63 = (...args) => sql`${sqlIdent71}(${sqlFromArgDigests(args)})`;
 const parameters63 = [];
-const extensions127 = {
+const extensions114 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4553,7 +4552,7 @@ const extensions127 = {
     behavior: ["-insert", "-update", "-delete"]
   }
 };
-const extensions128 = {
+const extensions115 = {
   description: "Should output as Input",
   pg: {
     serviceName: "main",
@@ -4570,7 +4569,7 @@ const uniques2 = [{
     tags: Object.create(null)
   }
 }];
-const extensions129 = {
+const extensions116 = {
   description: "Should output as Patch",
   pg: {
     serviceName: "main",
@@ -4587,7 +4586,7 @@ const uniques3 = [{
     tags: Object.create(null)
   }
 }];
-const extensions130 = {
+const extensions117 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4604,7 +4603,7 @@ const uniques4 = [{
     tags: Object.create(null)
   }
 }];
-const extensions131 = {
+const extensions118 = {
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4621,7 +4620,7 @@ const uniques5 = [{
     tags: Object.create(null)
   }
 }];
-const extensions132 = {
+const extensions119 = {
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   pg: {
     serviceName: "main",
@@ -4638,7 +4637,7 @@ const uniques6 = [{
     tags: Object.create(null)
   }
 }];
-const extensions133 = {
+const extensions120 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4655,7 +4654,7 @@ const uniques7 = [{
     tags: Object.create(null)
   }
 }];
-const extensions134 = {
+const extensions121 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4669,14 +4668,14 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: registryConfig_pgCodecs_foreignKey_foreignKey.sqlType,
-  codec: registryConfig_pgCodecs_foreignKey_foreignKey,
+  from: foreignKeyCodec.sqlType,
+  codec: foreignKeyCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions134
+  extensions: extensions121
 };
-const extensions135 = {
+const extensions122 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4693,7 +4692,7 @@ const uniques9 = [{
     tags: Object.create(null)
   }
 }];
-const extensions136 = {
+const extensions123 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4703,7 +4702,7 @@ const extensions136 = {
   tags: {}
 };
 const uniques10 = [];
-const extensions137 = {
+const extensions124 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4726,14 +4725,14 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
   executor: executor_mainPgExecutor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey.sqlType,
-  codec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+  from: uniqueForeignKeyCodec.sqlType,
+  codec: uniqueForeignKeyCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions137
+  extensions: extensions124
 };
-const extensions138 = {
+const extensions125 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4750,7 +4749,7 @@ const uniques12 = [{
     tags: Object.create(null)
   }
 }];
-const extensions139 = {
+const extensions126 = {
   description: "Tracks the person's secret",
   pg: {
     serviceName: "main",
@@ -4773,14 +4772,14 @@ const registryConfig_pgResources_c_person_secret_c_person_secret = {
   executor: executor_mainPgExecutor,
   name: "c_person_secret",
   identifier: "main.c.person_secret",
-  from: registryConfig_pgCodecs_cPersonSecret_cPersonSecret.sqlType,
-  codec: registryConfig_pgCodecs_cPersonSecret_cPersonSecret,
+  from: cPersonSecretCodec.sqlType,
+  codec: cPersonSecretCodec,
   uniques: uniques13,
   isVirtual: false,
   description: "Tracks the person's secret",
-  extensions: extensions139
+  extensions: extensions126
 };
-const extensions140 = {
+const extensions127 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4797,7 +4796,7 @@ const uniques14 = [{
     tags: Object.create(null)
   }
 }];
-const extensions141 = {
+const extensions128 = {
   description: "YOYOYO!!",
   pg: {
     serviceName: "main",
@@ -4809,7 +4808,7 @@ const extensions141 = {
   }
 };
 const uniques15 = [];
-const extensions142 = {
+const extensions129 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4830,14 +4829,14 @@ const registryConfig_pgResources_c_compound_key_c_compound_key = {
   executor: executor_mainPgExecutor,
   name: "c_compound_key",
   identifier: "main.c.compound_key",
-  from: registryConfig_pgCodecs_cCompoundKey_cCompoundKey.sqlType,
-  codec: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+  from: cCompoundKeyCodec.sqlType,
+  codec: cCompoundKeyCodec,
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
-  extensions: extensions142
+  extensions: extensions129
 };
-const extensions143 = {
+const extensions130 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4854,7 +4853,7 @@ const uniques17 = [{
     tags: Object.create(null)
   }
 }];
-const extensions144 = {
+const extensions131 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4871,7 +4870,7 @@ const uniques18 = [{
     tags: Object.create(null)
   }
 }];
-const extensions145 = {
+const extensions132 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4888,7 +4887,7 @@ const uniques19 = [{
     tags: Object.create(null)
   }
 }];
-const extensions146 = {
+const extensions133 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -4899,21 +4898,21 @@ const extensions146 = {
   }
 };
 const parts114 = ["c", "edge_case_computed"];
-const sqlIdent114 = sql.identifier(...parts114);
-const fromCallback64 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
+const sqlIdent72 = sql.identifier(...parts114);
+const fromCallback64 = (...args) => sql`${sqlIdent72}(${sqlFromArgDigests(args)})`;
 const parameters64 = [{
   name: "edge_case",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_cEdgeCase_cEdgeCase
+  codec: cEdgeCaseCodec
 }];
 const parts115 = ["c", "return_table_without_grants"];
-const sqlIdent115 = sql.identifier(...parts115);
+const sqlIdent73 = sql.identifier(...parts115);
 const options_c_return_table_without_grants = {
   name: "c_return_table_without_grants",
   identifier: "main.c.return_table_without_grants()",
   from(...args) {
-    return sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent73}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -4931,7 +4930,7 @@ const options_c_return_table_without_grants = {
   },
   description: undefined
 };
-const extensions147 = {
+const extensions134 = {
   pg: {
     serviceName: "main",
     schemaName: "b",
@@ -4942,13 +4941,13 @@ const extensions147 = {
   }
 };
 const parts116 = ["b", "list_bde_mutation"];
-const sqlIdent116 = sql.identifier(...parts116);
-const fromCallback65 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
+const sqlIdent74 = sql.identifier(...parts116);
+const fromCallback65 = (...args) => sql`${sqlIdent74}(${sqlFromArgDigests(args)})`;
 const parameters65 = [{
   name: "b",
   required: true,
   notNull: false,
-  codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray
+  codec: pgCatalogTextArrayCodec
 }, {
   name: "d",
   required: true,
@@ -4960,7 +4959,7 @@ const parameters65 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions148 = {
+const extensions135 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -4970,7 +4969,7 @@ const extensions148 = {
   tags: {}
 };
 const uniques20 = [];
-const extensions149 = {
+const extensions136 = {
   description: "Tracks metadata about the left arms of various people",
   pg: {
     serviceName: "main",
@@ -4998,20 +4997,20 @@ const registryConfig_pgResources_c_left_arm_c_left_arm = {
   executor: executor_mainPgExecutor,
   name: "c_left_arm",
   identifier: "main.c.left_arm",
-  from: registryConfig_pgCodecs_cLeftArm_cLeftArm.sqlType,
-  codec: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+  from: cLeftArmCodec.sqlType,
+  codec: cLeftArmCodec,
   uniques: uniques21,
   isVirtual: false,
   description: "Tracks metadata about the left arms of various people",
-  extensions: extensions149
+  extensions: extensions136
 };
 const parts117 = ["b", "authenticate_fail"];
-const sqlIdent117 = sql.identifier(...parts117);
+const sqlIdent75 = sql.identifier(...parts117);
 const options_b_authenticate_fail = {
   name: "b_authenticate_fail",
   identifier: "main.b.authenticate_fail()",
   from(...args) {
-    return sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent75}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5029,7 +5028,7 @@ const options_b_authenticate_fail = {
   },
   description: undefined
 };
-const extensions150 = {
+const extensions137 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5045,20 +5044,20 @@ const resourceConfig_b_jwt_token = {
   executor: executor_mainPgExecutor,
   name: "b_jwt_token",
   identifier: "main.b.jwt_token",
-  from: registryConfig_pgCodecs_bJwtToken_bJwtToken.sqlType,
-  codec: registryConfig_pgCodecs_bJwtToken_bJwtToken,
+  from: bJwtTokenCodec.sqlType,
+  codec: bJwtTokenCodec,
   uniques: uniques22,
   isVirtual: true,
   description: undefined,
-  extensions: extensions150
+  extensions: extensions137
 };
 const parts118 = ["b", "authenticate"];
-const sqlIdent118 = sql.identifier(...parts118);
+const sqlIdent76 = sql.identifier(...parts118);
 const options_b_authenticate = {
   name: "b_authenticate",
   identifier: "main.b.authenticate(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent76}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5091,7 +5090,7 @@ const options_b_authenticate = {
   },
   description: undefined
 };
-const extensions151 = {
+const extensions138 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5112,26 +5111,26 @@ const registryConfig_pgResources_c_issue756_c_issue756 = {
   executor: executor_mainPgExecutor,
   name: "c_issue756",
   identifier: "main.c.issue756",
-  from: registryConfig_pgCodecs_cIssue756_cIssue756.sqlType,
-  codec: registryConfig_pgCodecs_cIssue756_cIssue756,
+  from: cIssue756Codec.sqlType,
+  codec: cIssue756Codec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions151
+  extensions: extensions138
 };
 const parts119 = ["c", "left_arm_identity"];
-const sqlIdent119 = sql.identifier(...parts119);
+const sqlIdent77 = sql.identifier(...parts119);
 const options_c_left_arm_identity = {
   name: "c_left_arm_identity",
   identifier: "main.c.left_arm_identity(c.left_arm)",
   from(...args) {
-    return sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent77}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "left_arm",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+    codec: cLeftArmCodec,
     extensions: {
       variant: "base"
     }
@@ -5154,12 +5153,12 @@ const options_c_left_arm_identity = {
   description: undefined
 };
 const parts120 = ["c", "issue756_mutation"];
-const sqlIdent120 = sql.identifier(...parts120);
+const sqlIdent78 = sql.identifier(...parts120);
 const options_c_issue756_mutation = {
   name: "c_issue756_mutation",
   identifier: "main.c.issue756_mutation()",
   from(...args) {
-    return sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent78}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5178,12 +5177,12 @@ const options_c_issue756_mutation = {
   description: undefined
 };
 const parts121 = ["c", "issue756_set_mutation"];
-const sqlIdent121 = sql.identifier(...parts121);
+const sqlIdent79 = sql.identifier(...parts121);
 const options_c_issue756_set_mutation = {
   name: "c_issue756_set_mutation",
   identifier: "main.c.issue756_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent79}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5202,12 +5201,12 @@ const options_c_issue756_set_mutation = {
   description: undefined
 };
 const parts122 = ["b", "authenticate_many"];
-const sqlIdent122 = sql.identifier(...parts122);
+const sqlIdent80 = sql.identifier(...parts122);
 const options_b_authenticate_many = {
   name: "b_authenticate_many",
   identifier: "main.b.authenticate_many(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent80}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5241,12 +5240,12 @@ const options_b_authenticate_many = {
   description: undefined
 };
 const parts123 = ["b", "authenticate_payload"];
-const sqlIdent123 = sql.identifier(...parts123);
+const sqlIdent81 = sql.identifier(...parts123);
 const options_b_authenticate_payload = {
   name: "b_authenticate_payload",
   identifier: "main.b.authenticate_payload(int4,numeric,int8)",
   from(...args) {
-    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent81}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "a",
@@ -5279,7 +5278,7 @@ const options_b_authenticate_payload = {
   },
   description: undefined
 };
-const extensions152 = {
+const extensions139 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5296,14 +5295,14 @@ const resourceConfig_b_auth_payload = {
   executor: executor_mainPgExecutor,
   name: "b_auth_payload",
   identifier: "main.b.auth_payload",
-  from: registryConfig_pgCodecs_bAuthPayload_bAuthPayload.sqlType,
-  codec: registryConfig_pgCodecs_bAuthPayload_bAuthPayload,
+  from: bAuthPayloadCodec.sqlType,
+  codec: bAuthPayloadCodec,
   uniques: uniques24,
   isVirtual: true,
   description: undefined,
-  extensions: extensions152
+  extensions: extensions139
 };
-const extensions153 = {
+const extensions140 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5314,8 +5313,8 @@ const extensions153 = {
   }
 };
 const parts124 = ["c", "types_mutation"];
-const sqlIdent124 = sql.identifier(...parts124);
-const fromCallback66 = (...args) => sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
+const sqlIdent82 = sql.identifier(...parts124);
+const fromCallback66 = (...args) => sql`${sqlIdent82}(${sqlFromArgDigests(args)})`;
 const parameters66 = [{
   name: "a",
   required: true,
@@ -5335,7 +5334,7 @@ const parameters66 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array
+  codec: pgCatalogInt4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5345,9 +5344,9 @@ const parameters66 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_cFloatrange_cFloatrange
+  codec: cFloatrangeCodec
 }];
-const extensions154 = {
+const extensions141 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5358,8 +5357,8 @@ const extensions154 = {
   }
 };
 const parts125 = ["c", "types_query"];
-const sqlIdent125 = sql.identifier(...parts125);
-const fromCallback67 = (...args) => sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
+const sqlIdent83 = sql.identifier(...parts125);
+const fromCallback67 = (...args) => sql`${sqlIdent83}(${sqlFromArgDigests(args)})`;
 const parameters67 = [{
   name: "a",
   required: true,
@@ -5379,7 +5378,7 @@ const parameters67 = [{
   name: "d",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array
+  codec: pgCatalogInt4ArrayCodec
 }, {
   name: "e",
   required: true,
@@ -5389,9 +5388,9 @@ const parameters67 = [{
   name: "f",
   required: true,
   notNull: true,
-  codec: registryConfig_pgCodecs_cFloatrange_cFloatrange
+  codec: cFloatrangeCodec
 }];
-const extensions155 = {
+const extensions142 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5402,15 +5401,15 @@ const extensions155 = {
   }
 };
 const parts126 = ["c", "compound_type_computed_field"];
-const sqlIdent126 = sql.identifier(...parts126);
-const fromCallback68 = (...args) => sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
+const sqlIdent84 = sql.identifier(...parts126);
+const fromCallback68 = (...args) => sql`${sqlIdent84}(${sqlFromArgDigests(args)})`;
 const parameters68 = [{
   name: "compound_type",
   required: true,
   notNull: false,
-  codec: attributes_o2_codec_cCompoundType
+  codec: cCompoundTypeCodec
 }];
-const extensions156 = {
+const extensions143 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5421,15 +5420,15 @@ const extensions156 = {
   }
 };
 const parts127 = ["a", "post_computed_interval_set"];
-const sqlIdent127 = sql.identifier(...parts127);
-const fromCallback69 = (...args) => sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
+const sqlIdent85 = sql.identifier(...parts127);
+const fromCallback69 = (...args) => sql`${sqlIdent85}(${sqlFromArgDigests(args)})`;
 const parameters69 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions157 = {
+const extensions144 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5440,15 +5439,15 @@ const extensions157 = {
   }
 };
 const parts128 = ["a", "post_computed_interval_array"];
-const sqlIdent128 = sql.identifier(...parts128);
-const fromCallback70 = (...args) => sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
+const sqlIdent86 = sql.identifier(...parts128);
+const fromCallback70 = (...args) => sql`${sqlIdent86}(${sqlFromArgDigests(args)})`;
 const parameters70 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions158 = {
+const extensions145 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5459,15 +5458,15 @@ const extensions158 = {
   }
 };
 const parts129 = ["a", "post_computed_text_array"];
-const sqlIdent129 = sql.identifier(...parts129);
-const fromCallback71 = (...args) => sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
+const sqlIdent87 = sql.identifier(...parts129);
+const fromCallback71 = (...args) => sql`${sqlIdent87}(${sqlFromArgDigests(args)})`;
 const parameters71 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }];
-const extensions159 = {
+const extensions146 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5480,20 +5479,20 @@ const extensions159 = {
   }
 };
 const parts130 = ["a", "post_computed_with_optional_arg"];
-const sqlIdent130 = sql.identifier(...parts130);
-const fromCallback72 = (...args) => sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
+const sqlIdent88 = sql.identifier(...parts130);
+const fromCallback72 = (...args) => sql`${sqlIdent88}(${sqlFromArgDigests(args)})`;
 const parameters72 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: false,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions160 = {
+const extensions147 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5506,20 +5505,20 @@ const extensions160 = {
   }
 };
 const parts131 = ["a", "post_computed_with_required_arg"];
-const sqlIdent131 = sql.identifier(...parts131);
-const fromCallback73 = (...args) => sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
+const sqlIdent89 = sql.identifier(...parts131);
+const fromCallback73 = (...args) => sql`${sqlIdent89}(${sqlFromArgDigests(args)})`;
 const parameters73 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "i",
   required: true,
   notNull: true,
   codec: TYPES.int
 }];
-const extensions161 = {
+const extensions148 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5530,15 +5529,15 @@ const extensions161 = {
   }
 };
 const parts132 = ["c", "func_out_out_compound_type"];
-const sqlIdent132 = sql.identifier(...parts132);
-const fromCallback74 = (...args) => sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
+const sqlIdent90 = sql.identifier(...parts132);
+const fromCallback74 = (...args) => sql`${sqlIdent90}(${sqlFromArgDigests(args)})`;
 const parameters74 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions162 = {
+const extensions149 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5549,15 +5548,15 @@ const extensions162 = {
   }
 };
 const parts133 = ["c", "mutation_out_out_compound_type"];
-const sqlIdent133 = sql.identifier(...parts133);
-const fromCallback75 = (...args) => sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
+const sqlIdent91 = sql.identifier(...parts133);
+const fromCallback75 = (...args) => sql`${sqlIdent91}(${sqlFromArgDigests(args)})`;
 const parameters75 = [{
   name: "i1",
   required: true,
   notNull: false,
   codec: TYPES.int
 }];
-const extensions163 = {
+const extensions150 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5568,13 +5567,13 @@ const extensions163 = {
   }
 };
 const parts134 = ["a", "post_headline_trimmed"];
-const sqlIdent134 = sql.identifier(...parts134);
-const fromCallback76 = (...args) => sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
+const sqlIdent92 = sql.identifier(...parts134);
+const fromCallback76 = (...args) => sql`${sqlIdent92}(${sqlFromArgDigests(args)})`;
 const parameters76 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5586,7 +5585,7 @@ const parameters76 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions164 = {
+const extensions151 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5597,13 +5596,13 @@ const extensions164 = {
   }
 };
 const parts135 = ["a", "post_headline_trimmed_no_defaults"];
-const sqlIdent135 = sql.identifier(...parts135);
-const fromCallback77 = (...args) => sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
+const sqlIdent93 = sql.identifier(...parts135);
+const fromCallback77 = (...args) => sql`${sqlIdent93}(${sqlFromArgDigests(args)})`;
 const parameters77 = [{
   name: "post",
   required: true,
   notNull: false,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: true,
@@ -5615,7 +5614,7 @@ const parameters77 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions165 = {
+const extensions152 = {
   pg: {
     serviceName: "main",
     schemaName: "a",
@@ -5626,13 +5625,13 @@ const extensions165 = {
   }
 };
 const parts136 = ["a", "post_headline_trimmed_strict"];
-const sqlIdent136 = sql.identifier(...parts136);
-const fromCallback78 = (...args) => sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
+const sqlIdent94 = sql.identifier(...parts136);
+const fromCallback78 = (...args) => sql`${sqlIdent94}(${sqlFromArgDigests(args)})`;
 const parameters78 = [{
   name: "post",
   required: true,
   notNull: true,
-  codec: attributes_post_codec_post
+  codec: postCodec
 }, {
   name: "length",
   required: false,
@@ -5644,7 +5643,7 @@ const parameters78 = [{
   notNull: true,
   codec: TYPES.text
 }];
-const extensions166 = {
+const extensions153 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -5655,8 +5654,8 @@ const extensions166 = {
   }
 };
 const parts137 = ["c", "query_output_two_rows"];
-const sqlIdent137 = sql.identifier(...parts137);
-const fromCallback79 = (...args) => sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
+const sqlIdent95 = sql.identifier(...parts137);
+const fromCallback79 = (...args) => sql`${sqlIdent95}(${sqlFromArgDigests(args)})`;
 const parameters79 = [{
   name: "left_arm_id",
   required: true,
@@ -5673,7 +5672,7 @@ const parameters79 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions167 = {
+const extensions154 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -5694,20 +5693,20 @@ const registryConfig_pgResources_post_post = {
   executor: executor_mainPgExecutor,
   name: "post",
   identifier: "main.a.post",
-  from: attributes_post_codec_post.sqlType,
-  codec: attributes_post_codec_post,
+  from: postCodec.sqlType,
+  codec: postCodec,
   uniques: uniques25,
   isVirtual: false,
   description: undefined,
-  extensions: extensions167
+  extensions: extensions154
 };
 const parts138 = ["c", "compound_type_set_query"];
-const sqlIdent138 = sql.identifier(...parts138);
+const sqlIdent96 = sql.identifier(...parts138);
 const options_c_compound_type_set_query = {
   name: "c_compound_type_set_query",
   identifier: "main.c.compound_type_set_query()",
   from(...args) {
-    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent96}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -5725,7 +5724,7 @@ const options_c_compound_type_set_query = {
   },
   description: undefined
 };
-const extensions168 = {
+const extensions155 = {
   description: "Awesome feature!",
   pg: {
     serviceName: "main",
@@ -5741,26 +5740,26 @@ const resourceConfig_c_compound_type = {
   executor: executor_mainPgExecutor,
   name: "c_compound_type",
   identifier: "main.c.compound_type",
-  from: attributes_o2_codec_cCompoundType.sqlType,
-  codec: attributes_o2_codec_cCompoundType,
+  from: cCompoundTypeCodec.sqlType,
+  codec: cCompoundTypeCodec,
   uniques: uniques26,
   isVirtual: true,
   description: "Awesome feature!",
-  extensions: extensions168
+  extensions: extensions155
 };
 const parts139 = ["b", "compound_type_mutation"];
-const sqlIdent139 = sql.identifier(...parts139);
+const sqlIdent97 = sql.identifier(...parts139);
 const options_b_compound_type_mutation = {
   name: "b_compound_type_mutation",
   identifier: "main.b.compound_type_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent97}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5778,18 +5777,18 @@ const options_b_compound_type_mutation = {
   description: undefined
 };
 const parts140 = ["b", "compound_type_query"];
-const sqlIdent140 = sql.identifier(...parts140);
+const sqlIdent98 = sql.identifier(...parts140);
 const options_b_compound_type_query = {
   name: "b_compound_type_query",
   identifier: "main.b.compound_type_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent98}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -5807,18 +5806,18 @@ const options_b_compound_type_query = {
   description: undefined
 };
 const parts141 = ["b", "compound_type_set_mutation"];
-const sqlIdent141 = sql.identifier(...parts141);
+const sqlIdent99 = sql.identifier(...parts141);
 const options_b_compound_type_set_mutation = {
   name: "b_compound_type_set_mutation",
   identifier: "main.b.compound_type_set_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent141}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent99}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -5836,12 +5835,12 @@ const options_b_compound_type_set_mutation = {
   description: undefined
 };
 const parts142 = ["c", "table_mutation"];
-const sqlIdent142 = sql.identifier(...parts142);
+const sqlIdent100 = sql.identifier(...parts142);
 const options_c_table_mutation = {
   name: "c_table_mutation",
   identifier: "main.c.table_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent142}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent100}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5865,12 +5864,12 @@ const options_c_table_mutation = {
   description: undefined
 };
 const parts143 = ["c", "table_query"];
-const sqlIdent143 = sql.identifier(...parts143);
+const sqlIdent101 = sql.identifier(...parts143);
 const options_c_table_query = {
   name: "c_table_query",
   identifier: "main.c.table_query(int4)",
   from(...args) {
-    return sql`${sqlIdent143}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent101}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -5894,18 +5893,18 @@ const options_c_table_query = {
   description: undefined
 };
 const parts144 = ["a", "post_with_suffix"];
-const sqlIdent144 = sql.identifier(...parts144);
+const sqlIdent102 = sql.identifier(...parts144);
 const options_post_with_suffix = {
   name: "post_with_suffix",
   identifier: "main.a.post_with_suffix(a.post,text)",
   from(...args) {
-    return sql`${sqlIdent144}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent102}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "suffix",
     required: true,
@@ -5929,18 +5928,18 @@ const options_post_with_suffix = {
   description: undefined
 };
 const parts145 = ["a", "mutation_compound_type_array"];
-const sqlIdent145 = sql.identifier(...parts145);
+const sqlIdent103 = sql.identifier(...parts145);
 const options_mutation_compound_type_array = {
   name: "mutation_compound_type_array",
   identifier: "main.a.mutation_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent145}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent103}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -5958,18 +5957,18 @@ const options_mutation_compound_type_array = {
   description: undefined
 };
 const parts146 = ["a", "query_compound_type_array"];
-const sqlIdent146 = sql.identifier(...parts146);
+const sqlIdent104 = sql.identifier(...parts146);
 const options_query_compound_type_array = {
   name: "query_compound_type_array",
   identifier: "main.a.query_compound_type_array(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent146}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent104}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -5987,18 +5986,18 @@ const options_query_compound_type_array = {
   description: undefined
 };
 const parts147 = ["b", "compound_type_array_mutation"];
-const sqlIdent147 = sql.identifier(...parts147);
+const sqlIdent105 = sql.identifier(...parts147);
 const options_b_compound_type_array_mutation = {
   name: "b_compound_type_array_mutation",
   identifier: "main.b.compound_type_array_mutation(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent147}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent105}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6016,18 +6015,18 @@ const options_b_compound_type_array_mutation = {
   description: undefined
 };
 const parts148 = ["b", "compound_type_array_query"];
-const sqlIdent148 = sql.identifier(...parts148);
+const sqlIdent106 = sql.identifier(...parts148);
 const options_b_compound_type_array_query = {
   name: "b_compound_type_array_query",
   identifier: "main.b.compound_type_array_query(c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent148}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent106}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6045,23 +6044,23 @@ const options_b_compound_type_array_query = {
   description: undefined
 };
 const parts149 = ["a", "post_computed_compound_type_array"];
-const sqlIdent149 = sql.identifier(...parts149);
+const sqlIdent107 = sql.identifier(...parts149);
 const options_post_computed_compound_type_array = {
   name: "post_computed_compound_type_array",
   identifier: "main.a.post_computed_compound_type_array(a.post,c.compound_type)",
   from(...args) {
-    return sql`${sqlIdent149}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent107}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "post",
     required: true,
     notNull: false,
-    codec: attributes_post_codec_post
+    codec: postCodec
   }, {
     name: "object",
     required: true,
     notNull: false,
-    codec: attributes_o2_codec_cCompoundType
+    codec: cCompoundTypeCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -6079,18 +6078,18 @@ const options_post_computed_compound_type_array = {
   description: undefined
 };
 const parts150 = ["a", "post_many"];
-const sqlIdent150 = sql.identifier(...parts150);
+const sqlIdent108 = sql.identifier(...parts150);
 const options_post_many = {
   name: "post_many",
   identifier: "main.a.post_many(a._post)",
   from(...args) {
-    return sql`${sqlIdent150}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent108}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "posts",
     required: true,
     notNull: false,
-    codec: registryConfig_pgCodecs_postArray_postArray
+    codec: postArrayCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6107,7 +6106,7 @@ const options_post_many = {
   },
   description: undefined
 };
-const extensions169 = {
+const extensions156 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6122,15 +6121,15 @@ const extensions169 = {
   singleOutputParameterName: "o1"
 };
 const parts151 = ["c", "person_computed_out"];
-const sqlIdent151 = sql.identifier(...parts151);
-const fromCallback80 = (...args) => sql`${sqlIdent151}(${sqlFromArgDigests(args)})`;
+const sqlIdent109 = sql.identifier(...parts151);
+const fromCallback80 = (...args) => sql`${sqlIdent109}(${sqlFromArgDigests(args)})`;
 const parameters80 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }];
-const extensions170 = {
+const extensions157 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6142,15 +6141,15 @@ const extensions170 = {
   }
 };
 const parts152 = ["c", "person_first_name"];
-const sqlIdent152 = sql.identifier(...parts152);
-const fromCallback81 = (...args) => sql`${sqlIdent152}(${sqlFromArgDigests(args)})`;
+const sqlIdent110 = sql.identifier(...parts152);
+const fromCallback81 = (...args) => sql`${sqlIdent110}(${sqlFromArgDigests(args)})`;
 const parameters81 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }];
-const extensions171 = {
+const extensions158 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6161,15 +6160,15 @@ const extensions171 = {
   }
 };
 const parts153 = ["c", "person_computed_out_out"];
-const sqlIdent153 = sql.identifier(...parts153);
-const fromCallback82 = (...args) => sql`${sqlIdent153}(${sqlFromArgDigests(args)})`;
+const sqlIdent111 = sql.identifier(...parts153);
+const fromCallback82 = (...args) => sql`${sqlIdent111}(${sqlFromArgDigests(args)})`;
 const parameters82 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }];
-const extensions172 = {
+const extensions159 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6181,20 +6180,20 @@ const extensions172 = {
   singleOutputParameterName: "ino"
 };
 const parts154 = ["c", "person_computed_inout"];
-const sqlIdent154 = sql.identifier(...parts154);
-const fromCallback83 = (...args) => sql`${sqlIdent154}(${sqlFromArgDigests(args)})`;
+const sqlIdent112 = sql.identifier(...parts154);
+const fromCallback83 = (...args) => sql`${sqlIdent112}(${sqlFromArgDigests(args)})`;
 const parameters83 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions173 = {
+const extensions160 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6205,20 +6204,20 @@ const extensions173 = {
   }
 };
 const parts155 = ["c", "person_computed_inout_out"];
-const sqlIdent155 = sql.identifier(...parts155);
-const fromCallback84 = (...args) => sql`${sqlIdent155}(${sqlFromArgDigests(args)})`;
+const sqlIdent113 = sql.identifier(...parts155);
+const fromCallback84 = (...args) => sql`${sqlIdent113}(${sqlFromArgDigests(args)})`;
 const parameters84 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }, {
   name: "ino",
   required: true,
   notNull: false,
   codec: TYPES.text
 }];
-const extensions174 = {
+const extensions161 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6230,20 +6229,20 @@ const extensions174 = {
   }
 };
 const parts156 = ["c", "person_exists"];
-const sqlIdent156 = sql.identifier(...parts156);
-const fromCallback85 = (...args) => sql`${sqlIdent156}(${sqlFromArgDigests(args)})`;
+const sqlIdent114 = sql.identifier(...parts156);
+const fromCallback85 = (...args) => sql`${sqlIdent114}(${sqlFromArgDigests(args)})`;
 const parameters85 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }, {
   name: "email",
   required: true,
   notNull: false,
-  codec: attributes_email_codec_bEmail
+  codec: bEmailCodec
 }];
-const extensions175 = {
+const extensions162 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6254,15 +6253,15 @@ const extensions175 = {
   }
 };
 const parts157 = ["c", "person_computed_first_arg_inout_out"];
-const sqlIdent157 = sql.identifier(...parts157);
-const fromCallback86 = (...args) => sql`${sqlIdent157}(${sqlFromArgDigests(args)})`;
+const sqlIdent115 = sql.identifier(...parts157);
+const fromCallback86 = (...args) => sql`${sqlIdent115}(${sqlFromArgDigests(args)})`;
 const parameters86 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }];
-const extensions176 = {
+const extensions163 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6273,8 +6272,8 @@ const extensions176 = {
   }
 };
 const parts158 = ["c", "func_out_complex"];
-const sqlIdent158 = sql.identifier(...parts158);
-const fromCallback87 = (...args) => sql`${sqlIdent158}(${sqlFromArgDigests(args)})`;
+const sqlIdent116 = sql.identifier(...parts158);
+const fromCallback87 = (...args) => sql`${sqlIdent116}(${sqlFromArgDigests(args)})`;
 const parameters87 = [{
   name: "a",
   required: true,
@@ -6286,7 +6285,7 @@ const parameters87 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions177 = {
+const extensions164 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6297,8 +6296,8 @@ const extensions177 = {
   }
 };
 const parts159 = ["c", "func_out_complex_setof"];
-const sqlIdent159 = sql.identifier(...parts159);
-const fromCallback88 = (...args) => sql`${sqlIdent159}(${sqlFromArgDigests(args)})`;
+const sqlIdent117 = sql.identifier(...parts159);
+const fromCallback88 = (...args) => sql`${sqlIdent117}(${sqlFromArgDigests(args)})`;
 const parameters88 = [{
   name: "a",
   required: true,
@@ -6310,7 +6309,7 @@ const parameters88 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions178 = {
+const extensions165 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6321,8 +6320,8 @@ const extensions178 = {
   }
 };
 const parts160 = ["c", "mutation_out_complex"];
-const sqlIdent160 = sql.identifier(...parts160);
-const fromCallback89 = (...args) => sql`${sqlIdent160}(${sqlFromArgDigests(args)})`;
+const sqlIdent118 = sql.identifier(...parts160);
+const fromCallback89 = (...args) => sql`${sqlIdent118}(${sqlFromArgDigests(args)})`;
 const parameters89 = [{
   name: "a",
   required: true,
@@ -6334,7 +6333,7 @@ const parameters89 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions179 = {
+const extensions166 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6345,8 +6344,8 @@ const extensions179 = {
   }
 };
 const parts161 = ["c", "mutation_out_complex_setof"];
-const sqlIdent161 = sql.identifier(...parts161);
-const fromCallback90 = (...args) => sql`${sqlIdent161}(${sqlFromArgDigests(args)})`;
+const sqlIdent119 = sql.identifier(...parts161);
+const fromCallback90 = (...args) => sql`${sqlIdent119}(${sqlFromArgDigests(args)})`;
 const parameters90 = [{
   name: "a",
   required: true,
@@ -6358,7 +6357,7 @@ const parameters90 = [{
   notNull: false,
   codec: TYPES.text
 }];
-const extensions180 = {
+const extensions167 = {
   pg: {
     serviceName: "main",
     schemaName: "c",
@@ -6369,13 +6368,13 @@ const extensions180 = {
   }
 };
 const parts162 = ["c", "person_computed_complex"];
-const sqlIdent162 = sql.identifier(...parts162);
-const fromCallback91 = (...args) => sql`${sqlIdent162}(${sqlFromArgDigests(args)})`;
+const sqlIdent120 = sql.identifier(...parts162);
+const fromCallback91 = (...args) => sql`${sqlIdent120}(${sqlFromArgDigests(args)})`;
 const parameters91 = [{
   name: "person",
   required: true,
   notNull: false,
-  codec: attributes_person_codec_cPerson
+  codec: cPersonCodec
 }, {
   name: "a",
   required: true,
@@ -6388,18 +6387,18 @@ const parameters91 = [{
   codec: TYPES.text
 }];
 const parts163 = ["c", "person_first_post"];
-const sqlIdent163 = sql.identifier(...parts163);
+const sqlIdent121 = sql.identifier(...parts163);
 const options_c_person_first_post = {
   name: "c_person_first_post",
   identifier: "main.c.person_first_post(c.person)",
   from(...args) {
-    return sql`${sqlIdent163}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent121}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6416,7 +6415,7 @@ const options_c_person_first_post = {
   },
   description: "The first post by the person."
 };
-const extensions181 = {
+const extensions168 = {
   description: "Person test comment",
   pg: {
     serviceName: "main",
@@ -6444,20 +6443,20 @@ const registryConfig_pgResources_c_person_c_person = {
   executor: executor_mainPgExecutor,
   name: "c_person",
   identifier: "main.c.person",
-  from: attributes_person_codec_cPerson.sqlType,
-  codec: attributes_person_codec_cPerson,
+  from: cPersonCodec.sqlType,
+  codec: cPersonCodec,
   uniques: uniques27,
   isVirtual: false,
   description: "Person test comment",
-  extensions: extensions181
+  extensions: extensions168
 };
 const parts164 = ["c", "badly_behaved_function"];
-const sqlIdent164 = sql.identifier(...parts164);
+const sqlIdent122 = sql.identifier(...parts164);
 const options_c_badly_behaved_function = {
   name: "c_badly_behaved_function",
   identifier: "main.c.badly_behaved_function()",
   from(...args) {
-    return sql`${sqlIdent164}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent122}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6477,12 +6476,12 @@ const options_c_badly_behaved_function = {
   description: undefined
 };
 const parts165 = ["c", "func_out_table"];
-const sqlIdent165 = sql.identifier(...parts165);
+const sqlIdent123 = sql.identifier(...parts165);
 const options_c_func_out_table = {
   name: "c_func_out_table",
   identifier: "main.c.func_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent165}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent123}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6501,12 +6500,12 @@ const options_c_func_out_table = {
   description: undefined
 };
 const parts166 = ["c", "func_out_table_setof"];
-const sqlIdent166 = sql.identifier(...parts166);
+const sqlIdent124 = sql.identifier(...parts166);
 const options_c_func_out_table_setof = {
   name: "c_func_out_table_setof",
   identifier: "main.c.func_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent166}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent124}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6525,12 +6524,12 @@ const options_c_func_out_table_setof = {
   description: undefined
 };
 const parts167 = ["c", "mutation_out_table"];
-const sqlIdent167 = sql.identifier(...parts167);
+const sqlIdent125 = sql.identifier(...parts167);
 const options_c_mutation_out_table = {
   name: "c_mutation_out_table",
   identifier: "main.c.mutation_out_table(c.person)",
   from(...args) {
-    return sql`${sqlIdent167}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent125}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6549,12 +6548,12 @@ const options_c_mutation_out_table = {
   description: undefined
 };
 const parts168 = ["c", "mutation_out_table_setof"];
-const sqlIdent168 = sql.identifier(...parts168);
+const sqlIdent126 = sql.identifier(...parts168);
 const options_c_mutation_out_table_setof = {
   name: "c_mutation_out_table_setof",
   identifier: "main.c.mutation_out_table_setof(c.person)",
   from(...args) {
-    return sql`${sqlIdent168}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent126}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6573,12 +6572,12 @@ const options_c_mutation_out_table_setof = {
   description: undefined
 };
 const parts169 = ["c", "table_set_mutation"];
-const sqlIdent169 = sql.identifier(...parts169);
+const sqlIdent127 = sql.identifier(...parts169);
 const options_c_table_set_mutation = {
   name: "c_table_set_mutation",
   identifier: "main.c.table_set_mutation()",
   from(...args) {
-    return sql`${sqlIdent169}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent127}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6597,12 +6596,12 @@ const options_c_table_set_mutation = {
   description: undefined
 };
 const parts170 = ["c", "table_set_query"];
-const sqlIdent170 = sql.identifier(...parts170);
+const sqlIdent128 = sql.identifier(...parts170);
 const options_c_table_set_query = {
   name: "c_table_set_query",
   identifier: "main.c.table_set_query()",
   from(...args) {
-    return sql`${sqlIdent170}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent128}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6623,12 +6622,12 @@ const options_c_table_set_query = {
   description: undefined
 };
 const parts171 = ["c", "table_set_query_plpgsql"];
-const sqlIdent171 = sql.identifier(...parts171);
+const sqlIdent129 = sql.identifier(...parts171);
 const options_c_table_set_query_plpgsql = {
   name: "c_table_set_query_plpgsql",
   identifier: "main.c.table_set_query_plpgsql()",
   from(...args) {
-    return sql`${sqlIdent171}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent129}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6647,18 +6646,18 @@ const options_c_table_set_query_plpgsql = {
   description: undefined
 };
 const parts172 = ["c", "person_computed_first_arg_inout"];
-const sqlIdent172 = sql.identifier(...parts172);
+const sqlIdent130 = sql.identifier(...parts172);
 const options_c_person_computed_first_arg_inout = {
   name: "c_person_computed_first_arg_inout",
   identifier: "main.c.person_computed_first_arg_inout(c.person)",
   from(...args) {
-    return sql`${sqlIdent172}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent130}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }],
   returnsArray: false,
   returnsSetof: false,
@@ -6677,18 +6676,18 @@ const options_c_person_computed_first_arg_inout = {
   description: undefined
 };
 const parts173 = ["c", "person_friends"];
-const sqlIdent173 = sql.identifier(...parts173);
+const sqlIdent131 = sql.identifier(...parts173);
 const options_c_person_friends = {
   name: "c_person_friends",
   identifier: "main.c.person_friends(c.person)",
   from(...args) {
-    return sql`${sqlIdent173}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent131}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "person",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6706,7 +6705,7 @@ const options_c_person_friends = {
   },
   description: undefined
 };
-const extensions182 = {
+const extensions169 = {
   description: undefined,
   pg: {
     serviceName: "main",
@@ -6714,7 +6713,7 @@ const extensions182 = {
     name: "types"
   },
   tags: {
-    foreignKey: extensions54.tags.foreignKey
+    foreignKey: extensions46.tags.foreignKey
   }
 };
 const uniques28 = [{
@@ -6729,20 +6728,20 @@ const registryConfig_pgResources_b_types_b_types = {
   executor: executor_mainPgExecutor,
   name: "b_types",
   identifier: "main.b.types",
-  from: registryConfig_pgCodecs_bTypes_bTypes.sqlType,
-  codec: registryConfig_pgCodecs_bTypes_bTypes,
+  from: bTypesCodec.sqlType,
+  codec: bTypesCodec,
   uniques: uniques28,
   isVirtual: false,
   description: undefined,
-  extensions: extensions182
+  extensions: extensions169
 };
 const parts174 = ["b", "type_function_connection"];
-const sqlIdent174 = sql.identifier(...parts174);
+const sqlIdent132 = sql.identifier(...parts174);
 const options_b_type_function_connection = {
   name: "b_type_function_connection",
   identifier: "main.b.type_function_connection()",
   from(...args) {
-    return sql`${sqlIdent174}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent132}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6761,12 +6760,12 @@ const options_b_type_function_connection = {
   description: undefined
 };
 const parts175 = ["b", "type_function_connection_mutation"];
-const sqlIdent175 = sql.identifier(...parts175);
+const sqlIdent133 = sql.identifier(...parts175);
 const options_b_type_function_connection_mutation = {
   name: "b_type_function_connection_mutation",
   identifier: "main.b.type_function_connection_mutation()",
   from(...args) {
-    return sql`${sqlIdent175}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent133}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -6785,12 +6784,12 @@ const options_b_type_function_connection_mutation = {
   description: undefined
 };
 const parts176 = ["b", "type_function"];
-const sqlIdent176 = sql.identifier(...parts176);
+const sqlIdent134 = sql.identifier(...parts176);
 const options_b_type_function = {
   name: "b_type_function",
   identifier: "main.b.type_function(int4)",
   from(...args) {
-    return sql`${sqlIdent176}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent134}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6814,12 +6813,12 @@ const options_b_type_function = {
   description: undefined
 };
 const parts177 = ["b", "type_function_mutation"];
-const sqlIdent177 = sql.identifier(...parts177);
+const sqlIdent135 = sql.identifier(...parts177);
 const options_b_type_function_mutation = {
   name: "b_type_function_mutation",
   identifier: "main.b.type_function_mutation(int4)",
   from(...args) {
-    return sql`${sqlIdent177}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent135}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -6843,18 +6842,18 @@ const options_b_type_function_mutation = {
   description: undefined
 };
 const parts178 = ["c", "person_type_function_connection"];
-const sqlIdent178 = sql.identifier(...parts178);
+const sqlIdent136 = sql.identifier(...parts178);
 const options_c_person_type_function_connection = {
   name: "c_person_type_function_connection",
   identifier: "main.c.person_type_function_connection(c.person)",
   from(...args) {
-    return sql`${sqlIdent178}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent136}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }],
   returnsArray: false,
   returnsSetof: true,
@@ -6872,18 +6871,18 @@ const options_c_person_type_function_connection = {
   description: undefined
 };
 const parts179 = ["c", "person_type_function"];
-const sqlIdent179 = sql.identifier(...parts179);
+const sqlIdent137 = sql.identifier(...parts179);
 const options_c_person_type_function = {
   name: "c_person_type_function",
   identifier: "main.c.person_type_function(c.person,int4)",
   from(...args) {
-    return sql`${sqlIdent179}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent137}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }, {
     name: "id",
     required: true,
@@ -6906,12 +6905,12 @@ const options_c_person_type_function = {
   description: undefined
 };
 const parts180 = ["b", "type_function_list"];
-const sqlIdent180 = sql.identifier(...parts180);
+const sqlIdent138 = sql.identifier(...parts180);
 const options_b_type_function_list = {
   name: "b_type_function_list",
   identifier: "main.b.type_function_list()",
   from(...args) {
-    return sql`${sqlIdent180}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent138}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6930,12 +6929,12 @@ const options_b_type_function_list = {
   description: undefined
 };
 const parts181 = ["b", "type_function_list_mutation"];
-const sqlIdent181 = sql.identifier(...parts181);
+const sqlIdent139 = sql.identifier(...parts181);
 const options_b_type_function_list_mutation = {
   name: "b_type_function_list_mutation",
   identifier: "main.b.type_function_list_mutation()",
   from(...args) {
-    return sql`${sqlIdent181}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent139}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: true,
@@ -6954,18 +6953,18 @@ const options_b_type_function_list_mutation = {
   description: undefined
 };
 const parts182 = ["c", "person_type_function_list"];
-const sqlIdent182 = sql.identifier(...parts182);
+const sqlIdent140 = sql.identifier(...parts182);
 const options_c_person_type_function_list = {
   name: "c_person_type_function_list",
   identifier: "main.c.person_type_function_list(c.person)",
   from(...args) {
-    return sql`${sqlIdent182}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent140}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "p",
     required: true,
     notNull: false,
-    codec: attributes_person_codec_cPerson
+    codec: cPersonCodec
   }],
   returnsArray: true,
   returnsSetof: false,
@@ -7002,61 +7001,61 @@ const registry = makeRegistry({
     CFuncReturnsTableMultiColRecord: registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableMultiColRecord,
     CMutationOutUnnamedOutOutUnnamedRecord: registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOutUnnamedOutOutUnnamedRecord,
     CMutationReturnsTableMultiColRecord: registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationReturnsTableMultiColRecord,
-    bGuid: registryConfig_pgCodecs_bGuid_bGuid,
+    bGuid: bGuidCodec,
     varchar: TYPES.varchar,
-    pgCatalogIntervalArray: registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray,
-    pgCatalogTextArray: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
-    nonUpdatableView: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
-    inputs: registryConfig_pgCodecs_inputs_inputs,
-    patchs: registryConfig_pgCodecs_patchs_patchs,
-    reserved: registryConfig_pgCodecs_reserved_reserved,
-    reservedPatchs: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
-    reservedInput: registryConfig_pgCodecs_reservedInput_reservedInput,
-    defaultValue: registryConfig_pgCodecs_defaultValue_defaultValue,
-    foreignKey: registryConfig_pgCodecs_foreignKey_foreignKey,
-    noPrimaryKey: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
-    testview: registryConfig_pgCodecs_testview_testview,
-    uniqueForeignKey: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
-    cMyTable: registryConfig_pgCodecs_cMyTable_cMyTable,
-    cPersonSecret: registryConfig_pgCodecs_cPersonSecret_cPersonSecret,
-    viewTable: registryConfig_pgCodecs_viewTable_viewTable,
-    bUpdatableView: registryConfig_pgCodecs_bUpdatableView_bUpdatableView,
-    cCompoundKey: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+    pgCatalogIntervalArray: pgCatalogIntervalArrayCodec,
+    pgCatalogTextArray: pgCatalogTextArrayCodec,
+    nonUpdatableView: nonUpdatableViewCodec,
+    inputs: inputsCodec,
+    patchs: patchsCodec,
+    reserved: reservedCodec,
+    reservedPatchs: reservedPatchsCodec,
+    reservedInput: reservedInputCodec,
+    defaultValue: defaultValueCodec,
+    foreignKey: foreignKeyCodec,
+    noPrimaryKey: noPrimaryKeyCodec,
+    testview: testviewCodec,
+    uniqueForeignKey: uniqueForeignKeyCodec,
+    cMyTable: cMyTableCodec,
+    cPersonSecret: cPersonSecretCodec,
+    viewTable: viewTableCodec,
+    bUpdatableView: bUpdatableViewCodec,
+    cCompoundKey: cCompoundKeyCodec,
     bool: TYPES.boolean,
-    similarTable1: registryConfig_pgCodecs_similarTable1_similarTable1,
-    similarTable2: registryConfig_pgCodecs_similarTable2_similarTable2,
-    cNullTestRecord: registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord,
-    pgCatalogUuidArray: registryConfig_pgCodecs_pgCatalogUuidArray_pgCatalogUuidArray,
+    similarTable1: similarTable1Codec,
+    similarTable2: similarTable2Codec,
+    cNullTestRecord: cNullTestRecordCodec,
+    pgCatalogUuidArray: pgCatalogUuidArrayCodec,
     uuid: TYPES.uuid,
-    cEdgeCase: registryConfig_pgCodecs_cEdgeCase_cEdgeCase,
+    cEdgeCase: cEdgeCaseCodec,
     int2: TYPES.int2,
-    cLeftArm: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+    cLeftArm: cLeftArmCodec,
     float8: TYPES.float,
-    bJwtToken: registryConfig_pgCodecs_bJwtToken_bJwtToken,
+    bJwtToken: bJwtTokenCodec,
     numeric: TYPES.numeric,
-    cIssue756: registryConfig_pgCodecs_cIssue756_cIssue756,
-    cNotNullTimestamp: attributes_ts_codec_cNotNullTimestamp,
+    cIssue756: cIssue756Codec,
+    cNotNullTimestamp: cNotNullTimestampCodec,
     timestamptz: TYPES.timestamptz,
-    bAuthPayload: registryConfig_pgCodecs_bAuthPayload_bAuthPayload,
+    bAuthPayload: bAuthPayloadCodec,
     CFuncOutOutCompoundTypeRecord: registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord,
-    cCompoundType: attributes_o2_codec_cCompoundType,
-    bColor: attributes_c_codec_bColor,
-    bEnumCaps: attributes_e_codec_bEnumCaps,
-    bEnumWithEmptyString: attributes_f_codec_bEnumWithEmptyString,
+    cCompoundType: cCompoundTypeCodec,
+    bColor: bColorCodec,
+    bEnumCaps: bEnumCapsCodec,
+    bEnumWithEmptyString: bEnumWithEmptyStringCodec,
     CMutationOutOutCompoundTypeRecord: registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord,
     CQueryOutputTwoRowsRecord: registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord,
-    post: attributes_post_codec_post,
-    anEnumArray: attributes_enums_codec_anEnumArray,
-    anEnum: innerCodec_anEnum,
-    comptypeArray: attributes_comptypes_codec_comptypeArray,
-    comptype: innerCodec_comptype,
+    post: postCodec,
+    anEnumArray: anEnumArrayCodec,
+    anEnum: anEnumCodec,
+    comptypeArray: comptypeArrayCodec,
+    comptype: comptypeCodec,
     CPersonComputedOutOutRecord: registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord,
     CPersonComputedInoutOutRecord: registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord,
     CPersonComputedFirstArgInoutOutRecord: registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord,
-    cPerson: attributes_person_codec_cPerson,
-    bEmail: attributes_email_codec_bEmail,
-    bWrappedUrl: attributes_site_codec_bWrappedUrl,
-    bNotNullUrl: attributes_url_codec_bNotNullUrl,
+    cPerson: cPersonCodec,
+    bEmail: bEmailCodec,
+    bWrappedUrl: bWrappedUrlCodec,
+    bNotNullUrl: bNotNullUrlCodec,
     hstore: TYPES.hstore,
     inet: TYPES.inet,
     cidr: TYPES.cidr,
@@ -7067,18 +7066,18 @@ const registry = makeRegistry({
     CMutationOutComplexRecord: registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord,
     CMutationOutComplexSetofRecord: registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord,
     CPersonComputedComplexRecord: registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord,
-    bTypes: registryConfig_pgCodecs_bTypes_bTypes,
-    bColorArray: attributes_enum_array_codec_bColorArray,
-    anInt: attributes_domain_codec_anInt,
-    bAnotherInt: attributes_domain2_codec_bAnotherInt,
-    pgCatalogNumrange: attributes_nullable_range_codec_pgCatalogNumrange,
-    pgCatalogDaterange: attributes_daterange_codec_pgCatalogDaterange,
+    bTypes: bTypesCodec,
+    bColorArray: bColorArrayCodec,
+    anInt: anIntCodec,
+    bAnotherInt: bAnotherIntCodec,
+    pgCatalogNumrange: pgCatalogNumrangeCodec,
+    pgCatalogDaterange: pgCatalogDaterangeCodec,
     date: TYPES.date,
-    anIntRange: attributes_an_int_range_codec_anIntRange,
+    anIntRange: anIntRangeCodec,
     time: TYPES.time,
     timetz: TYPES.timetz,
     money: TYPES.money,
-    bNestedCompoundType: attributes_nested_compound_type_codec_bNestedCompoundType,
+    bNestedCompoundType: bNestedCompoundTypeCodec,
     point: TYPES.point,
     regproc: TYPES.regproc,
     regprocedure: TYPES.regprocedure,
@@ -7088,38 +7087,38 @@ const registry = makeRegistry({
     regtype: TYPES.regtype,
     regconfig: TYPES.regconfig,
     regdictionary: TYPES.regdictionary,
-    cTextArrayDomain: attributes_text_array_domain_codec_cTextArrayDomain,
-    cInt8ArrayDomain: attributes_int8_array_domain_codec_cInt8ArrayDomain,
+    cTextArrayDomain: cTextArrayDomainCodec,
+    cInt8ArrayDomain: cInt8ArrayDomainCodec,
     bytea: TYPES.bytea,
-    pgCatalogByteaArray: attributes_bytea_array_codec_pgCatalogByteaArray,
-    ltree: attributes_ltree_codec_ltree,
-    "ltree[]": attributes_ltree_array_codec_ltree_,
+    pgCatalogByteaArray: pgCatalogByteaArrayCodec,
+    ltree: bTypesAttributes_ltree_codec_ltree,
+    "ltree[]": bTypesAttributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
-    cCompoundTypeArray: listOfCodec(attributes_o2_codec_cCompoundType, {
-      extensions: extensions55,
+    cCompoundTypeArray: listOfCodec(cCompoundTypeCodec, {
+      extensions: cCompoundTypeArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "cCompoundTypeArray"
     }),
-    bJwtTokenArray: listOfCodec(registryConfig_pgCodecs_bJwtToken_bJwtToken, {
-      extensions: extensions56,
+    bJwtTokenArray: listOfCodec(bJwtTokenCodec, {
+      extensions: bJwtTokenArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "bJwtTokenArray"
     }),
-    bTypesArray: listOfCodec(registryConfig_pgCodecs_bTypes_bTypes, {
-      extensions: extensions57,
+    bTypesArray: listOfCodec(bTypesCodec, {
+      extensions: bTypesArrayCodecExtensions,
       typeDelim: ",",
       description: undefined,
       name: "bTypesArray"
     }),
-    pgCatalogInt4Array: registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array,
-    cFloatrange: registryConfig_pgCodecs_cFloatrange_cFloatrange,
-    postArray: registryConfig_pgCodecs_postArray_postArray,
-    pgCatalogInt8Array: innerCodec_pgCatalogInt8Array,
-    tablefuncCrosstab2: recordCodec(spec_tablefuncCrosstab2),
-    tablefuncCrosstab3: recordCodec(spec_tablefuncCrosstab3),
-    tablefuncCrosstab4: recordCodec(spec_tablefuncCrosstab4)
+    pgCatalogInt4Array: pgCatalogInt4ArrayCodec,
+    cFloatrange: cFloatrangeCodec,
+    postArray: postArrayCodec,
+    pgCatalogInt8Array: pgCatalogInt8ArrayCodec,
+    tablefuncCrosstab2: recordCodec(tablefuncCrosstab2CodecSpec),
+    tablefuncCrosstab3: recordCodec(tablefuncCrosstab3CodecSpec),
+    tablefuncCrosstab4: recordCodec(tablefuncCrosstab4CodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     c_current_user_id: {
@@ -7127,14 +7126,14 @@ const registry = makeRegistry({
       name: "c_current_user_id",
       identifier: "main.c.current_user_id()",
       from(...args) {
-        return sql`${sqlIdent51}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent9}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       isUnique: !false,
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions64,
+      extensions: extensions51,
       description: undefined
     },
     c_func_out: {
@@ -7147,7 +7146,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions65,
+      extensions: extensions52,
       description: undefined
     },
     c_func_out_setof: {
@@ -7160,7 +7159,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions66,
+      extensions: extensions53,
       description: undefined
     },
     c_func_out_unnamed: {
@@ -7173,7 +7172,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions67,
+      extensions: extensions54,
       description: undefined
     },
     c_mutation_out: {
@@ -7186,7 +7185,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions68,
+      extensions: extensions55,
       description: undefined
     },
     c_mutation_out_setof: {
@@ -7199,7 +7198,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions69,
+      extensions: extensions56,
       description: undefined
     },
     c_mutation_out_unnamed: {
@@ -7212,7 +7211,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions70,
+      extensions: extensions57,
       description: undefined
     },
     c_no_args_mutation: {
@@ -7225,7 +7224,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions71,
+      extensions: extensions58,
       description: undefined
     },
     c_no_args_query: {
@@ -7238,7 +7237,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions72,
+      extensions: extensions59,
       description: undefined
     },
     return_void_mutation: {
@@ -7251,7 +7250,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: true,
-      extensions: extensions73,
+      extensions: extensions60,
       description: undefined
     },
     mutation_interval_set: {
@@ -7264,7 +7263,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: true,
-      extensions: extensions74,
+      extensions: extensions61,
       description: undefined
     },
     query_interval_set: {
@@ -7277,7 +7276,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions75,
+      extensions: extensions62,
       description: undefined
     },
     static_big_integer: {
@@ -7290,7 +7289,7 @@ const registry = makeRegistry({
       codec: TYPES.bigint,
       uniques: [],
       isMutation: false,
-      extensions: extensions76,
+      extensions: extensions63,
       description: undefined
     },
     c_func_in_out: {
@@ -7303,7 +7302,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions77,
+      extensions: extensions64,
       description: undefined
     },
     c_func_returns_table_one_col: {
@@ -7316,7 +7315,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions78,
+      extensions: extensions65,
       description: undefined
     },
     c_mutation_in_out: {
@@ -7329,7 +7328,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions79,
+      extensions: extensions66,
       description: undefined
     },
     c_mutation_returns_table_one_col: {
@@ -7342,7 +7341,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions80,
+      extensions: extensions67,
       description: undefined
     },
     assert_something: {
@@ -7355,7 +7354,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions81,
+      extensions: extensions68,
       description: undefined
     },
     assert_something_nx: {
@@ -7368,7 +7367,7 @@ const registry = makeRegistry({
       codec: TYPES.void,
       uniques: [],
       isMutation: false,
-      extensions: extensions82,
+      extensions: extensions69,
       description: undefined
     },
     c_json_identity: {
@@ -7381,7 +7380,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: false,
-      extensions: extensions83,
+      extensions: extensions70,
       description: undefined
     },
     c_json_identity_mutation: {
@@ -7394,7 +7393,7 @@ const registry = makeRegistry({
       codec: TYPES.json,
       uniques: [],
       isMutation: true,
-      extensions: extensions84,
+      extensions: extensions71,
       description: undefined
     },
     c_jsonb_identity: {
@@ -7407,7 +7406,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: false,
-      extensions: extensions85,
+      extensions: extensions72,
       description: undefined
     },
     c_jsonb_identity_mutation: {
@@ -7420,7 +7419,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions86,
+      extensions: extensions73,
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql: {
@@ -7433,7 +7432,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions87,
+      extensions: extensions74,
       description: undefined
     },
     c_jsonb_identity_mutation_plpgsql_with_default: {
@@ -7446,7 +7445,7 @@ const registry = makeRegistry({
       codec: TYPES.jsonb,
       uniques: [],
       isMutation: true,
-      extensions: extensions88,
+      extensions: extensions75,
       description: undefined
     },
     add_1_mutation: {
@@ -7459,7 +7458,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions89,
+      extensions: extensions76,
       description: "lol, add some stuff 1 mutation"
     },
     add_1_query: {
@@ -7472,7 +7471,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions90,
+      extensions: extensions77,
       description: "lol, add some stuff 1 query"
     },
     add_2_mutation: {
@@ -7485,7 +7484,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions91,
+      extensions: extensions78,
       description: "lol, add some stuff 2 mutation"
     },
     add_2_query: {
@@ -7498,7 +7497,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions92,
+      extensions: extensions79,
       description: "lol, add some stuff 2 query"
     },
     add_3_mutation: {
@@ -7511,7 +7510,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions93,
+      extensions: extensions80,
       description: "lol, add some stuff 3 mutation"
     },
     add_3_query: {
@@ -7524,7 +7523,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions94,
+      extensions: extensions81,
       description: "lol, add some stuff 3 query"
     },
     add_4_mutation: {
@@ -7537,7 +7536,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions95,
+      extensions: extensions82,
       description: "lol, add some stuff 4 mutation"
     },
     add_4_mutation_error: {
@@ -7550,7 +7549,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions96,
+      extensions: extensions83,
       description: undefined
     },
     add_4_query: {
@@ -7563,7 +7562,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions97,
+      extensions: extensions84,
       description: "lol, add some stuff 4 query"
     },
     b_mult_1: {
@@ -7576,7 +7575,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions98,
+      extensions: extensions85,
       description: undefined
     },
     b_mult_2: {
@@ -7589,7 +7588,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions99,
+      extensions: extensions86,
       description: undefined
     },
     b_mult_3: {
@@ -7602,7 +7601,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions100,
+      extensions: extensions87,
       description: undefined
     },
     b_mult_4: {
@@ -7615,7 +7614,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions101,
+      extensions: extensions88,
       description: undefined
     },
     c_func_in_inout: {
@@ -7628,7 +7627,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions102,
+      extensions: extensions89,
       description: undefined
     },
     c_func_out_out: {
@@ -7641,7 +7640,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutOutRecord_CFuncOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions103,
+      extensions: extensions90,
       description: undefined
     },
     c_func_out_out_setof: {
@@ -7654,7 +7653,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutOutSetofRecord_CFuncOutOutSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions104,
+      extensions: extensions91,
       description: undefined
     },
     c_func_out_out_unnamed: {
@@ -7667,7 +7666,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutOutUnnamedRecord_CFuncOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions105,
+      extensions: extensions92,
       description: undefined
     },
     c_mutation_in_inout: {
@@ -7680,7 +7679,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions106,
+      extensions: extensions93,
       description: undefined
     },
     c_mutation_out_out: {
@@ -7693,7 +7692,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutOutRecord_CMutationOutOutRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions107,
+      extensions: extensions94,
       description: undefined
     },
     c_mutation_out_out_setof: {
@@ -7706,7 +7705,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutOutSetofRecord_CMutationOutOutSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions108,
+      extensions: extensions95,
       description: undefined
     },
     c_mutation_out_out_unnamed: {
@@ -7719,7 +7718,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutOutUnnamedRecord_CMutationOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions109,
+      extensions: extensions96,
       description: undefined
     },
     c_search_test_summaries: {
@@ -7732,7 +7731,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CSearchTestSummariesRecord_CSearchTestSummariesRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions110,
+      extensions: extensions97,
       description: undefined
     },
     optional_missing_middle_1: {
@@ -7745,7 +7744,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions111,
+      extensions: extensions98,
       description: undefined
     },
     optional_missing_middle_2: {
@@ -7758,7 +7757,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions112,
+      extensions: extensions99,
       description: undefined
     },
     optional_missing_middle_3: {
@@ -7771,7 +7770,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions113,
+      extensions: extensions100,
       description: undefined
     },
     optional_missing_middle_4: {
@@ -7784,7 +7783,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions114,
+      extensions: extensions101,
       description: undefined
     },
     optional_missing_middle_5: {
@@ -7797,7 +7796,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions115,
+      extensions: extensions102,
       description: undefined
     },
     c_func_out_unnamed_out_out_unnamed: {
@@ -7810,7 +7809,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutUnnamedOutOutUnnamedRecord_CFuncOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions116,
+      extensions: extensions103,
       description: undefined
     },
     c_func_returns_table_multi_col: {
@@ -7823,7 +7822,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncReturnsTableMultiColRecord_CFuncReturnsTableMultiColRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions117,
+      extensions: extensions104,
       description: undefined
     },
     c_int_set_mutation: {
@@ -7836,7 +7835,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: true,
-      extensions: extensions118,
+      extensions: extensions105,
       description: undefined
     },
     c_int_set_query: {
@@ -7849,7 +7848,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions119,
+      extensions: extensions106,
       description: undefined
     },
     c_mutation_out_unnamed_out_out_unnamed: {
@@ -7862,7 +7861,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutUnnamedOutOutUnnamedRecord_CMutationOutUnnamedOutOutUnnamedRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions120,
+      extensions: extensions107,
       description: undefined
     },
     c_mutation_returns_table_multi_col: {
@@ -7875,7 +7874,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationReturnsTableMultiColRecord_CMutationReturnsTableMultiColRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions121,
+      extensions: extensions108,
       description: undefined
     },
     b_guid_fn: {
@@ -7885,10 +7884,10 @@ const registry = makeRegistry({
       from: fromCallback59,
       parameters: parameters59,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_bGuid_bGuid,
+      codec: bGuidCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions122,
+      extensions: extensions109,
       description: undefined
     },
     mutation_interval_array: {
@@ -7898,10 +7897,10 @@ const registry = makeRegistry({
       from: fromCallback60,
       parameters: parameters60,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray,
+      codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions123,
+      extensions: extensions110,
       description: undefined
     },
     query_interval_array: {
@@ -7911,10 +7910,10 @@ const registry = makeRegistry({
       from: fromCallback61,
       parameters: parameters61,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray,
+      codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions124,
+      extensions: extensions111,
       description: undefined
     },
     mutation_text_array: {
@@ -7924,10 +7923,10 @@ const registry = makeRegistry({
       from: fromCallback62,
       parameters: parameters62,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+      codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions125,
+      extensions: extensions112,
       description: undefined
     },
     query_text_array: {
@@ -7937,180 +7936,180 @@ const registry = makeRegistry({
       from: fromCallback63,
       parameters: parameters63,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+      codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions126,
+      extensions: extensions113,
       description: undefined
     },
     non_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_nonUpdatableView_nonUpdatableView,
+      from: nonUpdatableViewCodec.sqlType,
+      codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
       description: undefined,
-      extensions: extensions127
+      extensions: extensions114
     },
     inputs: {
       executor: executor_mainPgExecutor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: registryConfig_pgCodecs_inputs_inputs.sqlType,
-      codec: registryConfig_pgCodecs_inputs_inputs,
+      from: inputsCodec.sqlType,
+      codec: inputsCodec,
       uniques: uniques2,
       isVirtual: false,
       description: "Should output as Input",
-      extensions: extensions128
+      extensions: extensions115
     },
     patchs: {
       executor: executor_mainPgExecutor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: registryConfig_pgCodecs_patchs_patchs.sqlType,
-      codec: registryConfig_pgCodecs_patchs_patchs,
+      from: patchsCodec.sqlType,
+      codec: patchsCodec,
       uniques: uniques3,
       isVirtual: false,
       description: "Should output as Patch",
-      extensions: extensions129
+      extensions: extensions116
     },
     reserved: {
       executor: executor_mainPgExecutor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: registryConfig_pgCodecs_reserved_reserved.sqlType,
-      codec: registryConfig_pgCodecs_reserved_reserved,
+      from: reservedCodec.sqlType,
+      codec: reservedCodec,
       uniques: uniques4,
       isVirtual: false,
       description: undefined,
-      extensions: extensions130
+      extensions: extensions117
     },
     reservedPatchs: {
       executor: executor_mainPgExecutor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: registryConfig_pgCodecs_reservedPatchs_reservedPatchs.sqlType,
-      codec: registryConfig_pgCodecs_reservedPatchs_reservedPatchs,
+      from: reservedPatchsCodec.sqlType,
+      codec: reservedPatchsCodec,
       uniques: uniques5,
       isVirtual: false,
       description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
-      extensions: extensions131
+      extensions: extensions118
     },
     reserved_input: {
       executor: executor_mainPgExecutor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: registryConfig_pgCodecs_reservedInput_reservedInput.sqlType,
-      codec: registryConfig_pgCodecs_reservedInput_reservedInput,
+      from: reservedInputCodec.sqlType,
+      codec: reservedInputCodec,
       uniques: uniques6,
       isVirtual: false,
       description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
-      extensions: extensions132
+      extensions: extensions119
     },
     default_value: {
       executor: executor_mainPgExecutor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: registryConfig_pgCodecs_defaultValue_defaultValue.sqlType,
-      codec: registryConfig_pgCodecs_defaultValue_defaultValue,
+      from: defaultValueCodec.sqlType,
+      codec: defaultValueCodec,
       uniques: uniques7,
       isVirtual: false,
       description: undefined,
-      extensions: extensions133
+      extensions: extensions120
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
       executor: executor_mainPgExecutor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey.sqlType,
-      codec: registryConfig_pgCodecs_noPrimaryKey_noPrimaryKey,
+      from: noPrimaryKeyCodec.sqlType,
+      codec: noPrimaryKeyCodec,
       uniques: uniques9,
       isVirtual: false,
       description: undefined,
-      extensions: extensions135
+      extensions: extensions122
     },
     testview: {
       executor: executor_mainPgExecutor,
       name: "testview",
       identifier: "main.a.testview",
-      from: registryConfig_pgCodecs_testview_testview.sqlType,
-      codec: registryConfig_pgCodecs_testview_testview,
+      from: testviewCodec.sqlType,
+      codec: testviewCodec,
       uniques: uniques10,
       isVirtual: false,
       description: undefined,
-      extensions: extensions136
+      extensions: extensions123
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     c_my_table: {
       executor: executor_mainPgExecutor,
       name: "c_my_table",
       identifier: "main.c.my_table",
-      from: registryConfig_pgCodecs_cMyTable_cMyTable.sqlType,
-      codec: registryConfig_pgCodecs_cMyTable_cMyTable,
+      from: cMyTableCodec.sqlType,
+      codec: cMyTableCodec,
       uniques: uniques12,
       isVirtual: false,
       description: undefined,
-      extensions: extensions138
+      extensions: extensions125
     },
     c_person_secret: registryConfig_pgResources_c_person_secret_c_person_secret,
     view_table: {
       executor: executor_mainPgExecutor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: registryConfig_pgCodecs_viewTable_viewTable.sqlType,
-      codec: registryConfig_pgCodecs_viewTable_viewTable,
+      from: viewTableCodec.sqlType,
+      codec: viewTableCodec,
       uniques: uniques14,
       isVirtual: false,
       description: undefined,
-      extensions: extensions140
+      extensions: extensions127
     },
     b_updatable_view: {
       executor: executor_mainPgExecutor,
       name: "b_updatable_view",
       identifier: "main.b.updatable_view",
-      from: registryConfig_pgCodecs_bUpdatableView_bUpdatableView.sqlType,
-      codec: registryConfig_pgCodecs_bUpdatableView_bUpdatableView,
+      from: bUpdatableViewCodec.sqlType,
+      codec: bUpdatableViewCodec,
       uniques: uniques15,
       isVirtual: false,
       description: "YOYOYO!!",
-      extensions: extensions141
+      extensions: extensions128
     },
     c_compound_key: registryConfig_pgResources_c_compound_key_c_compound_key,
     similar_table_1: {
       executor: executor_mainPgExecutor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: registryConfig_pgCodecs_similarTable1_similarTable1.sqlType,
-      codec: registryConfig_pgCodecs_similarTable1_similarTable1,
+      from: similarTable1Codec.sqlType,
+      codec: similarTable1Codec,
       uniques: uniques17,
       isVirtual: false,
       description: undefined,
-      extensions: extensions143
+      extensions: extensions130
     },
     similar_table_2: {
       executor: executor_mainPgExecutor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: registryConfig_pgCodecs_similarTable2_similarTable2.sqlType,
-      codec: registryConfig_pgCodecs_similarTable2_similarTable2,
+      from: similarTable2Codec.sqlType,
+      codec: similarTable2Codec,
       uniques: uniques18,
       isVirtual: false,
       description: undefined,
-      extensions: extensions144
+      extensions: extensions131
     },
     c_null_test_record: {
       executor: executor_mainPgExecutor,
       name: "c_null_test_record",
       identifier: "main.c.null_test_record",
-      from: registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord.sqlType,
-      codec: registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord,
+      from: cNullTestRecordCodec.sqlType,
+      codec: cNullTestRecordCodec,
       uniques: uniques19,
       isVirtual: false,
       description: undefined,
-      extensions: extensions145
+      extensions: extensions132
     },
     c_edge_case_computed: {
       executor: executor_mainPgExecutor,
@@ -8122,7 +8121,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions146,
+      extensions: extensions133,
       description: undefined
     },
     c_return_table_without_grants: PgResource.functionResourceOptions(registryConfig_pgResources_c_compound_key_c_compound_key, options_c_return_table_without_grants),
@@ -8133,22 +8132,22 @@ const registry = makeRegistry({
       from: fromCallback65,
       parameters: parameters65,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogUuidArray_pgCatalogUuidArray,
+      codec: pgCatalogUuidArrayCodec,
       uniques: [],
       isMutation: true,
-      extensions: extensions147,
+      extensions: extensions134,
       description: undefined
     },
     c_edge_case: {
       executor: executor_mainPgExecutor,
       name: "c_edge_case",
       identifier: "main.c.edge_case",
-      from: registryConfig_pgCodecs_cEdgeCase_cEdgeCase.sqlType,
-      codec: registryConfig_pgCodecs_cEdgeCase_cEdgeCase,
+      from: cEdgeCaseCodec.sqlType,
+      codec: cEdgeCaseCodec,
       uniques: uniques20,
       isVirtual: false,
       description: undefined,
-      extensions: extensions148
+      extensions: extensions135
     },
     c_left_arm: registryConfig_pgResources_c_left_arm_c_left_arm,
     b_authenticate_fail: PgResource.functionResourceOptions(resourceConfig_b_jwt_token, options_b_authenticate_fail),
@@ -8169,7 +8168,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions153,
+      extensions: extensions140,
       description: undefined
     },
     c_types_query: {
@@ -8182,7 +8181,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions154,
+      extensions: extensions141,
       description: undefined
     },
     c_compound_type_computed_field: {
@@ -8195,7 +8194,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions155,
+      extensions: extensions142,
       description: undefined
     },
     post_computed_interval_set: {
@@ -8208,7 +8207,7 @@ const registry = makeRegistry({
       codec: TYPES.interval,
       uniques: [],
       isMutation: false,
-      extensions: extensions156,
+      extensions: extensions143,
       description: undefined
     },
     post_computed_interval_array: {
@@ -8218,10 +8217,10 @@ const registry = makeRegistry({
       from: fromCallback70,
       parameters: parameters70,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogIntervalArray_pgCatalogIntervalArray,
+      codec: pgCatalogIntervalArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions157,
+      extensions: extensions144,
       description: undefined
     },
     post_computed_text_array: {
@@ -8231,10 +8230,10 @@ const registry = makeRegistry({
       from: fromCallback71,
       parameters: parameters71,
       isUnique: !false,
-      codec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+      codec: pgCatalogTextArrayCodec,
       uniques: [],
       isMutation: false,
-      extensions: extensions158,
+      extensions: extensions145,
       description: undefined
     },
     post_computed_with_optional_arg: {
@@ -8247,7 +8246,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions159,
+      extensions: extensions146,
       description: undefined
     },
     post_computed_with_required_arg: {
@@ -8260,7 +8259,7 @@ const registry = makeRegistry({
       codec: TYPES.int,
       uniques: [],
       isMutation: false,
-      extensions: extensions160,
+      extensions: extensions147,
       description: undefined
     },
     c_func_out_out_compound_type: {
@@ -8273,7 +8272,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions161,
+      extensions: extensions148,
       description: undefined
     },
     c_mutation_out_out_compound_type: {
@@ -8286,7 +8285,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutCompoundTypeRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions162,
+      extensions: extensions149,
       description: undefined
     },
     post_headline_trimmed: {
@@ -8299,7 +8298,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions163,
+      extensions: extensions150,
       description: undefined
     },
     post_headline_trimmed_no_defaults: {
@@ -8312,7 +8311,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions164,
+      extensions: extensions151,
       description: undefined
     },
     post_headline_trimmed_strict: {
@@ -8325,7 +8324,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions165,
+      extensions: extensions152,
       description: undefined
     },
     c_query_output_two_rows: {
@@ -8338,7 +8337,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions166,
+      extensions: extensions153,
       description: undefined
     },
     post: registryConfig_pgResources_post_post,
@@ -8365,7 +8364,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions169,
+      extensions: extensions156,
       description: undefined
     },
     c_person_first_name: {
@@ -8378,7 +8377,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions170,
+      extensions: extensions157,
       description: "The first name of the person."
     },
     c_person_computed_out_out: {
@@ -8391,7 +8390,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CPersonComputedOutOutRecord_CPersonComputedOutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions171,
+      extensions: extensions158,
       description: undefined
     },
     c_person_computed_inout: {
@@ -8404,7 +8403,7 @@ const registry = makeRegistry({
       codec: TYPES.text,
       uniques: [],
       isMutation: false,
-      extensions: extensions172,
+      extensions: extensions159,
       description: undefined
     },
     c_person_computed_inout_out: {
@@ -8417,7 +8416,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions173,
+      extensions: extensions160,
       description: undefined
     },
     c_person_exists: {
@@ -8430,7 +8429,7 @@ const registry = makeRegistry({
       codec: TYPES.boolean,
       uniques: [],
       isMutation: false,
-      extensions: extensions174,
+      extensions: extensions161,
       description: undefined
     },
     c_person_computed_first_arg_inout_out: {
@@ -8443,7 +8442,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions175,
+      extensions: extensions162,
       description: undefined
     },
     c_func_out_complex: {
@@ -8456,7 +8455,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutComplexRecord_CFuncOutComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions176,
+      extensions: extensions163,
       description: undefined
     },
     c_func_out_complex_setof: {
@@ -8469,7 +8468,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CFuncOutComplexSetofRecord_CFuncOutComplexSetofRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions177,
+      extensions: extensions164,
       description: undefined
     },
     c_mutation_out_complex: {
@@ -8482,7 +8481,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutComplexRecord_CMutationOutComplexRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions178,
+      extensions: extensions165,
       description: undefined
     },
     c_mutation_out_complex_setof: {
@@ -8495,7 +8494,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CMutationOutComplexSetofRecord_CMutationOutComplexSetofRecord,
       uniques: [],
       isMutation: true,
-      extensions: extensions179,
+      extensions: extensions166,
       description: undefined
     },
     c_person_computed_complex: {
@@ -8508,7 +8507,7 @@ const registry = makeRegistry({
       codec: registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComplexRecord,
       uniques: [],
       isMutation: false,
-      extensions: extensions180,
+      extensions: extensions167,
       description: undefined
     },
     c_person_first_post: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, options_c_person_first_post),
@@ -8537,7 +8536,7 @@ const registry = makeRegistry({
   pgRelations: Object.assign(Object.create(null), {
     foreignKey: Object.assign(Object.create(null), {
       cCompoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_c_compound_key_c_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8552,7 +8551,7 @@ const registry = makeRegistry({
         }
       },
       cPersonByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_foreignKey_foreignKey,
+        localCodec: foreignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8569,7 +8568,7 @@ const registry = makeRegistry({
     }),
     post: Object.assign(Object.create(null), {
       cPersonByMyAuthorId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -8584,7 +8583,7 @@ const registry = makeRegistry({
         }
       },
       bTypesByTheirSmallint: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_b_types_b_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8599,7 +8598,7 @@ const registry = makeRegistry({
         }
       },
       bTypesByTheirId: {
-        localCodec: attributes_post_codec_post,
+        localCodec: postCodec,
         remoteResourceOptions: registryConfig_pgResources_b_types_b_types,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8616,7 +8615,7 @@ const registry = makeRegistry({
     }),
     uniqueForeignKey: Object.assign(Object.create(null), {
       cCompoundKeyByMyCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_uniqueForeignKey_uniqueForeignKey,
+        localCodec: uniqueForeignKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_c_compound_key_c_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["compound_key_1", "compound_key_2"],
@@ -8633,7 +8632,7 @@ const registry = makeRegistry({
     }),
     bAuthPayload: Object.assign(Object.create(null), {
       cPersonByMyId: {
-        localCodec: registryConfig_pgCodecs_bAuthPayload_bAuthPayload,
+        localCodec: bAuthPayloadCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8650,7 +8649,7 @@ const registry = makeRegistry({
     }),
     bTypes: Object.assign(Object.create(null), {
       postByMySmallint: {
-        localCodec: registryConfig_pgCodecs_bTypes_bTypes,
+        localCodec: bTypesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["smallint"],
@@ -8665,7 +8664,7 @@ const registry = makeRegistry({
         }
       },
       postByMyId: {
-        localCodec: registryConfig_pgCodecs_bTypes_bTypes,
+        localCodec: bTypesCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8682,7 +8681,7 @@ const registry = makeRegistry({
     }),
     cCompoundKey: Object.assign(Object.create(null), {
       cPersonByMyPersonId1: {
-        localCodec: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+        localCodec: cCompoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1"],
@@ -8697,7 +8696,7 @@ const registry = makeRegistry({
         }
       },
       cPersonByMyPersonId2: {
-        localCodec: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+        localCodec: cCompoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_2"],
@@ -8712,7 +8711,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+        localCodec: cCompoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8727,7 +8726,7 @@ const registry = makeRegistry({
         }
       },
       uniqueForeignKeyByTheirCompoundKey1AndCompoundKey2: {
-        localCodec: registryConfig_pgCodecs_cCompoundKey_cCompoundKey,
+        localCodec: cCompoundKeyCodec,
         remoteResourceOptions: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id_1", "person_id_2"],
@@ -8744,7 +8743,7 @@ const registry = makeRegistry({
     }),
     cLeftArm: Object.assign(Object.create(null), {
       cPersonByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+        localCodec: cLeftArmCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -8761,7 +8760,7 @@ const registry = makeRegistry({
     }),
     cPerson: Object.assign(Object.create(null), {
       postsByTheirAuthorId: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_post_post,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8776,7 +8775,7 @@ const registry = makeRegistry({
         }
       },
       foreignKeysByTheirPersonId: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_foreign_key_foreign_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8791,7 +8790,7 @@ const registry = makeRegistry({
         }
       },
       cPersonSecretByTheirPersonId: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_secret_c_person_secret,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8808,7 +8807,7 @@ const registry = makeRegistry({
         }
       },
       cLeftArmByTheirPersonId: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_c_left_arm_c_left_arm,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8823,7 +8822,7 @@ const registry = makeRegistry({
         }
       },
       cCompoundKeysByTheirPersonId1: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_c_compound_key_c_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8838,7 +8837,7 @@ const registry = makeRegistry({
         }
       },
       cCompoundKeysByTheirPersonId2: {
-        localCodec: attributes_person_codec_cPerson,
+        localCodec: cPersonCodec,
         remoteResourceOptions: registryConfig_pgResources_c_compound_key_c_compound_key,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -8855,7 +8854,7 @@ const registry = makeRegistry({
     }),
     cPersonSecret: Object.assign(Object.create(null), {
       cPersonByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_cPersonSecret_cPersonSecret,
+        localCodec: cPersonSecretCodec,
         remoteResourceOptions: registryConfig_pgResources_c_person_c_person,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -10695,7 +10694,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array,
+  pgCodec: pgCatalogInt4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -10707,7 +10706,7 @@ const argDetailsSimple32 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_cFloatrange_cFloatrange,
+  pgCodec: cFloatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -10759,7 +10758,7 @@ const resource_c_types_queryPgResource = registry.pgResources["c_types_query"];
 const argDetailsSimple33 = [{
   graphqlArgName: "compoundType",
   postgresArgName: "compound_type",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -10992,7 +10991,7 @@ function Query_cCompoundTypeSetQuery_after_applyPlan(_, $connection, val) {
 const argDetailsSimple37 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11096,7 +11095,7 @@ const resource_c_table_queryPgResource = registry.pgResources["c_table_query"];
 const argDetailsSimple39 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -11148,7 +11147,7 @@ const resource_query_compound_type_arrayPgResource = registry.pgResources["query
 const argDetailsSimple40 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -12462,7 +12461,7 @@ const resource_c_person_computed_inout_outPgResource = registry.pgResources["c_p
 const argDetailsSimple56 = [{
   graphqlArgName: "email",
   postgresArgName: "email",
-  pgCodec: attributes_email_codec_bEmail,
+  pgCodec: bEmailCodec,
   required: true,
   fetcher: null
 }];
@@ -13723,7 +13722,7 @@ const resource_post_headline_trimmed_strictPgResource = registry.pgResources["po
 const argDetailsSimple77 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15756,7 +15755,7 @@ function Mutation_cMutationReturnsTableMultiCol_input_applyPlan(_, $object) {
 const argDetailsSimple107 = [{
   graphqlArgName: "g",
   postgresArgName: "g",
-  pgCodec: registryConfig_pgCodecs_bGuid_bGuid,
+  pgCodec: bGuidCodec,
   required: true,
   fetcher: null
 }];
@@ -15909,7 +15908,7 @@ function Mutation_mutationTextArray_input_applyPlan(_, $object) {
 const argDetailsSimple110 = [{
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: registryConfig_pgCodecs_pgCatalogTextArray_pgCatalogTextArray,
+  pgCodec: pgCatalogTextArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16092,7 +16091,7 @@ function Mutation_bAuthenticate_input_applyPlan(_, $object) {
 const argDetailsSimple113 = [{
   graphqlArgName: "leftArm",
   postgresArgName: "left_arm",
-  pgCodec: registryConfig_pgCodecs_cLeftArm_cLeftArm,
+  pgCodec: cLeftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -16397,7 +16396,7 @@ const argDetailsSimple118 = [{
 }, {
   graphqlArgName: "d",
   postgresArgName: "d",
-  pgCodec: registryConfig_pgCodecs_pgCatalogInt4Array_pgCatalogInt4Array,
+  pgCodec: pgCatalogInt4ArrayCodec,
   required: true,
   fetcher: null
 }, {
@@ -16409,7 +16408,7 @@ const argDetailsSimple118 = [{
 }, {
   graphqlArgName: "f",
   postgresArgName: "f",
-  pgCodec: registryConfig_pgCodecs_cFloatrange_cFloatrange,
+  pgCodec: cFloatrangeCodec,
   required: true,
   fetcher: null
 }];
@@ -16519,7 +16518,7 @@ function Mutation_cMutationOutOutCompoundType_input_applyPlan(_, $object) {
 const argDetailsSimple120 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16574,7 +16573,7 @@ function Mutation_bCompoundTypeMutation_input_applyPlan(_, $object) {
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16684,7 +16683,7 @@ function Mutation_cTableMutation_input_applyPlan(_, $object) {
 const argDetailsSimple123 = [{
   graphqlArgName: "post",
   postgresArgName: "post",
-  pgCodec: attributes_post_codec_post,
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
@@ -16745,7 +16744,7 @@ function Mutation_postWithSuffix_input_applyPlan(_, $object) {
 const argDetailsSimple124 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16800,7 +16799,7 @@ function Mutation_mutationCompoundTypeArray_input_applyPlan(_, $object) {
 const argDetailsSimple125 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
-  pgCodec: attributes_o2_codec_cCompoundType,
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -16855,7 +16854,7 @@ function Mutation_bCompoundTypeArrayMutation_input_applyPlan(_, $object) {
 const argDetailsSimple126 = [{
   graphqlArgName: "posts",
   postgresArgName: "posts",
-  pgCodec: registryConfig_pgCodecs_postArray_postArray,
+  pgCodec: postArrayCodec,
   required: true,
   fetcher: null
 }];
@@ -31986,7 +31985,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_bTypes_bTypes.attributes[attributeName];
+          const attribute = bTypesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -32002,7 +32001,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques28[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_bTypes_bTypes.attributes[attributeName];
+          const attribute = bTypesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33154,7 +33153,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.id.codec)}`;
             }
           });
         }
@@ -33177,7 +33176,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.smallint.codec)}`;
             }
           });
         }
@@ -33200,7 +33199,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.bigint.codec)}`;
             }
           });
         }
@@ -33223,7 +33222,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.numeric.codec)}`;
             }
           });
         }
@@ -33246,7 +33245,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.decimal.codec)}`;
             }
           });
         }
@@ -33269,7 +33268,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.boolean.codec)}`;
             }
           });
         }
@@ -33292,7 +33291,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.varchar.codec)}`;
             }
           });
         }
@@ -33315,7 +33314,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.enum.codec)}`;
             }
           });
         }
@@ -33338,7 +33337,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.domain.codec)}`;
             }
           });
         }
@@ -33361,7 +33360,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.domain2.codec)}`;
             }
           });
         }
@@ -33384,7 +33383,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.json.codec)}`;
             }
           });
         }
@@ -33407,7 +33406,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.jsonb.codec)}`;
             }
           });
         }
@@ -33430,7 +33429,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timestamp.codec)}`;
             }
           });
         }
@@ -33453,7 +33452,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timestamptz.codec)}`;
             }
           });
         }
@@ -33476,7 +33475,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.date.codec)}`;
             }
           });
         }
@@ -33499,7 +33498,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.time.codec)}`;
             }
           });
         }
@@ -33522,7 +33521,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timetz.codec)}`;
             }
           });
         }
@@ -33545,7 +33544,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.interval.codec)}`;
             }
           });
         }
@@ -33568,7 +33567,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.money.codec)}`;
             }
           });
         }
@@ -33591,7 +33590,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.point.codec)}`;
             }
           });
         }
@@ -33614,7 +33613,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -33637,7 +33636,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.inet.codec)}`;
             }
           });
         }
@@ -33660,7 +33659,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.cidr.codec)}`;
             }
           });
         }
@@ -33683,7 +33682,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.macaddr.codec)}`;
             }
           });
         }
@@ -33706,7 +33705,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regproc.codec)}`;
             }
           });
         }
@@ -33729,7 +33728,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regprocedure.codec)}`;
             }
           });
         }
@@ -33752,7 +33751,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regoper.codec)}`;
             }
           });
         }
@@ -33775,7 +33774,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regoperator.codec)}`;
             }
           });
         }
@@ -33798,7 +33797,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regclass.codec)}`;
             }
           });
         }
@@ -33821,7 +33820,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regtype.codec)}`;
             }
           });
         }
@@ -33844,7 +33843,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regconfig.codec)}`;
             }
           });
         }
@@ -33867,7 +33866,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33890,7 +33889,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes51.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.ltree.codec)}`;
             }
           });
         }
@@ -33952,7 +33951,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -33968,7 +33967,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques25[0].attributes.forEach(attributeName => {
-          const attribute = attributes_post_codec_post.attributes[attributeName];
+          const attribute = postCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34134,7 +34133,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
             }
           });
         }
@@ -34157,7 +34156,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
             }
           });
         }
@@ -34180,7 +34179,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
             }
           });
         }
@@ -34203,7 +34202,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes39.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
             }
           });
         }
@@ -34376,7 +34375,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
             }
           });
         }
@@ -34399,7 +34398,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34422,7 +34421,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes19.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34490,7 +34489,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cCompoundKey_cCompoundKey.attributes[attributeName];
+          const attribute = cCompoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34506,7 +34505,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cCompoundKey_cCompoundKey.attributes[attributeName];
+          const attribute = cCompoundKeyCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -34638,7 +34637,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34661,7 +34660,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34684,7 +34683,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes26.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.extra.codec)}`;
             }
           });
         }
@@ -35179,7 +35178,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
             }
           });
         }
@@ -35213,7 +35212,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35229,7 +35228,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_inputs_inputs.attributes[attributeName];
+          const attribute = inputsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35293,7 +35292,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
             }
           });
         }
@@ -35327,7 +35326,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35343,7 +35342,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_patchs_patchs.attributes[attributeName];
+          const attribute = patchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35407,7 +35406,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
             }
           });
         }
@@ -35441,7 +35440,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35457,7 +35456,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reserved_reserved.attributes[attributeName];
+          const attribute = reservedCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35521,7 +35520,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
             }
           });
         }
@@ -35555,7 +35554,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35571,7 +35570,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedPatchs_reservedPatchs.attributes[attributeName];
+          const attribute = reservedPatchsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35635,7 +35634,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
             }
           });
         }
@@ -35669,7 +35668,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35685,7 +35684,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_reservedInput_reservedInput.attributes[attributeName];
+          const attribute = reservedInputCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35749,7 +35748,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
             }
           });
         }
@@ -35783,7 +35782,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35799,7 +35798,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_defaultValue_defaultValue.attributes[attributeName];
+          const attribute = defaultValueCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -35897,7 +35896,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
             }
           });
         }
@@ -35920,7 +35919,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
             }
           });
         }
@@ -36036,7 +36035,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
             }
           });
         }
@@ -36059,7 +36058,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes20.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
             }
           });
         }
@@ -36221,7 +36220,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
             }
           });
         }
@@ -36244,7 +36243,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
             }
           });
         }
@@ -36267,7 +36266,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes21.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
             }
           });
         }
@@ -36383,7 +36382,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes22.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), uniqueForeignKeyAttributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -36406,7 +36405,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes22.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), uniqueForeignKeyAttributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -36440,7 +36439,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cMyTable_cMyTable.attributes[attributeName];
+          const attribute = cMyTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36456,7 +36455,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cMyTable_cMyTable.attributes[attributeName];
+          const attribute = cMyTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36554,7 +36553,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cMyTableAttributes.id.codec)}`;
             }
           });
         }
@@ -36577,7 +36576,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes23.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cMyTableAttributes.json_data.codec)}`;
             }
           });
         }
@@ -36611,7 +36610,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cPersonSecret_cPersonSecret.attributes[attributeName];
+          const attribute = cPersonSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36627,7 +36626,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cPersonSecret_cPersonSecret.attributes[attributeName];
+          const attribute = cPersonSecretCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36725,7 +36724,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonSecretAttributes.person_id.codec)}`;
             }
           });
         }
@@ -36748,7 +36747,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes24.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonSecretAttributes.sekrit.codec)}`;
             }
           });
         }
@@ -36782,7 +36781,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36798,7 +36797,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_viewTable_viewTable.attributes[attributeName];
+          const attribute = viewTableCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -36930,7 +36929,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
             }
           });
         }
@@ -36953,7 +36952,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
             }
           });
         }
@@ -36976,7 +36975,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes25.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
             }
           });
         }
@@ -37175,7 +37174,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.x.codec)}`;
             }
           });
         }
@@ -37198,7 +37197,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.name.codec)}`;
             }
           });
         }
@@ -37221,7 +37220,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.description.codec)}`;
             }
           });
         }
@@ -37244,7 +37243,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.constant.codec)}`;
             }
           });
         }
@@ -37278,7 +37277,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37294,7 +37293,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable1_similarTable1.attributes[attributeName];
+          const attribute = similarTable1Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37460,7 +37459,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
             }
           });
         }
@@ -37483,7 +37482,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
             }
           });
         }
@@ -37506,7 +37505,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
             }
           });
         }
@@ -37529,7 +37528,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes27.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
             }
           });
         }
@@ -37563,7 +37562,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37579,7 +37578,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_similarTable2_similarTable2.attributes[attributeName];
+          const attribute = similarTable2Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37745,7 +37744,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
             }
           });
         }
@@ -37768,7 +37767,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
             }
           });
         }
@@ -37791,7 +37790,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
             }
           });
         }
@@ -37814,7 +37813,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes28.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
             }
           });
         }
@@ -37848,7 +37847,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord.attributes[attributeName];
+          const attribute = cNullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -37864,7 +37863,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cNullTestRecord_cNullTestRecord.attributes[attributeName];
+          const attribute = cNullTestRecordCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38030,7 +38029,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.id.codec)}`;
             }
           });
         }
@@ -38053,7 +38052,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38076,7 +38075,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38099,7 +38098,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes29.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38295,7 +38294,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38318,7 +38317,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38341,7 +38340,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes30.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.row_id.codec)}`;
             }
           });
         }
@@ -38375,7 +38374,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cLeftArm_cLeftArm.attributes[attributeName];
+          const attribute = cLeftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38391,7 +38390,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cLeftArm_cLeftArm.attributes[attributeName];
+          const attribute = cLeftArmCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38557,7 +38556,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.id.codec)}`;
             }
           });
         }
@@ -38580,7 +38579,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.person_id.codec)}`;
             }
           });
         }
@@ -38603,7 +38602,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38626,7 +38625,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes31.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.mood.codec)}`;
             }
           });
         }
@@ -38660,7 +38659,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cIssue756_cIssue756.attributes[attributeName];
+          const attribute = cIssue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38676,7 +38675,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_cIssue756_cIssue756.attributes[attributeName];
+          const attribute = cIssue756Codec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38774,7 +38773,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cIssue756Attributes.id.codec)}`;
             }
           });
         }
@@ -38797,7 +38796,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes33.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cIssue756Attributes.ts.codec)}`;
             }
           });
         }
@@ -38813,7 +38812,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_cPerson.attributes[attributeName];
+          const attribute = cPersonCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -38829,7 +38828,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques27[0].attributes.forEach(attributeName => {
-          const attribute = attributes_person_codec_cPerson.attributes[attributeName];
+          const attribute = cPersonCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -39165,7 +39164,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.id.codec)}`;
             }
           });
         }
@@ -39188,7 +39187,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.person_full_name.codec)}`;
             }
           });
         }
@@ -39211,7 +39210,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.about.codec)}`;
             }
           });
         }
@@ -39234,7 +39233,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.email.codec)}`;
             }
           });
         }
@@ -39257,7 +39256,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.config.codec)}`;
             }
           });
         }
@@ -39280,7 +39279,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -39303,7 +39302,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -39326,7 +39325,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.user_mac.codec)}`;
             }
           });
         }
@@ -39349,7 +39348,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes44.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.created_at.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -2,7 +2,7 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const attributes = Object.assign(Object.create(null), {
+const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -32,10 +32,11 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const spec_awsApplicationFirstPartyVulnerabilities = {
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
+const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]),
-  attributes,
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -50,8 +51,8 @@ const spec_awsApplicationFirstPartyVulnerabilities = {
   },
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
-const attributes2 = Object.assign(Object.create(null), {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
+const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -83,17 +84,17 @@ const extensions2 = {
   })
 };
 const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const sqlIdent2 = sql.identifier(...parts2);
-const spec_awsApplicationThirdPartyVulnerabilities = {
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
+const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent2,
-  attributes: attributes2,
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions2,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
-const attributes3 = Object.assign(Object.create(null), {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
+const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -125,17 +126,17 @@ const extensions3 = {
   })
 };
 const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const sqlIdent3 = sql.identifier(...parts3);
-const spec_gcpApplicationFirstPartyVulnerabilities = {
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
+const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sqlIdent3,
-  attributes: attributes3,
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions3,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
-const attributes4 = Object.assign(Object.create(null), {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
+const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
     codec: TYPES.int,
@@ -167,17 +168,17 @@ const extensions4 = {
   })
 };
 const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const sqlIdent4 = sql.identifier(...parts4);
-const spec_gcpApplicationThirdPartyVulnerabilities = {
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
+const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sqlIdent4,
-  attributes: attributes4,
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
+  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions4,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
-const attributes_object_Object_ = Object.assign(Object.create(null), {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
     codec: TYPES.int,
@@ -209,17 +210,17 @@ const extensions5 = {
   })
 };
 const parts5 = ["polymorphic", "organizations"];
-const sqlIdent5 = sql.identifier(...parts5);
-const spec_organizations = {
+const organizationsIdentifier = sql.identifier(...parts5);
+const organizationsCodecSpec = {
   name: "organizations",
-  identifier: sqlIdent5,
-  attributes: attributes_object_Object_,
+  identifier: organizationsIdentifier,
+  attributes: organizationsAttributes,
   description: undefined,
   extensions: extensions5,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_organizations_organizations = recordCodec(spec_organizations);
-const attributes5 = Object.assign(Object.create(null), {
+const organizationsCodec = recordCodec(organizationsCodecSpec);
+const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
     codec: TYPES.int,
@@ -266,17 +267,17 @@ const extensions6 = {
   })
 };
 const parts6 = ["polymorphic", "people"];
-const sqlIdent6 = sql.identifier(...parts6);
-const spec_people = {
+const peopleIdentifier = sql.identifier(...parts6);
+const peopleCodecSpec = {
   name: "people",
-  identifier: sqlIdent6,
-  attributes: attributes5,
+  identifier: peopleIdentifier,
+  attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_people_people = recordCodec(spec_people);
-const attributes6 = Object.assign(Object.create(null), {
+const peopleCodec = recordCodec(peopleCodecSpec);
+const prioritiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -308,16 +309,16 @@ const extensions7 = {
   })
 };
 const parts7 = ["polymorphic", "priorities"];
-const sqlIdent7 = sql.identifier(...parts7);
-const spec_priorities = {
+const prioritiesIdentifier = sql.identifier(...parts7);
+const prioritiesCodecSpec = {
   name: "priorities",
-  identifier: sqlIdent7,
-  attributes: attributes6,
+  identifier: prioritiesIdentifier,
+  attributes: prioritiesAttributes,
   description: undefined,
   extensions: extensions7,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_priorities_priorities = recordCodec(spec_priorities);
+const prioritiesCodec = recordCodec(prioritiesCodecSpec);
 const extensions8 = {
   pg: {
     serviceName: "main",
@@ -327,15 +328,14 @@ const extensions8 = {
   tags: Object.create(null)
 };
 const parts8 = ["polymorphic", "item_type"];
-const sqlIdent8 = sql.identifier(...parts8);
-const attributes_type_codec_itemType = enumCodec({
+const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sqlIdent8,
+  identifier: sql.identifier(...parts8),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
   extensions: extensions8
 });
-const attributes7 = Object.assign(Object.create(null), {
+const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -366,7 +366,7 @@ const attributes7 = Object.assign(Object.create(null), {
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemId",
@@ -476,17 +476,17 @@ const extensions9 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts9 = ["polymorphic", "relational_checklists"];
-const sqlIdent9 = sql.identifier(...parts9);
-const spec_relationalChecklists = {
+const relationalChecklistsIdentifier = sql.identifier(...parts9);
+const relationalChecklistsCodecSpec = {
   name: "relationalChecklists",
-  identifier: sqlIdent9,
-  attributes: attributes7,
+  identifier: relationalChecklistsIdentifier,
+  attributes: relationalChecklistsAttributes,
   description: undefined,
   extensions: extensions9,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklists_relationalChecklists = recordCodec(spec_relationalChecklists);
-const attributes8 = Object.assign(Object.create(null), {
+const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -516,17 +516,17 @@ const extensions10 = {
   tags: Object.create(null)
 };
 const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const sqlIdent10 = sql.identifier(...parts10);
-const spec_relationalItemRelationCompositePks = {
+const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
+const relationalItemRelationCompositePksCodecSpec = {
   name: "relationalItemRelationCompositePks",
-  identifier: sqlIdent10,
-  attributes: attributes8,
+  identifier: relationalItemRelationCompositePksIdentifier,
+  attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions10,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks = recordCodec(spec_relationalItemRelationCompositePks);
-const attributes9 = Object.assign(Object.create(null), {
+const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -553,18 +553,18 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyTopicItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -575,7 +575,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -586,7 +586,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -597,7 +597,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -608,7 +608,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -619,7 +619,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -630,7 +630,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -641,7 +641,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -652,7 +652,7 @@ const attributes9 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -667,17 +667,17 @@ const extensions11 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts11 = ["polymorphic", "relational_topics"];
-const sqlIdent11 = sql.identifier(...parts11);
-const spec_relationalTopics = {
+const relationalTopicsIdentifier = sql.identifier(...parts11);
+const relationalTopicsCodecSpec = {
   name: "relationalTopics",
-  identifier: sqlIdent11,
-  attributes: attributes9,
+  identifier: relationalTopicsIdentifier,
+  attributes: relationalTopicsAttributes,
   description: undefined,
   extensions: extensions11,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalTopics_relationalTopics = recordCodec(spec_relationalTopics);
-const attributes10 = Object.assign(Object.create(null), {
+const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
     codec: TYPES.int,
@@ -707,17 +707,17 @@ const extensions12 = {
   tags: Object.create(null)
 };
 const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const sqlIdent12 = sql.identifier(...parts12);
-const spec_singleTableItemRelationCompositePks = {
+const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
+const singleTableItemRelationCompositePksCodecSpec = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sqlIdent12,
-  attributes: attributes10,
+  identifier: singleTableItemRelationCompositePksIdentifier,
+  attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
   extensions: extensions12,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks = recordCodec(spec_singleTableItemRelationCompositePks);
-const attributes11 = Object.assign(Object.create(null), {
+const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -753,18 +753,18 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyChecklistItemItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -775,7 +775,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -786,7 +786,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -797,7 +797,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -808,7 +808,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -819,7 +819,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -830,7 +830,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -841,7 +841,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -852,7 +852,7 @@ const attributes11 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -867,17 +867,17 @@ const extensions13 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts13 = ["polymorphic", "relational_checklist_items"];
-const sqlIdent13 = sql.identifier(...parts13);
-const spec_relationalChecklistItems = {
+const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
+const relationalChecklistItemsCodecSpec = {
   name: "relationalChecklistItems",
-  identifier: sqlIdent13,
-  attributes: attributes11,
+  identifier: relationalChecklistItemsIdentifier,
+  attributes: relationalChecklistItemsAttributes,
   description: undefined,
   extensions: extensions13,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems = recordCodec(spec_relationalChecklistItems);
-const attributes12 = Object.assign(Object.create(null), {
+const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -913,18 +913,18 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyDividerItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -935,7 +935,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -946,7 +946,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -957,7 +957,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -968,7 +968,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -979,7 +979,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -990,7 +990,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1001,7 +1001,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1012,7 +1012,7 @@ const attributes12 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1027,17 +1027,17 @@ const extensions14 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts14 = ["polymorphic", "relational_dividers"];
-const sqlIdent14 = sql.identifier(...parts14);
-const spec_relationalDividers = {
+const relationalDividersIdentifier = sql.identifier(...parts14);
+const relationalDividersCodecSpec = {
   name: "relationalDividers",
-  identifier: sqlIdent14,
-  attributes: attributes12,
+  identifier: relationalDividersIdentifier,
+  attributes: relationalDividersAttributes,
   description: undefined,
   extensions: extensions14,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalDividers_relationalDividers = recordCodec(spec_relationalDividers);
-const attributes13 = Object.assign(Object.create(null), {
+const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1076,17 +1076,17 @@ const extensions15 = {
   tags: Object.create(null)
 };
 const parts15 = ["polymorphic", "relational_item_relations"];
-const sqlIdent15 = sql.identifier(...parts15);
-const spec_relationalItemRelations = {
+const relationalItemRelationsIdentifier = sql.identifier(...parts15);
+const relationalItemRelationsCodecSpec = {
   name: "relationalItemRelations",
-  identifier: sqlIdent15,
-  attributes: attributes13,
+  identifier: relationalItemRelationsIdentifier,
+  attributes: relationalItemRelationsAttributes,
   description: undefined,
   extensions: extensions15,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations = recordCodec(spec_relationalItemRelations);
-const attributes14 = Object.assign(Object.create(null), {
+const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1125,17 +1125,17 @@ const extensions16 = {
   tags: Object.create(null)
 };
 const parts16 = ["polymorphic", "single_table_item_relations"];
-const sqlIdent16 = sql.identifier(...parts16);
-const spec_singleTableItemRelations = {
+const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
+const singleTableItemRelationsCodecSpec = {
   name: "singleTableItemRelations",
-  identifier: sqlIdent16,
-  attributes: attributes14,
+  identifier: singleTableItemRelationsIdentifier,
+  attributes: singleTableItemRelationsAttributes,
   description: undefined,
   extensions: extensions16,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations = recordCodec(spec_singleTableItemRelations);
-const attributes15 = Object.assign(Object.create(null), {
+const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1199,17 +1199,17 @@ const extensions17 = {
   })
 };
 const parts17 = ["polymorphic", "log_entries"];
-const sqlIdent17 = sql.identifier(...parts17);
-const spec_logEntries = {
+const logEntriesIdentifier = sql.identifier(...parts17);
+const logEntriesCodecSpec = {
   name: "logEntries",
-  identifier: sqlIdent17,
-  attributes: attributes15,
+  identifier: logEntriesIdentifier,
+  attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_logEntries_logEntries = recordCodec(spec_logEntries);
-const attributes16 = Object.assign(Object.create(null), {
+const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
     codec: TYPES.int,
@@ -1254,18 +1254,18 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     via: "relationalItemsByMyPostItemId",
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1276,7 +1276,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1287,7 +1287,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -1298,7 +1298,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -1309,7 +1309,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -1320,7 +1320,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -1331,7 +1331,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -1342,7 +1342,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -1353,7 +1353,7 @@ const attributes16 = Object.assign(Object.create(null), {
     restrictedAccess: undefined,
     description: undefined,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -1368,17 +1368,17 @@ const extensions18 = {
   relationalInterfaceCodecName: "relationalItems"
 };
 const parts18 = ["polymorphic", "relational_posts"];
-const sqlIdent18 = sql.identifier(...parts18);
-const spec_relationalPosts = {
+const relationalPostsIdentifier = sql.identifier(...parts18);
+const relationalPostsCodecSpec = {
   name: "relationalPosts",
-  identifier: sqlIdent18,
-  attributes: attributes16,
+  identifier: relationalPostsIdentifier,
+  attributes: relationalPostsAttributes,
   description: undefined,
   extensions: extensions18,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalPosts_relationalPosts = recordCodec(spec_relationalPosts);
-const attributes_object_Object_2 = Object.assign(Object.create(null), {
+const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1454,17 +1454,17 @@ const extensions19 = {
   })
 };
 const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const sqlIdent19 = sql.identifier(...parts19);
-const spec_firstPartyVulnerabilities = {
+const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
+const firstPartyVulnerabilitiesCodecSpec = {
   name: "firstPartyVulnerabilities",
-  identifier: sqlIdent19,
-  attributes: attributes_object_Object_2,
+  identifier: firstPartyVulnerabilitiesIdentifier,
+  attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities = recordCodec(spec_firstPartyVulnerabilities);
-const attributes_object_Object_3 = Object.assign(Object.create(null), {
+const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1540,17 +1540,17 @@ const extensions20 = {
   })
 };
 const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const sqlIdent20 = sql.identifier(...parts20);
-const spec_thirdPartyVulnerabilities = {
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
+const thirdPartyVulnerabilitiesCodecSpec = {
   name: "thirdPartyVulnerabilities",
-  identifier: sqlIdent20,
-  attributes: attributes_object_Object_3,
+  identifier: thirdPartyVulnerabilitiesIdentifier,
+  attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities = recordCodec(spec_thirdPartyVulnerabilities);
-const attributes_object_Object_4 = Object.assign(Object.create(null), {
+const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1644,17 +1644,17 @@ const extensions21 = {
   })
 };
 const parts21 = ["polymorphic", "aws_applications"];
-const sqlIdent21 = sql.identifier(...parts21);
-const spec_awsApplications = {
+const awsApplicationsIdentifier = sql.identifier(...parts21);
+const awsApplicationsCodecSpec = {
   name: "awsApplications",
-  identifier: sqlIdent21,
-  attributes: attributes_object_Object_4,
+  identifier: awsApplicationsIdentifier,
+  attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_awsApplications_awsApplications = recordCodec(spec_awsApplications);
-const attributes_object_Object_5 = Object.assign(Object.create(null), {
+const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1748,17 +1748,17 @@ const extensions22 = {
   })
 };
 const parts22 = ["polymorphic", "gcp_applications"];
-const sqlIdent22 = sql.identifier(...parts22);
-const spec_gcpApplications = {
+const gcpApplicationsIdentifier = sql.identifier(...parts22);
+const gcpApplicationsCodecSpec = {
   name: "gcpApplications",
-  identifier: sqlIdent22,
-  attributes: attributes_object_Object_5,
+  identifier: gcpApplicationsIdentifier,
+  attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_gcpApplications_gcpApplications = recordCodec(spec_gcpApplications);
-const attributes17 = Object.assign(Object.create(null), {
+const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -1770,7 +1770,7 @@ const attributes17 = Object.assign(Object.create(null), {
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
@@ -1933,33 +1933,33 @@ const extensions23 = {
   })
 };
 const parts23 = ["polymorphic", "single_table_items"];
-const sqlIdent23 = sql.identifier(...parts23);
-const spec_singleTableItems = {
+const singleTableItemsIdentifier = sql.identifier(...parts23);
+const singleTableItemsCodecSpec = {
   name: "singleTableItems",
-  identifier: sqlIdent23,
-  attributes: attributes17,
+  identifier: singleTableItemsIdentifier,
+  attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_singleTableItems_singleTableItems = recordCodec(spec_singleTableItems);
-const attributes18 = Object.assign(Object.create(null), {
+const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.id.extensions.tags
+      tags: relationalChecklistsAttributes.id.extensions.tags
     }
   },
   type: {
     description: undefined,
-    codec: attributes_type_codec_itemType,
+    codec: itemTypeCodec,
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.type.extensions.tags
+      tags: relationalChecklistsAttributes.type.extensions.tags
     }
   },
   parent_id: {
@@ -1968,7 +1968,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.parent_id.extensions.tags
+      tags: relationalChecklistsAttributes.parent_id.extensions.tags
     }
   },
   root_topic_id: {
@@ -1977,7 +1977,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.root_topic_id.extensions.tags
+      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
     }
   },
   author_id: {
@@ -1986,7 +1986,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: false,
     extensions: {
-      tags: attributes7.author_id.extensions.tags
+      tags: relationalChecklistsAttributes.author_id.extensions.tags
     }
   },
   position: {
@@ -1995,7 +1995,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.position.extensions.tags
+      tags: relationalChecklistsAttributes.position.extensions.tags
     }
   },
   created_at: {
@@ -2004,7 +2004,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.created_at.extensions.tags
+      tags: relationalChecklistsAttributes.created_at.extensions.tags
     }
   },
   updated_at: {
@@ -2013,7 +2013,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.updated_at.extensions.tags
+      tags: relationalChecklistsAttributes.updated_at.extensions.tags
     }
   },
   is_explicitly_archived: {
@@ -2022,7 +2022,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: true,
     hasDefault: true,
     extensions: {
-      tags: attributes7.is_explicitly_archived.extensions.tags
+      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
     }
   },
   archived_at: {
@@ -2031,7 +2031,7 @@ const attributes18 = Object.assign(Object.create(null), {
     notNull: false,
     hasDefault: false,
     extensions: {
-      tags: attributes7.archived_at.extensions.tags
+      tags: relationalChecklistsAttributes.archived_at.extensions.tags
     }
   }
 });
@@ -2048,17 +2048,17 @@ const extensions24 = {
   })
 };
 const parts24 = ["polymorphic", "relational_items"];
-const sqlIdent24 = sql.identifier(...parts24);
-const spec_relationalItems = {
+const relationalItemsIdentifier = sql.identifier(...parts24);
+const relationalItemsCodecSpec = {
   name: "relationalItems",
-  identifier: sqlIdent24,
-  attributes: attributes18,
+  identifier: relationalItemsIdentifier,
+  attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
 };
-const registryConfig_pgCodecs_relationalItems_relationalItems = recordCodec(spec_relationalItems);
-const attributes_object_Object_6 = Object.assign(Object.create(null), {
+const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2130,16 +2130,16 @@ const extensions25 = {
   })
 };
 const parts25 = ["polymorphic", "applications"];
-const sqlIdent25 = sql.identifier(...parts25);
-const spec_Application = {
+const ApplicationIdentifier = sql.identifier(...parts25);
+const ApplicationCodecSpec = {
   name: "Application",
-  identifier: sqlIdent25,
-  attributes: attributes_object_Object_6,
+  identifier: ApplicationIdentifier,
+  attributes: ApplicationAttributes,
   description: undefined,
   extensions: extensions25,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_7 = Object.assign(Object.create(null), {
+const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2213,16 +2213,16 @@ const extensions26 = {
   })
 };
 const parts26 = ["polymorphic", "vulnerabilities"];
-const sqlIdent26 = sql.identifier(...parts26);
-const spec_Vulnerability = {
+const VulnerabilityIdentifier = sql.identifier(...parts26);
+const VulnerabilityCodecSpec = {
   name: "Vulnerability",
-  identifier: sqlIdent26,
-  attributes: attributes_object_Object_7,
+  identifier: VulnerabilityIdentifier,
+  attributes: VulnerabilityAttributes,
   description: undefined,
   extensions: extensions26,
   executor: executor_mainPgExecutor
 };
-const attributes_object_Object_8 = Object.assign(Object.create(null), {
+const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
     codec: TYPES.int,
@@ -2256,11 +2256,11 @@ const extensions27 = {
   })
 };
 const parts27 = ["polymorphic", "zero_implementation"];
-const sqlIdent27 = sql.identifier(...parts27);
-const spec_ZeroImplementation = {
+const ZeroImplementationIdentifier = sql.identifier(...parts27);
+const ZeroImplementationCodecSpec = {
   name: "ZeroImplementation",
-  identifier: sqlIdent27,
-  attributes: attributes_object_Object_8,
+  identifier: ZeroImplementationIdentifier,
+  attributes: ZeroImplementationAttributes,
   description: undefined,
   extensions: extensions27,
   executor: executor_mainPgExecutor
@@ -2288,8 +2288,8 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques,
   isVirtual: false,
   description: undefined,
@@ -2318,8 +2318,8 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   executor: executor_mainPgExecutor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
@@ -2348,8 +2348,8 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
@@ -2378,8 +2378,8 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
   executor: executor_mainPgExecutor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
@@ -2415,8 +2415,8 @@ const registryConfig_pgResources_organizations_organizations = {
   executor: executor_mainPgExecutor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: registryConfig_pgCodecs_organizations_organizations.sqlType,
-  codec: registryConfig_pgCodecs_organizations_organizations,
+  from: organizationsCodec.sqlType,
+  codec: organizationsCodec,
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
@@ -2454,8 +2454,8 @@ const registryConfig_pgResources_people_people = {
   executor: executor_mainPgExecutor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: registryConfig_pgCodecs_people_people.sqlType,
-  codec: registryConfig_pgCodecs_people_people,
+  from: peopleCodec.sqlType,
+  codec: peopleCodec,
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
@@ -2484,8 +2484,8 @@ const registryConfig_pgResources_priorities_priorities = {
   executor: executor_mainPgExecutor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: registryConfig_pgCodecs_priorities_priorities.sqlType,
-  codec: registryConfig_pgCodecs_priorities_priorities,
+  from: prioritiesCodec.sqlType,
+  codec: prioritiesCodec,
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
@@ -2512,8 +2512,8 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   executor: executor_mainPgExecutor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: registryConfig_pgCodecs_relationalChecklists_relationalChecklists.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+  from: relationalChecklistsCodec.sqlType,
+  codec: relationalChecklistsCodec,
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
@@ -2540,8 +2540,8 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   executor: executor_mainPgExecutor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+  from: relationalItemRelationCompositePksCodec.sqlType,
+  codec: relationalItemRelationCompositePksCodec,
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
@@ -2568,8 +2568,8 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   executor: executor_mainPgExecutor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: registryConfig_pgCodecs_relationalTopics_relationalTopics.sqlType,
-  codec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+  from: relationalTopicsCodec.sqlType,
+  codec: relationalTopicsCodec,
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
@@ -2596,8 +2596,8 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   executor: executor_mainPgExecutor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+  from: singleTableItemRelationCompositePksCodec.sqlType,
+  codec: singleTableItemRelationCompositePksCodec,
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
@@ -2624,8 +2624,8 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   executor: executor_mainPgExecutor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+  from: relationalChecklistItemsCodec.sqlType,
+  codec: relationalChecklistItemsCodec,
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
@@ -2652,8 +2652,8 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   executor: executor_mainPgExecutor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: registryConfig_pgCodecs_relationalDividers_relationalDividers.sqlType,
-  codec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+  from: relationalDividersCodec.sqlType,
+  codec: relationalDividersCodec,
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
@@ -2687,8 +2687,8 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   executor: executor_mainPgExecutor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+  from: relationalItemRelationsCodec.sqlType,
+  codec: relationalItemRelationsCodec,
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
@@ -2722,8 +2722,8 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   executor: executor_mainPgExecutor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+  from: singleTableItemRelationsCodec.sqlType,
+  codec: singleTableItemRelationsCodec,
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
@@ -2753,8 +2753,8 @@ const registryConfig_pgResources_log_entries_log_entries = {
   executor: executor_mainPgExecutor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: registryConfig_pgCodecs_logEntries_logEntries.sqlType,
-  codec: registryConfig_pgCodecs_logEntries_logEntries,
+  from: logEntriesCodec.sqlType,
+  codec: logEntriesCodec,
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
@@ -2781,8 +2781,8 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   executor: executor_mainPgExecutor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: registryConfig_pgCodecs_relationalPosts_relationalPosts.sqlType,
-  codec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+  from: relationalPostsCodec.sqlType,
+  codec: relationalPostsCodec,
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
@@ -2813,8 +2813,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   executor: executor_mainPgExecutor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+  from: firstPartyVulnerabilitiesCodec.sqlType,
+  codec: firstPartyVulnerabilitiesCodec,
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
@@ -2845,8 +2845,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   executor: executor_mainPgExecutor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.sqlType,
-  codec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  codec: thirdPartyVulnerabilitiesCodec,
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
@@ -2877,8 +2877,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   executor: executor_mainPgExecutor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: registryConfig_pgCodecs_awsApplications_awsApplications.sqlType,
-  codec: registryConfig_pgCodecs_awsApplications_awsApplications,
+  from: awsApplicationsCodec.sqlType,
+  codec: awsApplicationsCodec,
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
@@ -2909,8 +2909,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   executor: executor_mainPgExecutor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: registryConfig_pgCodecs_gcpApplications_gcpApplications.sqlType,
-  codec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+  from: gcpApplicationsCodec.sqlType,
+  codec: gcpApplicationsCodec,
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
@@ -2928,7 +2928,7 @@ const extensions49 = {
   }
 };
 const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent28 = sql.identifier(...parts28);
+const sqlIdent2 = sql.identifier(...parts28);
 const extensions50 = {
   description: undefined,
   pg: {
@@ -2954,20 +2954,20 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   executor: executor_mainPgExecutor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: registryConfig_pgCodecs_singleTableItems_singleTableItems.sqlType,
-  codec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+  from: singleTableItemsCodec.sqlType,
+  codec: singleTableItemsCodec,
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
   extensions: extensions50
 };
 const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent29 = sql.identifier(...parts29);
+const sqlIdent3 = sql.identifier(...parts29);
 const options_all_single_tables = {
   name: "all_single_tables",
   identifier: "main.polymorphic.all_single_tables()",
   from(...args) {
-    return sql`${sqlIdent29}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
   },
   parameters: [],
   returnsArray: false,
@@ -2986,12 +2986,12 @@ const options_all_single_tables = {
   description: undefined
 };
 const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent30 = sql.identifier(...parts30);
+const sqlIdent4 = sql.identifier(...parts30);
 const options_get_single_table_topic_by_id = {
   name: "get_single_table_topic_by_id",
   identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
   from(...args) {
-    return sql`${sqlIdent30}(${sqlFromArgDigests(args)})`;
+    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
   },
   parameters: [{
     name: "id",
@@ -3039,8 +3039,8 @@ const registryConfig_pgResources_relational_items_relational_items = {
   executor: executor_mainPgExecutor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: registryConfig_pgCodecs_relationalItems_relationalItems.sqlType,
-  codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+  from: relationalItemsCodec.sqlType,
+  codec: relationalItemsCodec,
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
@@ -3048,41 +3048,41 @@ const registryConfig_pgResources_relational_items_relational_items = {
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
-    awsApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+    awsApplicationFirstPartyVulnerabilities: awsApplicationFirstPartyVulnerabilitiesCodec,
     int4: TYPES.int,
-    awsApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
-    gcpApplicationFirstPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
-    gcpApplicationThirdPartyVulnerabilities: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
-    organizations: registryConfig_pgCodecs_organizations_organizations,
+    awsApplicationThirdPartyVulnerabilities: awsApplicationThirdPartyVulnerabilitiesCodec,
+    gcpApplicationFirstPartyVulnerabilities: gcpApplicationFirstPartyVulnerabilitiesCodec,
+    gcpApplicationThirdPartyVulnerabilities: gcpApplicationThirdPartyVulnerabilitiesCodec,
+    organizations: organizationsCodec,
     text: TYPES.text,
-    people: registryConfig_pgCodecs_people_people,
-    priorities: registryConfig_pgCodecs_priorities_priorities,
-    relationalChecklists: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
-    relationalItemRelationCompositePks: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
-    relationalTopics: registryConfig_pgCodecs_relationalTopics_relationalTopics,
-    singleTableItemRelationCompositePks: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
-    relationalChecklistItems: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
-    relationalDividers: registryConfig_pgCodecs_relationalDividers_relationalDividers,
-    relationalItemRelations: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
-    singleTableItemRelations: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
-    logEntries: registryConfig_pgCodecs_logEntries_logEntries,
-    relationalPosts: registryConfig_pgCodecs_relationalPosts_relationalPosts,
-    firstPartyVulnerabilities: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+    people: peopleCodec,
+    priorities: prioritiesCodec,
+    relationalChecklists: relationalChecklistsCodec,
+    relationalItemRelationCompositePks: relationalItemRelationCompositePksCodec,
+    relationalTopics: relationalTopicsCodec,
+    singleTableItemRelationCompositePks: singleTableItemRelationCompositePksCodec,
+    relationalChecklistItems: relationalChecklistItemsCodec,
+    relationalDividers: relationalDividersCodec,
+    relationalItemRelations: relationalItemRelationsCodec,
+    singleTableItemRelations: singleTableItemRelationsCodec,
+    logEntries: logEntriesCodec,
+    relationalPosts: relationalPostsCodec,
+    firstPartyVulnerabilities: firstPartyVulnerabilitiesCodec,
     float8: TYPES.float,
-    thirdPartyVulnerabilities: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
-    awsApplications: registryConfig_pgCodecs_awsApplications_awsApplications,
+    thirdPartyVulnerabilities: thirdPartyVulnerabilitiesCodec,
+    awsApplications: awsApplicationsCodec,
     timestamptz: TYPES.timestamptz,
-    gcpApplications: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+    gcpApplications: gcpApplicationsCodec,
     bool: TYPES.boolean,
-    singleTableItems: registryConfig_pgCodecs_singleTableItems_singleTableItems,
-    itemType: attributes_type_codec_itemType,
+    singleTableItems: singleTableItemsCodec,
+    itemType: itemTypeCodec,
     int8: TYPES.bigint,
-    relationalItems: registryConfig_pgCodecs_relationalItems_relationalItems,
+    relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(spec_Application),
-    Vulnerability: recordCodec(spec_Vulnerability),
-    ZeroImplementation: recordCodec(spec_ZeroImplementation)
+    Application: recordCodec(ApplicationCodecSpec),
+    Vulnerability: recordCodec(VulnerabilityCodecSpec),
+    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3111,13 +3111,13 @@ const registryConfig = {
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent28}(${sqlFromArgDigests(args)})`;
+        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
         required: true,
         notNull: false,
-        codec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        codec: relationalItemsCodec,
         extensions: {
           variant: "nodeId"
         }
@@ -3137,7 +3137,7 @@ const registryConfig = {
   pgRelations: Object.assign(Object.create(null), {
     awsApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3152,7 +3152,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities,
+        localCodec: awsApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3169,7 +3169,7 @@ const registryConfig = {
     }),
     awsApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3184,7 +3184,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByMyAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities,
+        localCodec: awsApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["aws_application_id"],
@@ -3201,7 +3201,7 @@ const registryConfig = {
     }),
     awsApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3216,7 +3216,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3231,7 +3231,7 @@ const registryConfig = {
         }
       },
       awsApplicationFirstPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3246,7 +3246,7 @@ const registryConfig = {
         }
       },
       awsApplicationThirdPartyVulnerabilitiesByTheirAwsApplicationId: {
-        localCodec: registryConfig_pgCodecs_awsApplications_awsApplications,
+        localCodec: awsApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3263,7 +3263,7 @@ const registryConfig = {
     }),
     firstPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3278,7 +3278,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities,
+        localCodec: firstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3295,7 +3295,7 @@ const registryConfig = {
     }),
     gcpApplicationFirstPartyVulnerabilities: Object.assign(Object.create(null), {
       firstPartyVulnerabilitiesByMyFirstPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["first_party_vulnerability_id"],
@@ -3310,7 +3310,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities,
+        localCodec: gcpApplicationFirstPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3327,7 +3327,7 @@ const registryConfig = {
     }),
     gcpApplicationThirdPartyVulnerabilities: Object.assign(Object.create(null), {
       thirdPartyVulnerabilitiesByMyThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["third_party_vulnerability_id"],
@@ -3342,7 +3342,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByMyGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities,
+        localCodec: gcpApplicationThirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["gcp_application_id"],
@@ -3359,7 +3359,7 @@ const registryConfig = {
     }),
     gcpApplications: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3374,7 +3374,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3389,7 +3389,7 @@ const registryConfig = {
         }
       },
       gcpApplicationFirstPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3404,7 +3404,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirGcpApplicationId: {
-        localCodec: registryConfig_pgCodecs_gcpApplications_gcpApplications,
+        localCodec: gcpApplicationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3421,7 +3421,7 @@ const registryConfig = {
     }),
     logEntries: Object.assign(Object.create(null), {
       organizationsByMyOrganizationId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_organizations_organizations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3436,7 +3436,7 @@ const registryConfig = {
         }
       },
       peopleByMyPersonId: {
-        localCodec: registryConfig_pgCodecs_logEntries_logEntries,
+        localCodec: logEntriesCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3453,7 +3453,7 @@ const registryConfig = {
     }),
     organizations: Object.assign(Object.create(null), {
       logEntriesByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3468,7 +3468,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3483,7 +3483,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirOrganizationId: {
-        localCodec: registryConfig_pgCodecs_organizations_organizations,
+        localCodec: organizationsCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["organization_id"],
@@ -3500,7 +3500,7 @@ const registryConfig = {
     }),
     people: Object.assign(Object.create(null), {
       logEntriesByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_log_entries_log_entries,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3515,7 +3515,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3530,7 +3530,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirAuthorId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3545,7 +3545,7 @@ const registryConfig = {
         }
       },
       awsApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_applications_aws_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3560,7 +3560,7 @@ const registryConfig = {
         }
       },
       gcpApplicationsByTheirPersonId: {
-        localCodec: registryConfig_pgCodecs_people_people,
+        localCodec: peopleCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_applications_gcp_applications,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["person_id"],
@@ -3577,7 +3577,7 @@ const registryConfig = {
     }),
     priorities: Object.assign(Object.create(null), {
       singleTableItemsByTheirPriorityId: {
-        localCodec: registryConfig_pgCodecs_priorities_priorities,
+        localCodec: prioritiesCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3594,7 +3594,7 @@ const registryConfig = {
     }),
     relationalChecklistItems: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems,
+        localCodec: relationalChecklistItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_item_id"],
@@ -3611,7 +3611,7 @@ const registryConfig = {
     }),
     relationalChecklists: Object.assign(Object.create(null), {
       relationalItemsByMyChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalChecklists_relationalChecklists,
+        localCodec: relationalChecklistsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["checklist_item_id"],
@@ -3628,7 +3628,7 @@ const registryConfig = {
     }),
     relationalDividers: Object.assign(Object.create(null), {
       relationalItemsByMyDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalDividers_relationalDividers,
+        localCodec: relationalDividersCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["divider_item_id"],
@@ -3645,7 +3645,7 @@ const registryConfig = {
     }),
     relationalItemRelationCompositePks: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3660,7 +3660,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks,
+        localCodec: relationalItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3677,7 +3677,7 @@ const registryConfig = {
     }),
     relationalItemRelations: Object.assign(Object.create(null), {
       relationalItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3692,7 +3692,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations,
+        localCodec: relationalItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3709,7 +3709,7 @@ const registryConfig = {
     }),
     relationalItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -3724,7 +3724,7 @@ const registryConfig = {
         }
       },
       relationalItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3739,7 +3739,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -3754,7 +3754,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3769,7 +3769,7 @@ const registryConfig = {
         }
       },
       relationalTopicsByTheirTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_topics_relational_topics,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3784,7 +3784,7 @@ const registryConfig = {
         }
       },
       relationalPostsByTheirPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_posts_relational_posts,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3799,7 +3799,7 @@ const registryConfig = {
         }
       },
       relationalDividersByTheirDividerItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_dividers_relational_dividers,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3814,7 +3814,7 @@ const registryConfig = {
         }
       },
       relationalChecklistsByTheirChecklistItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklists_relational_checklists,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3829,7 +3829,7 @@ const registryConfig = {
         }
       },
       relationalChecklistItemsByTheirChecklistItemItemId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_checklist_items_relational_checklist_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3844,7 +3844,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3859,7 +3859,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relations_relational_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3874,7 +3874,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3889,7 +3889,7 @@ const registryConfig = {
         }
       },
       relationalItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_relationalItems_relationalItems,
+        localCodec: relationalItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -3906,7 +3906,7 @@ const registryConfig = {
     }),
     relationalPosts: Object.assign(Object.create(null), {
       relationalItemsByMyPostItemId: {
-        localCodec: registryConfig_pgCodecs_relationalPosts_relationalPosts,
+        localCodec: relationalPostsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["post_item_id"],
@@ -3923,7 +3923,7 @@ const registryConfig = {
     }),
     relationalTopics: Object.assign(Object.create(null), {
       relationalItemsByMyTopicItemId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3938,7 +3938,7 @@ const registryConfig = {
         }
       },
       relationalItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_relationalTopics_relationalTopics,
+        localCodec: relationalTopicsCodec,
         remoteResourceOptions: registryConfig_pgResources_relational_items_relational_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["topic_item_id"],
@@ -3955,7 +3955,7 @@ const registryConfig = {
     }),
     singleTableItemRelationCompositePks: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -3970,7 +3970,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks,
+        localCodec: singleTableItemRelationCompositePksCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -3987,7 +3987,7 @@ const registryConfig = {
     }),
     singleTableItemRelations: Object.assign(Object.create(null), {
       singleTableItemsByMyChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["child_id"],
@@ -4002,7 +4002,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations,
+        localCodec: singleTableItemRelationsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4019,7 +4019,7 @@ const registryConfig = {
     }),
     singleTableItems: Object.assign(Object.create(null), {
       peopleByMyAuthorId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_people_people,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["author_id"],
@@ -4034,7 +4034,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["parent_id"],
@@ -4049,7 +4049,7 @@ const registryConfig = {
         }
       },
       prioritiesByMyPriorityId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_priorities_priorities,
         localCodecPolymorphicTypes: ["POST", "CHECKLIST_ITEM"],
         localAttributes: ["priority_id"],
@@ -4064,7 +4064,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByMyRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["root_topic_id"],
@@ -4079,7 +4079,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4094,7 +4094,7 @@ const registryConfig = {
         }
       },
       singleTableItemsByTheirRootTopicId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_items_single_table_items,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4109,7 +4109,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4124,7 +4124,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationsByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relations_single_table_item_relations,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4139,7 +4139,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirChildId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4154,7 +4154,7 @@ const registryConfig = {
         }
       },
       singleTableItemRelationCompositePksByTheirParentId: {
-        localCodec: registryConfig_pgCodecs_singleTableItems_singleTableItems,
+        localCodec: singleTableItemsCodec,
         remoteResourceOptions: registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4171,7 +4171,7 @@ const registryConfig = {
     }),
     thirdPartyVulnerabilities: Object.assign(Object.create(null), {
       awsApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4186,7 +4186,7 @@ const registryConfig = {
         }
       },
       gcpApplicationThirdPartyVulnerabilitiesByTheirThirdPartyVulnerabilityId: {
-        localCodec: registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities,
+        localCodec: thirdPartyVulnerabilitiesCodec,
         remoteResourceOptions: registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities,
         localCodecPolymorphicTypes: undefined,
         localAttributes: ["id"],
@@ -4442,7 +4442,7 @@ function LogEntryConnection_pageInfoPlan($connection) {
   return $connection.pageInfo();
 }
 const otherSource_organizationsPgResource = registry.pgResources["organizations"];
-const attributes19 = {};
+const attributes = {};
 const members2 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4635,7 +4635,7 @@ function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes20 = {};
+const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -4816,7 +4816,7 @@ function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes21 = {};
+const attributes3 = {};
 const members6 = [{
   resource: otherSource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -5055,7 +5055,7 @@ function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
 function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes22 = {};
+const attributes4 = {};
 const members8 = [{
   resource: otherSource_peoplePgResource,
   typeName: "Person",
@@ -5199,7 +5199,7 @@ function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, v
 function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
   $connection.setAfter(val.getRaw());
 }
-const attributes23 = {};
+const attributes5 = {};
 const members10 = [{
   resource: otherSource_aws_application_third_party_vulnerabilitiesPgResource,
   typeName: "Person",
@@ -16891,7 +16891,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -16998,7 +16998,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes19,
+        attributes,
         resourceByTypeName: resourceByTypeName2,
         members: members2,
         name: "author"
@@ -17166,7 +17166,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17182,7 +17182,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques16[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_logEntries_logEntries.attributes[attributeName];
+          const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17348,7 +17348,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
             }
           });
         }
@@ -17371,7 +17371,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
             }
           });
         }
@@ -17394,7 +17394,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -17417,7 +17417,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes15.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
             }
           });
         }
@@ -17572,7 +17572,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -17645,7 +17645,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes20,
+        attributes: attributes2,
         resourceByTypeName: resourceByTypeName4,
         members: members4,
         name: "owner"
@@ -17870,7 +17870,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "applications"
@@ -17943,7 +17943,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes21,
+        attributes: attributes3,
         resourceByTypeName: resourceByTypeName6,
         members: members6,
         name: "owners"
@@ -17964,7 +17964,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities.attributes[attributeName];
+          const attribute = awsApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -17980,7 +17980,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplicationFirstPartyVulnerabilities_awsApplicationFirstPartyVulnerabilities.attributes[attributeName];
+          const attribute = awsApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18078,7 +18078,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.aws_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationFirstPartyVulnerabilitiesAttributes.aws_application_id.codec)}`;
             }
           });
         }
@@ -18101,7 +18101,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes.first_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationFirstPartyVulnerabilitiesAttributes.first_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -18275,7 +18275,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "vulnerabilities"
@@ -18348,7 +18348,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes22,
+        attributes: attributes4,
         resourceByTypeName: resourceByTypeName8,
         members: members8,
         name: "owner"
@@ -18369,7 +18369,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities.attributes[attributeName];
+          const attribute = gcpApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18385,7 +18385,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques3[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplicationFirstPartyVulnerabilities_gcpApplicationFirstPartyVulnerabilities.attributes[attributeName];
+          const attribute = gcpApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18483,7 +18483,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.gcp_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationFirstPartyVulnerabilitiesAttributes.gcp_application_id.codec)}`;
             }
           });
         }
@@ -18506,7 +18506,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes3.first_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationFirstPartyVulnerabilitiesAttributes.first_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -18664,7 +18664,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "applications"
@@ -18737,7 +18737,7 @@ export const plans = {
         }, Object.create(null));
       }
       const $list = pgUnionAll({
-        attributes: attributes23,
+        attributes: attributes5,
         resourceByTypeName: resourceByTypeName10,
         members: members10,
         name: "owners"
@@ -18795,7 +18795,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = awsApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18811,7 +18811,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques2[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplicationThirdPartyVulnerabilities_awsApplicationThirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = awsApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18909,7 +18909,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.aws_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationThirdPartyVulnerabilitiesAttributes.aws_application_id.codec)}`;
             }
           });
         }
@@ -18932,7 +18932,7 @@ export const plans = {
             type: "attribute",
             attribute: "third_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes2.third_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationThirdPartyVulnerabilitiesAttributes.third_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -18948,7 +18948,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = gcpApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -18964,7 +18964,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques4[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplicationThirdPartyVulnerabilities_gcpApplicationThirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = gcpApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19062,7 +19062,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.gcp_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationThirdPartyVulnerabilitiesAttributes.gcp_application_id.codec)}`;
             }
           });
         }
@@ -19085,7 +19085,7 @@ export const plans = {
             type: "attribute",
             attribute: "third_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes4.third_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationThirdPartyVulnerabilitiesAttributes.third_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -19217,7 +19217,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
             }
           });
         }
@@ -19240,7 +19240,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
             }
           });
         }
@@ -19263,7 +19263,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_6.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -19404,7 +19404,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
             }
           });
         }
@@ -19427,7 +19427,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
             }
           });
         }
@@ -19450,7 +19450,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_7.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -19493,7 +19493,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19509,7 +19509,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques20[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_awsApplications_awsApplications.attributes[attributeName];
+          const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19743,7 +19743,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -19766,7 +19766,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -19789,7 +19789,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -19812,7 +19812,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -19835,7 +19835,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -19858,7 +19858,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_4.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
             }
           });
         }
@@ -19892,7 +19892,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -19908,7 +19908,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques21[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_gcpApplications_gcpApplications.attributes[attributeName];
+          const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20142,7 +20142,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
             }
           });
         }
@@ -20165,7 +20165,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
             }
           });
         }
@@ -20188,7 +20188,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
             }
           });
         }
@@ -20211,7 +20211,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
             }
           });
         }
@@ -20234,7 +20234,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -20257,7 +20257,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_5.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
             }
           });
         }
@@ -20300,7 +20300,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20316,7 +20316,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques22[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItems_singleTableItems.attributes[attributeName];
+          const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -20686,7 +20686,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -20709,7 +20709,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -20732,7 +20732,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -20755,7 +20755,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -20778,7 +20778,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -20801,7 +20801,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -20824,7 +20824,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -20847,7 +20847,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -20870,7 +20870,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -20893,7 +20893,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes17.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -21004,7 +21004,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -21020,7 +21020,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques23[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItems_relationalItems.attributes[attributeName];
+          const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -21390,7 +21390,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -21413,7 +21413,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -21436,7 +21436,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -21459,7 +21459,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -21482,7 +21482,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -21505,7 +21505,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -21528,7 +21528,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -21551,7 +21551,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -21574,7 +21574,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -21597,7 +21597,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes18.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -21690,7 +21690,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -21706,7 +21706,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques15[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelations_singleTableItemRelations.attributes[attributeName];
+          const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -21838,7 +21838,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -21861,7 +21861,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -21884,7 +21884,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes14.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -21900,7 +21900,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -21916,7 +21916,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques11[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_singleTableItemRelationCompositePks_singleTableItemRelationCompositePks.attributes[attributeName];
+          const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -22014,7 +22014,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -22037,7 +22037,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes10.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -23729,7 +23729,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -23745,7 +23745,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques14[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelations_relationalItemRelations.attributes[attributeName];
+          const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -23877,7 +23877,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
             }
           });
         }
@@ -23900,7 +23900,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -23923,7 +23923,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes13.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
             }
           });
         }
@@ -23939,7 +23939,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -23955,7 +23955,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques9[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalItemRelationCompositePks_relationalItemRelationCompositePks.attributes[attributeName];
+          const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -24053,7 +24053,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -24076,7 +24076,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes8.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
             }
           });
         }
@@ -26077,7 +26077,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_7,
+          attributes: VulnerabilityAttributes,
           resourceByTypeName: resourceByTypeName11,
           members: members11,
           name: "Vulnerability"
@@ -26133,7 +26133,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_6,
+          attributes: ApplicationAttributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "Application"
@@ -26189,7 +26189,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: attributes_object_Object_8,
+          attributes: ZeroImplementationAttributes,
           resourceByTypeName: resourceByTypeName13,
           members: members13,
           name: "ZeroImplementation"
@@ -27332,7 +27332,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
             }
           });
         }
@@ -27355,7 +27355,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_8.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
             }
           });
         }
@@ -27389,7 +27389,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27405,7 +27405,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques5[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_organizations_organizations.attributes[attributeName];
+          const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27503,7 +27503,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
             }
           });
         }
@@ -27526,7 +27526,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
             }
           });
         }
@@ -27560,7 +27560,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27576,7 +27576,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques6[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_people_people.attributes[attributeName];
+          const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27674,7 +27674,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
             }
           });
         }
@@ -27697,7 +27697,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes5.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
             }
           });
         }
@@ -27731,7 +27731,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_priorities_priorities.attributes[attributeName];
+          const attribute = prioritiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27747,7 +27747,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques7[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_priorities_priorities.attributes[attributeName];
+          const attribute = prioritiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27845,7 +27845,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), prioritiesAttributes.id.codec)}`;
             }
           });
         }
@@ -27868,7 +27868,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes6.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), prioritiesAttributes.title.codec)}`;
             }
           });
         }
@@ -27902,7 +27902,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -27918,7 +27918,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques8[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklists_relationalChecklists.attributes[attributeName];
+          const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28322,7 +28322,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
             }
           });
         }
@@ -28345,7 +28345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
             }
           });
         }
@@ -28368,7 +28368,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
             }
           });
         }
@@ -28391,7 +28391,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -28414,7 +28414,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -28437,7 +28437,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -28460,7 +28460,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
             }
           });
         }
@@ -28483,7 +28483,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -28506,7 +28506,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -28529,7 +28529,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28552,7 +28552,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes7.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -28586,7 +28586,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -28602,7 +28602,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques10[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalTopics_relationalTopics.attributes[attributeName];
+          const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -29006,7 +29006,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
             }
           });
         }
@@ -29029,7 +29029,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
             }
           });
         }
@@ -29052,7 +29052,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
             }
           });
         }
@@ -29075,7 +29075,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -29098,7 +29098,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -29121,7 +29121,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -29144,7 +29144,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
             }
           });
         }
@@ -29167,7 +29167,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -29190,7 +29190,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -29213,7 +29213,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -29236,7 +29236,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes9.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -29270,7 +29270,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -29286,7 +29286,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques12[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalChecklistItems_relationalChecklistItems.attributes[attributeName];
+          const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -29724,7 +29724,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
             }
           });
         }
@@ -29747,7 +29747,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
             }
           });
         }
@@ -29770,7 +29770,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
             }
           });
         }
@@ -29793,7 +29793,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
             }
           });
         }
@@ -29816,7 +29816,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -29839,7 +29839,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -29862,7 +29862,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -29885,7 +29885,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
             }
           });
         }
@@ -29908,7 +29908,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -29931,7 +29931,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -29954,7 +29954,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -29977,7 +29977,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes11.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -30011,7 +30011,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30027,7 +30027,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques13[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalDividers_relationalDividers.attributes[attributeName];
+          const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30465,7 +30465,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
             }
           });
         }
@@ -30488,7 +30488,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
             }
           });
         }
@@ -30511,7 +30511,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
             }
           });
         }
@@ -30534,7 +30534,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
             }
           });
         }
@@ -30557,7 +30557,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -30580,7 +30580,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -30603,7 +30603,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
             }
           });
         }
@@ -30626,7 +30626,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
             }
           });
         }
@@ -30649,7 +30649,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
             }
           });
         }
@@ -30672,7 +30672,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -30695,7 +30695,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -30718,7 +30718,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes12.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -30752,7 +30752,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -30768,7 +30768,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques17[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_relationalPosts_relationalPosts.attributes[attributeName];
+          const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -31240,7 +31240,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
             }
           });
         }
@@ -31263,7 +31263,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
             }
           });
         }
@@ -31286,7 +31286,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
             }
           });
         }
@@ -31309,7 +31309,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
             }
           });
         }
@@ -31332,7 +31332,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
             }
           });
         }
@@ -31355,7 +31355,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
             }
           });
         }
@@ -31378,7 +31378,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -31401,7 +31401,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
             }
           });
         }
@@ -31424,7 +31424,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
             }
           });
         }
@@ -31447,7 +31447,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
             }
           });
         }
@@ -31470,7 +31470,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
             }
           });
         }
@@ -31493,7 +31493,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -31516,7 +31516,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes16.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
             }
           });
         }
@@ -31550,7 +31550,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -31566,7 +31566,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques18[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_firstPartyVulnerabilities_firstPartyVulnerabilities.attributes[attributeName];
+          const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -31732,7 +31732,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -31755,7 +31755,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -31778,7 +31778,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -31801,7 +31801,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_2.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
             }
           });
         }
@@ -31835,7 +31835,7 @@ export const plans = {
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -31851,7 +31851,7 @@ export const plans = {
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
         uniques19[0].attributes.forEach(attributeName => {
-          const attribute = registryConfig_pgCodecs_thirdPartyVulnerabilities_thirdPartyVulnerabilities.attributes[attributeName];
+          const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
             fragment: sql`${step.alias}.${sql.identifier(attributeName)}`,
@@ -32017,7 +32017,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
             }
           });
         }
@@ -32040,7 +32040,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
             }
           });
         }
@@ -32063,7 +32063,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
             }
           });
         }
@@ -32086,7 +32086,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), attributes_object_Object_3.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -32,10 +32,9 @@ const executor_mainPgExecutor = new PgExecutor({
     });
   }
 });
-const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...["polymorphic", "aws_application_first_party_vulnerabilities"]);
-const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
   attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: {
@@ -50,8 +49,7 @@ const awsApplicationFirstPartyVulnerabilitiesCodecSpec = {
     })
   },
   executor: executor_mainPgExecutor
-};
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(awsApplicationFirstPartyVulnerabilitiesCodecSpec);
+});
 const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
     description: undefined,
@@ -72,28 +70,24 @@ const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.c
     }
   }
 });
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true
-  })
-};
-const parts2 = ["polymorphic", "aws_application_third_party_vulnerabilities"];
-const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts2);
-const awsApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
   attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
-  extensions: extensions2,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(awsApplicationThirdPartyVulnerabilitiesCodecSpec);
+});
 const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
@@ -114,28 +108,24 @@ const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.c
     }
   }
 });
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true
-  })
-};
-const parts3 = ["polymorphic", "gcp_application_first_party_vulnerabilities"];
-const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier(...parts3);
-const gcpApplicationFirstPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
   attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
   description: undefined,
-  extensions: extensions3,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(gcpApplicationFirstPartyVulnerabilitiesCodecSpec);
+});
 const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
     description: undefined,
@@ -156,28 +146,24 @@ const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.c
     }
   }
 });
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true
-  })
-};
-const parts4 = ["polymorphic", "gcp_application_third_party_vulnerabilities"];
-const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts4);
-const gcpApplicationThirdPartyVulnerabilitiesCodecSpec = {
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
   attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
   description: undefined,
-  extensions: extensions4,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(gcpApplicationThirdPartyVulnerabilitiesCodecSpec);
+});
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
     description: undefined,
@@ -198,28 +184,24 @@ const organizationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions5 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization"
-  })
-};
-const parts5 = ["polymorphic", "organizations"];
-const organizationsIdentifier = sql.identifier(...parts5);
-const organizationsCodecSpec = {
+const organizationsCodec = recordCodec({
   name: "organizations",
-  identifier: organizationsIdentifier,
+  identifier: sql.identifier("polymorphic", "organizations"),
   attributes: organizationsAttributes,
   description: undefined,
-  extensions: extensions5,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization"
+    })
+  },
   executor: executor_mainPgExecutor
-};
-const organizationsCodec = recordCodec(organizationsCodecSpec);
+});
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
     description: undefined,
@@ -266,17 +248,14 @@ const extensions6 = {
     }
   })
 };
-const parts6 = ["polymorphic", "people"];
-const peopleIdentifier = sql.identifier(...parts6);
-const peopleCodecSpec = {
+const peopleCodec = recordCodec({
   name: "people",
-  identifier: peopleIdentifier,
+  identifier: sql.identifier("polymorphic", "people"),
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
   executor: executor_mainPgExecutor
-};
-const peopleCodec = recordCodec(peopleCodecSpec);
+});
 const prioritiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -297,43 +276,37 @@ const prioritiesAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,filter,order"
-  })
-};
-const parts7 = ["polymorphic", "priorities"];
-const prioritiesIdentifier = sql.identifier(...parts7);
-const prioritiesCodecSpec = {
+const prioritiesCodec = recordCodec({
   name: "priorities",
-  identifier: prioritiesIdentifier,
+  identifier: sql.identifier("polymorphic", "priorities"),
   attributes: prioritiesAttributes,
   description: undefined,
-  extensions: extensions7,
-  executor: executor_mainPgExecutor
-};
-const prioritiesCodec = recordCodec(prioritiesCodecSpec);
-const extensions8 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "item_type"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,filter,order"
+    })
   },
-  tags: Object.create(null)
-};
-const parts8 = ["polymorphic", "item_type"];
+  executor: executor_mainPgExecutor
+});
 const itemTypeCodec = enumCodec({
   name: "itemType",
-  identifier: sql.identifier(...parts8),
+  identifier: sql.identifier("polymorphic", "item_type"),
   values: ["TOPIC", "POST", "DIVIDER", "CHECKLIST", "CHECKLIST_ITEM"],
   description: undefined,
-  extensions: extensions8
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "item_type"
+    },
+    tags: Object.create(null)
+  }
 });
 const relationalChecklistsAttributes = Object.assign(Object.create(null), {
   checklist_item_id: {
@@ -465,27 +438,23 @@ const relationalChecklistsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions9 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts9 = ["polymorphic", "relational_checklists"];
-const relationalChecklistsIdentifier = sql.identifier(...parts9);
-const relationalChecklistsCodecSpec = {
+const relationalChecklistsCodec = recordCodec({
   name: "relationalChecklists",
-  identifier: relationalChecklistsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklists"),
   attributes: relationalChecklistsAttributes,
   description: undefined,
-  extensions: extensions9,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistsCodec = recordCodec(relationalChecklistsCodecSpec);
+});
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -506,26 +475,22 @@ const relationalItemRelationCompositePksAttributes = Object.assign(Object.create
     }
   }
 });
-const extensions10 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts10 = ["polymorphic", "relational_item_relation_composite_pks"];
-const relationalItemRelationCompositePksIdentifier = sql.identifier(...parts10);
-const relationalItemRelationCompositePksCodecSpec = {
+const relationalItemRelationCompositePksCodec = recordCodec({
   name: "relationalItemRelationCompositePks",
-  identifier: relationalItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
   attributes: relationalItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions10,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationCompositePksCodec = recordCodec(relationalItemRelationCompositePksCodecSpec);
+});
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
     description: undefined,
@@ -656,27 +621,23 @@ const relationalTopicsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions11 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts11 = ["polymorphic", "relational_topics"];
-const relationalTopicsIdentifier = sql.identifier(...parts11);
-const relationalTopicsCodecSpec = {
+const relationalTopicsCodec = recordCodec({
   name: "relationalTopics",
-  identifier: relationalTopicsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_topics"),
   attributes: relationalTopicsAttributes,
   description: undefined,
-  extensions: extensions11,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalTopicsCodec = recordCodec(relationalTopicsCodecSpec);
+});
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
     description: undefined,
@@ -697,26 +658,22 @@ const singleTableItemRelationCompositePksAttributes = Object.assign(Object.creat
     }
   }
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: Object.create(null)
-};
-const parts12 = ["polymorphic", "single_table_item_relation_composite_pks"];
-const singleTableItemRelationCompositePksIdentifier = sql.identifier(...parts12);
-const singleTableItemRelationCompositePksCodecSpec = {
+const singleTableItemRelationCompositePksCodec = recordCodec({
   name: "singleTableItemRelationCompositePks",
-  identifier: singleTableItemRelationCompositePksIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
   attributes: singleTableItemRelationCompositePksAttributes,
   description: undefined,
-  extensions: extensions12,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationCompositePksCodec = recordCodec(singleTableItemRelationCompositePksCodecSpec);
+});
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
     description: undefined,
@@ -856,27 +813,23 @@ const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions13 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts13 = ["polymorphic", "relational_checklist_items"];
-const relationalChecklistItemsIdentifier = sql.identifier(...parts13);
-const relationalChecklistItemsCodecSpec = {
+const relationalChecklistItemsCodec = recordCodec({
   name: "relationalChecklistItems",
-  identifier: relationalChecklistItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
   attributes: relationalChecklistItemsAttributes,
   description: undefined,
-  extensions: extensions13,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalChecklistItemsCodec = recordCodec(relationalChecklistItemsCodecSpec);
+});
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
     description: undefined,
@@ -1016,27 +969,23 @@ const relationalDividersAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts14 = ["polymorphic", "relational_dividers"];
-const relationalDividersIdentifier = sql.identifier(...parts14);
-const relationalDividersCodecSpec = {
+const relationalDividersCodec = recordCodec({
   name: "relationalDividers",
-  identifier: relationalDividersIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_dividers"),
   attributes: relationalDividersAttributes,
   description: undefined,
-  extensions: extensions14,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalDividersCodec = recordCodec(relationalDividersCodecSpec);
+});
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1066,26 +1015,22 @@ const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions15 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts15 = ["polymorphic", "relational_item_relations"];
-const relationalItemRelationsIdentifier = sql.identifier(...parts15);
-const relationalItemRelationsCodecSpec = {
+const relationalItemRelationsCodec = recordCodec({
   name: "relationalItemRelations",
-  identifier: relationalItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_item_relations"),
   attributes: relationalItemRelationsAttributes,
   description: undefined,
-  extensions: extensions15,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const relationalItemRelationsCodec = recordCodec(relationalItemRelationsCodecSpec);
+});
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1115,26 +1060,22 @@ const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions16 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: Object.create(null)
-};
-const parts16 = ["polymorphic", "single_table_item_relations"];
-const singleTableItemRelationsIdentifier = sql.identifier(...parts16);
-const singleTableItemRelationsCodecSpec = {
+const singleTableItemRelationsCodec = recordCodec({
   name: "singleTableItemRelations",
-  identifier: singleTableItemRelationsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
   attributes: singleTableItemRelationsAttributes,
   description: undefined,
-  extensions: extensions16,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: Object.create(null)
+  },
   executor: executor_mainPgExecutor
-};
-const singleTableItemRelationsCodec = recordCodec(singleTableItemRelationsCodecSpec);
+});
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1198,17 +1139,14 @@ const extensions17 = {
     }
   })
 };
-const parts17 = ["polymorphic", "log_entries"];
-const logEntriesIdentifier = sql.identifier(...parts17);
-const logEntriesCodecSpec = {
+const logEntriesCodec = recordCodec({
   name: "logEntries",
-  identifier: logEntriesIdentifier,
+  identifier: sql.identifier("polymorphic", "log_entries"),
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
   executor: executor_mainPgExecutor
-};
-const logEntriesCodec = recordCodec(logEntriesCodecSpec);
+});
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
     description: undefined,
@@ -1357,27 +1295,23 @@ const relationalPostsAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions18 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: Object.create(null),
-  relationalInterfaceCodecName: "relationalItems"
-};
-const parts18 = ["polymorphic", "relational_posts"];
-const relationalPostsIdentifier = sql.identifier(...parts18);
-const relationalPostsCodecSpec = {
+const relationalPostsCodec = recordCodec({
   name: "relationalPosts",
-  identifier: relationalPostsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_posts"),
   attributes: relationalPostsAttributes,
   description: undefined,
-  extensions: extensions18,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: Object.create(null),
+    relationalInterfaceCodecName: "relationalItems"
+  },
   executor: executor_mainPgExecutor
-};
-const relationalPostsCodec = recordCodec(relationalPostsCodecSpec);
+});
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1453,17 +1387,14 @@ const extensions19 = {
     }
   })
 };
-const parts19 = ["polymorphic", "first_party_vulnerabilities"];
-const firstPartyVulnerabilitiesIdentifier = sql.identifier(...parts19);
-const firstPartyVulnerabilitiesCodecSpec = {
+const firstPartyVulnerabilitiesCodec = recordCodec({
   name: "firstPartyVulnerabilities",
-  identifier: firstPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
   executor: executor_mainPgExecutor
-};
-const firstPartyVulnerabilitiesCodec = recordCodec(firstPartyVulnerabilitiesCodecSpec);
+});
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1539,17 +1470,14 @@ const extensions20 = {
     }
   })
 };
-const parts20 = ["polymorphic", "third_party_vulnerabilities"];
-const thirdPartyVulnerabilitiesIdentifier = sql.identifier(...parts20);
-const thirdPartyVulnerabilitiesCodecSpec = {
+const thirdPartyVulnerabilitiesCodec = recordCodec({
   name: "thirdPartyVulnerabilities",
-  identifier: thirdPartyVulnerabilitiesIdentifier,
+  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
   executor: executor_mainPgExecutor
-};
-const thirdPartyVulnerabilitiesCodec = recordCodec(thirdPartyVulnerabilitiesCodecSpec);
+});
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1643,17 +1571,14 @@ const extensions21 = {
     }
   })
 };
-const parts21 = ["polymorphic", "aws_applications"];
-const awsApplicationsIdentifier = sql.identifier(...parts21);
-const awsApplicationsCodecSpec = {
+const awsApplicationsCodec = recordCodec({
   name: "awsApplications",
-  identifier: awsApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "aws_applications"),
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
   executor: executor_mainPgExecutor
-};
-const awsApplicationsCodec = recordCodec(awsApplicationsCodecSpec);
+});
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1747,17 +1672,14 @@ const extensions22 = {
     }
   })
 };
-const parts22 = ["polymorphic", "gcp_applications"];
-const gcpApplicationsIdentifier = sql.identifier(...parts22);
-const gcpApplicationsCodecSpec = {
+const gcpApplicationsCodec = recordCodec({
   name: "gcpApplications",
-  identifier: gcpApplicationsIdentifier,
+  identifier: sql.identifier("polymorphic", "gcp_applications"),
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
   executor: executor_mainPgExecutor
-};
-const gcpApplicationsCodec = recordCodec(gcpApplicationsCodecSpec);
+});
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -1932,17 +1854,14 @@ const extensions23 = {
     }
   })
 };
-const parts23 = ["polymorphic", "single_table_items"];
-const singleTableItemsIdentifier = sql.identifier(...parts23);
-const singleTableItemsCodecSpec = {
+const singleTableItemsCodec = recordCodec({
   name: "singleTableItems",
-  identifier: singleTableItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "single_table_items"),
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
   executor: executor_mainPgExecutor
-};
-const singleTableItemsCodec = recordCodec(singleTableItemsCodecSpec);
+});
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2047,17 +1966,14 @@ const extensions24 = {
     type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
   })
 };
-const parts24 = ["polymorphic", "relational_items"];
-const relationalItemsIdentifier = sql.identifier(...parts24);
-const relationalItemsCodecSpec = {
+const relationalItemsCodec = recordCodec({
   name: "relationalItems",
-  identifier: relationalItemsIdentifier,
+  identifier: sql.identifier("polymorphic", "relational_items"),
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
   executor: executor_mainPgExecutor
-};
-const relationalItemsCodec = recordCodec(relationalItemsCodecSpec);
+});
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2091,54 +2007,6 @@ const ApplicationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions25 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Application",
-    behavior: "node",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts25 = ["polymorphic", "applications"];
-const ApplicationIdentifier = sql.identifier(...parts25);
-const ApplicationCodecSpec = {
-  name: "Application",
-  identifier: ApplicationIdentifier,
-  attributes: ApplicationAttributes,
-  description: undefined,
-  extensions: extensions25,
-  executor: executor_mainPgExecutor
-};
 const VulnerabilityAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2174,54 +2042,6 @@ const VulnerabilityAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions26 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "Vulnerability",
-    behavior: "node",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
-};
-const parts26 = ["polymorphic", "vulnerabilities"];
-const VulnerabilityIdentifier = sql.identifier(...parts26);
-const VulnerabilityCodecSpec = {
-  name: "Vulnerability",
-  identifier: VulnerabilityIdentifier,
-  attributes: VulnerabilityAttributes,
-  description: undefined,
-  extensions: extensions26,
-  executor: executor_mainPgExecutor
-};
 const ZeroImplementationAttributes = Object.assign(Object.create(null), {
   id: {
     description: undefined,
@@ -2242,40 +2062,6 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const extensions27 = {
-  isTableLike: false,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "zero_implementation"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:union",
-    name: "ZeroImplementation",
-    behavior: "node"
-  })
-};
-const parts27 = ["polymorphic", "zero_implementation"];
-const ZeroImplementationIdentifier = sql.identifier(...parts27);
-const ZeroImplementationCodecSpec = {
-  name: "ZeroImplementation",
-  identifier: ZeroImplementationIdentifier,
-  attributes: ZeroImplementationAttributes,
-  description: undefined,
-  extensions: extensions27,
-  executor: executor_mainPgExecutor
-};
-const extensions28 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true
-  }
-};
 const uniques = [{
   isPrimary: true,
   attributes: ["aws_application_id", "first_party_vulnerability_id"],
@@ -2293,17 +2079,16 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   uniques,
   isVirtual: false,
   description: undefined,
-  extensions: extensions28
-};
-const extensions29 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true
+    }
   }
 };
 const uniques2 = [{
@@ -2323,17 +2108,16 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   uniques: uniques2,
   isVirtual: false,
   description: undefined,
-  extensions: extensions29
-};
-const extensions30 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
-  },
-  tags: {
-    omit: true
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true
+    }
   }
 };
 const uniques3 = [{
@@ -2353,17 +2137,16 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   uniques: uniques3,
   isVirtual: false,
   description: undefined,
-  extensions: extensions30
-};
-const extensions31 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
-  },
-  tags: {
-    omit: true
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: {
+      omit: true
+    }
   }
 };
 const uniques4 = [{
@@ -2383,17 +2166,16 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
   uniques: uniques4,
   isVirtual: false,
   description: undefined,
-  extensions: extensions31
-};
-const extensions32 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "organizations"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: {
+      omit: true
+    }
   }
 };
 const uniques5 = [{
@@ -2420,19 +2202,16 @@ const registryConfig_pgResources_organizations_organizations = {
   uniques: uniques5,
   isVirtual: false,
   description: undefined,
-  extensions: extensions32
-};
-const extensions33 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: extensions6.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "organizations"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization"
+    }
   }
 };
 const uniques6 = [{
@@ -2459,17 +2238,18 @@ const registryConfig_pgResources_people_people = {
   uniques: uniques6,
   isVirtual: false,
   description: undefined,
-  extensions: extensions33
-};
-const extensions34 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
-  },
-  tags: {
-    omit: "create,update,delete,filter,order"
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: extensions6.tags.refVia
+    }
   }
 };
 const uniques7 = [{
@@ -2489,16 +2269,17 @@ const registryConfig_pgResources_priorities_priorities = {
   uniques: uniques7,
   isVirtual: false,
   description: undefined,
-  extensions: extensions34
-};
-const extensions35 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklists"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: {
+      omit: "create,update,delete,filter,order"
+    }
+  }
 };
 const uniques8 = [{
   isPrimary: true,
@@ -2517,16 +2298,15 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
   uniques: uniques8,
   isVirtual: false,
   description: undefined,
-  extensions: extensions35
-};
-const extensions36 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklists"
+    },
+    tags: {}
+  }
 };
 const uniques9 = [{
   isPrimary: true,
@@ -2545,16 +2325,15 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
   uniques: uniques9,
   isVirtual: false,
   description: undefined,
-  extensions: extensions36
-};
-const extensions37 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_topics"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques10 = [{
   isPrimary: true,
@@ -2573,16 +2352,15 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
   uniques: uniques10,
   isVirtual: false,
   description: undefined,
-  extensions: extensions37
-};
-const extensions38 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relation_composite_pks"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_topics"
+    },
+    tags: {}
+  }
 };
 const uniques11 = [{
   isPrimary: true,
@@ -2601,16 +2379,15 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
   uniques: uniques11,
   isVirtual: false,
   description: undefined,
-  extensions: extensions38
-};
-const extensions39 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_checklist_items"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relation_composite_pks"
+    },
+    tags: {}
+  }
 };
 const uniques12 = [{
   isPrimary: true,
@@ -2629,16 +2406,15 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
   uniques: uniques12,
   isVirtual: false,
   description: undefined,
-  extensions: extensions39
-};
-const extensions40 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_dividers"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_checklist_items"
+    },
+    tags: {}
+  }
 };
 const uniques13 = [{
   isPrimary: true,
@@ -2657,16 +2433,15 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
   uniques: uniques13,
   isVirtual: false,
   description: undefined,
-  extensions: extensions40
-};
-const extensions41 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_dividers"
+    },
+    tags: {}
+  }
 };
 const uniques14 = [{
   isPrimary: true,
@@ -2692,16 +2467,15 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
   uniques: uniques14,
   isVirtual: false,
   description: undefined,
-  extensions: extensions41
-};
-const extensions42 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_item_relations"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_item_relations"
+    },
+    tags: {}
+  }
 };
 const uniques15 = [{
   isPrimary: true,
@@ -2727,18 +2501,14 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
   uniques: uniques15,
   isVirtual: false,
   description: undefined,
-  extensions: extensions42
-};
-const extensions43 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: extensions17.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_item_relations"
+    },
+    tags: {}
   }
 };
 const uniques16 = [{
@@ -2758,16 +2528,18 @@ const registryConfig_pgResources_log_entries_log_entries = {
   uniques: uniques16,
   isVirtual: false,
   description: undefined,
-  extensions: extensions43
-};
-const extensions44 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_posts"
-  },
-  tags: {}
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: extensions17.tags.refVia
+    }
+  }
 };
 const uniques17 = [{
   isPrimary: true,
@@ -2786,19 +2558,14 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
   uniques: uniques17,
   isVirtual: false,
   description: undefined,
-  extensions: extensions44
-};
-const extensions45 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions19.tags.ref,
-    refVia: extensions19.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_posts"
+    },
+    tags: {}
   }
 };
 const uniques18 = [{
@@ -2818,19 +2585,18 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
   uniques: uniques18,
   isVirtual: false,
   description: undefined,
-  extensions: extensions45
-};
-const extensions46 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: {
-    implements: "Vulnerability",
-    ref: extensions20.tags.ref,
-    refVia: extensions20.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions19.tags.ref,
+      refVia: extensions19.tags.refVia
+    }
   }
 };
 const uniques19 = [{
@@ -2850,19 +2616,18 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
   uniques: uniques19,
   isVirtual: false,
   description: undefined,
-  extensions: extensions46
-};
-const extensions47 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions21.tags.ref,
-    refVia: extensions21.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: {
+      implements: "Vulnerability",
+      ref: extensions20.tags.ref,
+      refVia: extensions20.tags.refVia
+    }
   }
 };
 const uniques20 = [{
@@ -2882,19 +2647,18 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
   uniques: uniques20,
   isVirtual: false,
   description: undefined,
-  extensions: extensions47
-};
-const extensions48 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: {
-    implements: "Application",
-    ref: extensions22.tags.ref,
-    refVia: extensions22.tags.refVia
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions21.tags.ref,
+      refVia: extensions21.tags.refVia
+    }
   }
 };
 const uniques21 = [{
@@ -2914,34 +2678,21 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
   uniques: uniques21,
   isVirtual: false,
   description: undefined,
-  extensions: extensions48
-};
-const extensions49 = {
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "custom_delete_relational_item"
-  },
-  tags: {
-    arg0variant: "nodeId",
-    behavior: ["-filter -order"]
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: {
+      implements: "Application",
+      ref: extensions22.tags.ref,
+      refVia: extensions22.tags.refVia
+    }
   }
 };
-const parts28 = ["polymorphic", "custom_delete_relational_item"];
-const sqlIdent2 = sql.identifier(...parts28);
-const extensions50 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: {
-    interface: "mode:single type:type",
-    type: extensions23.tags.type,
-    ref: extensions23.tags.ref
-  }
-};
+const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
 const uniques22 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -2959,74 +2710,22 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
   uniques: uniques22,
   isVirtual: false,
   description: undefined,
-  extensions: extensions50
-};
-const parts29 = ["polymorphic", "all_single_tables"];
-const sqlIdent3 = sql.identifier(...parts29);
-const options_all_single_tables = {
-  name: "all_single_tables",
-  identifier: "main.polymorphic.all_single_tables()",
-  from(...args) {
-    return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [],
-  returnsArray: false,
-  returnsSetof: true,
-  isMutation: false,
   extensions: {
+    description: undefined,
     pg: {
       serviceName: "main",
       schemaName: "polymorphic",
-      name: "all_single_tables"
+      name: "single_table_items"
     },
     tags: {
-      behavior: ["-filter -order"]
+      interface: "mode:single type:type",
+      type: extensions23.tags.type,
+      ref: extensions23.tags.ref
     }
-  },
-  description: undefined
-};
-const parts30 = ["polymorphic", "get_single_table_topic_by_id"];
-const sqlIdent4 = sql.identifier(...parts30);
-const options_get_single_table_topic_by_id = {
-  name: "get_single_table_topic_by_id",
-  identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
-  from(...args) {
-    return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
-  },
-  parameters: [{
-    name: "id",
-    required: true,
-    notNull: false,
-    codec: TYPES.int
-  }],
-  returnsArray: false,
-  returnsSetof: false,
-  isMutation: false,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "polymorphic",
-      name: "get_single_table_topic_by_id"
-    },
-    tags: {
-      returnType: "SingleTableTopic",
-      behavior: ["-filter -order"]
-    }
-  },
-  description: undefined
-};
-const extensions51 = {
-  description: undefined,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: {
-    interface: "mode:relational",
-    type: extensions24.tags.type
   }
 };
+const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
+const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
 const uniques23 = [{
   isPrimary: true,
   attributes: ["id"],
@@ -3044,7 +2743,18 @@ const registryConfig_pgResources_relational_items_relational_items = {
   uniques: uniques23,
   isVirtual: false,
   description: undefined,
-  extensions: extensions51
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: {
+      interface: "mode:relational",
+      type: extensions24.tags.type
+    }
+  }
 };
 const registryConfig = {
   pgCodecs: Object.assign(Object.create(null), {
@@ -3080,9 +2790,116 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec(ApplicationCodecSpec),
-    Vulnerability: recordCodec(VulnerabilityCodecSpec),
-    ZeroImplementation: recordCodec(ZeroImplementationCodecSpec)
+    Application: recordCodec({
+      name: "Application",
+      identifier: sql.identifier("polymorphic", "applications"),
+      attributes: ApplicationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "applications"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Application",
+          behavior: "node",
+          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          vulnerabilities: {
+            singular: false,
+            graphqlType: "Vulnerability",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owner: {
+            singular: true,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    Vulnerability: recordCodec({
+      name: "Vulnerability",
+      identifier: sql.identifier("polymorphic", "vulnerabilities"),
+      attributes: VulnerabilityAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "vulnerabilities"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "Vulnerability",
+          behavior: "node",
+          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+        }),
+        refDefinitions: Object.assign(Object.create(null), {
+          applications: {
+            singular: false,
+            graphqlType: "Application",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          },
+          owners: {
+            singular: false,
+            graphqlType: "PersonOrOrganization",
+            sourceGraphqlType: undefined,
+            extensions: {
+              via: undefined,
+              tags: {
+                behavior: undefined
+              }
+            }
+          }
+        })
+      },
+      executor: executor_mainPgExecutor
+    }),
+    ZeroImplementation: recordCodec({
+      name: "ZeroImplementation",
+      identifier: sql.identifier("polymorphic", "zero_implementation"),
+      attributes: ZeroImplementationAttributes,
+      description: undefined,
+      extensions: {
+        isTableLike: false,
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "zero_implementation"
+        },
+        tags: Object.assign(Object.create(null), {
+          interface: "mode:union",
+          name: "ZeroImplementation",
+          behavior: "node"
+        })
+      },
+      executor: executor_mainPgExecutor
+    })
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -3126,12 +2943,70 @@ const registryConfig = {
       codec: TYPES.boolean,
       uniques: [],
       isMutation: true,
-      extensions: extensions49,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "custom_delete_relational_item"
+        },
+        tags: {
+          arg0variant: "nodeId",
+          behavior: ["-filter -order"]
+        }
+      },
       description: undefined
     },
     single_table_items: registryConfig_pgResources_single_table_items_single_table_items,
-    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_all_single_tables),
-    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, options_get_single_table_topic_by_id),
+    all_single_tables: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "all_single_tables",
+      identifier: "main.polymorphic.all_single_tables()",
+      from(...args) {
+        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "all_single_tables"
+        },
+        tags: {
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
+    get_single_table_topic_by_id: PgResource.functionResourceOptions(registryConfig_pgResources_single_table_items_single_table_items, {
+      name: "get_single_table_topic_by_id",
+      identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
+      from(...args) {
+        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "id",
+        required: true,
+        notNull: false,
+        codec: TYPES.int
+      }],
+      returnsArray: false,
+      returnsSetof: false,
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "polymorphic",
+          name: "get_single_table_topic_by_id"
+        },
+        tags: {
+          returnType: "SingleTableTopic",
+          behavior: ["-filter -order"]
+        }
+      },
+      description: undefined
+    }),
     relational_items: registryConfig_pgResources_relational_items_relational_items
   }),
   pgRelations: Object.assign(Object.create(null), {
@@ -4206,21 +4081,6 @@ const registryConfig = {
 const registry = makeRegistry(registryConfig);
 const otherSource_peoplePgResource = registry.pgResources["people"];
 const otherSource_single_table_itemsPgResource = registry.pgResources["single_table_items"];
-function SingleTableTopic_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   const val = $value.eval();
   if (val == null) {
@@ -4240,146 +4100,11 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   });
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
-function SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_log_entriesPgResource = registry.pgResources["log_entries"];
-function Person_logEntriesByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_logEntriesByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_logEntriesByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_logEntriesByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_logEntriesByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_singleTableItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_singleTableItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_relational_itemsPgResource = registry.pgResources["relational_items"];
-function Person_relationalItemsByAuthorId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_relationalItemsByAuthorId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_relationalItemsByAuthorId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_aws_applicationsPgResource = registry.pgResources["aws_applications"];
-function Person_awsApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_awsApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_awsApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_gcp_applicationsPgResource = registry.pgResources["gcp_applications"];
-function Person_gcpApplicationsByPersonId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_gcpApplicationsByPersonId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_gcpApplicationsByPersonId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication",
@@ -4416,31 +4141,6 @@ const resourceByTypeName = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Person_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Person_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Person_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Person_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Person_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function LogEntryConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function LogEntryConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function LogEntryConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const otherSource_organizationsPgResource = registry.pgResources["organizations"];
 const attributes = {};
 const members2 = [{
@@ -4479,93 +4179,8 @@ const resourceByTypeName2 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function Organization_logEntriesByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_logEntriesByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_logEntriesByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_awsApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Organization_gcpApplicationsByOrganizationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function AwsApplicationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AwsApplicationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AwsApplicationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const otherSource_aws_application_first_party_vulnerabilitiesPgResource = registry.pgResources["aws_application_first_party_vulnerabilities"];
-function AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_aws_application_third_party_vulnerabilitiesPgResource = registry.pgResources["aws_application_third_party_vulnerabilities"];
-function AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members3 = [{
   resource: otherSource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "FirstPartyVulnerability",
@@ -4620,21 +4235,6 @@ const resourceByTypeName3 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function AwsApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function AwsApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function AwsApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function AwsApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function AwsApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes2 = {};
 const members4 = [{
   resource: otherSource_peoplePgResource,
@@ -4672,83 +4272,7 @@ const resourceByTypeName4 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function VulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function VulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function VulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ApplicationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ApplicationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ApplicationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PageInfo_hasNextPagePlan($pageInfo) {
-  return $pageInfo.hasNextPage();
-}
-function PageInfo_hasPreviousPagePlan($pageInfo) {
-  return $pageInfo.hasPreviousPage();
-}
-function PersonOrOrganizationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonOrOrganizationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonOrOrganizationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function AwsApplicationFirstPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AwsApplicationFirstPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AwsApplicationFirstPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_gcp_application_first_party_vulnerabilitiesPgResource = registry.pgResources["gcp_application_first_party_vulnerabilities"];
-function FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members5 = [{
   resource: otherSource_aws_application_first_party_vulnerabilitiesPgResource,
   typeName: "AwsApplication",
@@ -4801,21 +4325,6 @@ const resourceByTypeName5 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function FirstPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function FirstPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function FirstPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function FirstPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function FirstPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes3 = {};
 const members6 = [{
   resource: otherSource_aws_application_first_party_vulnerabilitiesPgResource,
@@ -4947,47 +4456,7 @@ const resourceByTypeName6 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function GcpApplicationFirstPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GcpApplicationFirstPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GcpApplicationFirstPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const otherSource_gcp_application_third_party_vulnerabilitiesPgResource = registry.pgResources["gcp_application_third_party_vulnerabilities"];
-function GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members7 = [{
   resource: otherSource_gcp_application_first_party_vulnerabilitiesPgResource,
   typeName: "FirstPartyVulnerability",
@@ -5040,21 +4509,6 @@ const resourceByTypeName7 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function GcpApplication_vulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function GcpApplication_vulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function GcpApplication_vulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function GcpApplication_vulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function GcpApplication_vulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes4 = {};
 const members8 = [{
   resource: otherSource_peoplePgResource,
@@ -5092,46 +4546,6 @@ const resourceByTypeName8 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function GcpApplicationThirdPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GcpApplicationThirdPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GcpApplicationThirdPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members9 = [{
   resource: otherSource_aws_application_third_party_vulnerabilitiesPgResource,
   typeName: "AwsApplication",
@@ -5184,21 +4598,6 @@ const resourceByTypeName9 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function ThirdPartyVulnerability_applications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function ThirdPartyVulnerability_applications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function ThirdPartyVulnerability_applications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const attributes5 = {};
 const members10 = [{
   resource: otherSource_aws_application_third_party_vulnerabilitiesPgResource,
@@ -5330,802 +4729,14 @@ const resourceByTypeName10 = Object.assign(Object.create(null), {
   Person: otherSource_peoplePgResource,
   Organization: otherSource_organizationsPgResource
 });
-function AwsApplicationThirdPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function AwsApplicationThirdPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function AwsApplicationThirdPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function GcpApplicationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function GcpApplicationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function GcpApplicationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SingleTableItemConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemRelationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalItemRelationCompositePkConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalItemRelationCompositePkConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalItemRelationCompositePkConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SingleTableItemRelationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function SingleTableItemRelationCompositePkConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function SingleTableItemRelationCompositePkConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function SingleTableItemRelationCompositePkConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
 const otherSource_prioritiesPgResource = registry.pgResources["priorities"];
-function SingleTablePost_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Priority_singleTableItemsByPriorityId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByRootTopicId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_topics_relational_topicsPgResource = registry.pgResources["relational_topics"];
-function RelationalTopic_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_posts_relational_postsPgResource = registry.pgResources["relational_posts"];
 const relational_dividers_relational_dividersPgResource = registry.pgResources["relational_dividers"];
 const relational_checklists_relational_checklistsPgResource = registry.pgResources["relational_checklists"];
 const relational_checklist_items_relational_checklist_itemsPgResource = registry.pgResources["relational_checklist_items"];
 const relational_item_relations_relational_item_relationsPgResource = registry.pgResources["relational_item_relations"];
-function RelationalTopic_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const relational_item_relation_composite_pks_relational_item_relation_composite_pksPgResource = registry.pgResources["relational_item_relation_composite_pks"];
-function RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_queryPlan() {
-  return rootValue();
-}
 const argDetailsSimple = [];
 const makeArgs = (args, path = []) => {
   const selectArgs = [];
@@ -6176,25 +4787,6 @@ const getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs(args);
   return resource_all_single_tablesPgResource.execute(selectArgs);
 };
-function Query_allSingleTablesPlan($parent, args, info) {
-  const $select = getSelectPlanFromParentAndArgs($parent, args, info);
-  return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
-}
-function Query_allSingleTables_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTables_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTables_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTables_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTables_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const argDetailsSimple2 = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -6258,21 +4850,6 @@ const resourceByTypeName11 = Object.assign(Object.create(null), {
   FirstPartyVulnerability: paths_0_resource_first_party_vulnerabilitiesPgResource,
   ThirdPartyVulnerability: paths_1_resource_third_party_vulnerabilitiesPgResource
 });
-function Query_allVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members12 = [{
   resource: otherSource_aws_applicationsPgResource,
   typeName: "AwsApplication"
@@ -6284,1405 +4861,8 @@ const resourceByTypeName12 = Object.assign(Object.create(null), {
   AwsApplication: otherSource_aws_applicationsPgResource,
   GcpApplication: otherSource_gcp_applicationsPgResource
 });
-function Query_allApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
 const members13 = [];
 const resourceByTypeName13 = Object.create(null);
-function Query_allZeroImplementations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allZeroImplementations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allZeroImplementations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allZeroImplementations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allZeroImplementations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allAwsApplicationFirstPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAwsApplicationFirstPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAwsApplicationFirstPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAwsApplicationFirstPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAwsApplicationFirstPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allAwsApplicationThirdPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAwsApplicationThirdPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAwsApplicationThirdPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAwsApplicationThirdPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAwsApplicationThirdPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allGcpApplicationFirstPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGcpApplicationFirstPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGcpApplicationFirstPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGcpApplicationFirstPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGcpApplicationFirstPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allGcpApplicationThirdPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGcpApplicationThirdPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGcpApplicationThirdPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGcpApplicationThirdPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGcpApplicationThirdPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allOrganizations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allOrganizations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allOrganizations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allOrganizations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allOrganizations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPeople_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPeople_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPeople_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPeople_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPeople_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allPriorities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allPriorities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allPriorities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allPriorities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allPriorities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklists_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklists_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklists_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklists_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklists_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalTopics_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalTopics_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalTopics_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalTopics_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalTopics_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelationCompositePks_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalChecklistItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalChecklistItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalChecklistItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalChecklistItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalChecklistItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalDividers_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalDividers_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalDividers_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalDividers_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalDividers_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItemRelations_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItemRelations_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItemRelations_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItemRelations_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItemRelations_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allLogEntries_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allLogEntries_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allLogEntries_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allLogEntries_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allLogEntries_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalPosts_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalPosts_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalPosts_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalPosts_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalPosts_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allFirstPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allThirdPartyVulnerabilities_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allAwsApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allAwsApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allAwsApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allAwsApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allAwsApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allGcpApplications_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allGcpApplications_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allGcpApplications_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allGcpApplications_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allGcpApplications_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allSingleTableItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allSingleTableItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allSingleTableItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allSingleTableItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allSingleTableItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function Query_allRelationalItems_first_applyPlan(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function Query_allRelationalItems_last_applyPlan(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function Query_allRelationalItems_offset_applyPlan(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function Query_allRelationalItems_before_applyPlan(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function Query_allRelationalItems_after_applyPlan(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function ZeroImplementationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ZeroImplementationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ZeroImplementationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function OrganizationConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function OrganizationConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function OrganizationConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PersonConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PersonConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PersonConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function PriorityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function PriorityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function PriorityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalTopicConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalTopicConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalTopicConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalChecklistItemConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalChecklistItemConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalChecklistItemConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalDividerConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalDividerConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalDividerConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function RelationalPostConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function RelationalPostConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function RelationalPostConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function FirstPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function FirstPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function FirstPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function ThirdPartyVulnerabilityConnection_nodesPlan($connection) {
-  return $connection.nodes();
-}
-function ThirdPartyVulnerabilityConnection_edgesPlan($connection) {
-  return $connection.edges();
-}
-function ThirdPartyVulnerabilityConnection_pageInfoPlan($connection) {
-  // TYPES: why is this a TypeScript issue without the 'any'?
-  return $connection.pageInfo();
-}
-function Mutation_createAwsApplicationFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createAwsApplicationThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createGcpApplicationFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createGcpApplicationThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createOrganization_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPerson_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createPriority_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelationCompositePk_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createRelationalItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createSingleTableItemRelation_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createLogEntry_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createFirstPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createThirdPartyVulnerability_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createAwsApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_createGcpApplication_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updatePriorityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateLogEntryByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateFirstPartyVulnerabilityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateThirdPartyVulnerabilityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateAwsApplicationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_updateGcpApplicationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByOrganizationId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteOrganizationByName_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByPersonId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePersonByUsername_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deletePriorityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteLogEntryByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteFirstPartyVulnerabilityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteThirdPartyVulnerabilityByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteAwsApplicationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function Mutation_deleteGcpApplicationByRowId_input_applyPlan(_, $object) {
-  return $object;
-}
-function CreateAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateAwsApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAwsApplicationFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAwsApplicationFirstPartyVulnerabilityInput_awsApplicationFirstPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateAwsApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAwsApplicationThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAwsApplicationThirdPartyVulnerabilityInput_awsApplicationThirdPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateGcpApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGcpApplicationFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGcpApplicationFirstPartyVulnerabilityInput_gcpApplicationFirstPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateGcpApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGcpApplicationThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGcpApplicationThirdPartyVulnerabilityInput_gcpApplicationThirdPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function CreateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateOrganizationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateOrganizationInput_organization_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function CreatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePersonInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePersonInput_person_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreatePriorityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreatePriorityPayload_priorityPlan($object) {
-  return $object.get("result");
-}
-function CreatePriorityPayload_queryPlan() {
-  return rootValue();
-}
-function CreatePriorityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreatePriorityInput_priority_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateRelationalItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateRelationalItemRelationInput_relationalItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function CreateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateSingleTableItemRelationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function CreateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function CreateLogEntryInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateLogEntryInput_logEntry_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function CreateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateAwsApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateAwsApplicationInput_awsApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function CreateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function CreateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function CreateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function CreateGcpApplicationInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function CreateGcpApplicationInput_gcpApplication_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateAwsApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_awsApplicationFirstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateAwsApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_awsApplicationThirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateGcpApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_gcpApplicationFirstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateGcpApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_gcpApplicationThirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function UpdateOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateOrganizationByNameInput_organizationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function UpdatePersonPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByPersonIdInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePersonByUsernameInput_personPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdatePriorityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdatePriorityPayload_priorityPlan($object) {
-  return $object.get("result");
-}
-function UpdatePriorityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdatePriorityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdatePriorityByRowIdInput_priorityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateRelationalItemRelationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByRowIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function UpdateSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateSingleTableItemRelationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByRowIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function UpdateLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateLogEntryByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateLogEntryByRowIdInput_logEntryPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateFirstPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateFirstPartyVulnerabilityByRowIdInput_firstPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function UpdateThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateThirdPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateThirdPartyVulnerabilityByRowIdInput_thirdPartyVulnerabilityPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateAwsApplicationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateAwsApplicationByRowIdInput_awsApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function UpdateGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function UpdateGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function UpdateGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function UpdateGcpApplicationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function UpdateGcpApplicationByRowIdInput_gcpApplicationPatch_applyPlan($object) {
-  const $record = $object.getStepForKey("result");
-  return $record.setPlan();
-}
-function DeleteAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteAwsApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteAwsApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteGcpApplicationFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteGcpApplicationThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOrganizationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteOrganizationPayload_organizationPlan($object) {
-  return $object.get("result");
-}
-function DeleteOrganizationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteOrganizationByNameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePersonPayload_personPlan($object) {
-  return $object.get("result");
-}
-function DeletePersonPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePersonByPersonIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePersonByUsernameInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeletePriorityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeletePriorityPayload_priorityPlan($object) {
-  return $object.get("result");
-}
-function DeletePriorityPayload_queryPlan() {
-  return rootValue();
-}
-function DeletePriorityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationCompositePkPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteRelationalItemRelationPayload_relationalItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteRelationalItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteRelationalItemRelationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan($object) {
-  return $object.get("result");
-}
-function DeleteSingleTableItemRelationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteSingleTableItemRelationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteLogEntryPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteLogEntryPayload_logEntryPlan($object) {
-  return $object.get("result");
-}
-function DeleteLogEntryPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteLogEntryByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteFirstPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteFirstPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan($object) {
-  return $object.get("result");
-}
-function DeleteThirdPartyVulnerabilityPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteThirdPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteAwsApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteAwsApplicationPayload_awsApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteAwsApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteAwsApplicationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
-function DeleteGcpApplicationPayload_clientMutationIdPlan($mutation) {
-  return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
-}
-function DeleteGcpApplicationPayload_gcpApplicationPlan($object) {
-  return $object.get("result");
-}
-function DeleteGcpApplicationPayload_queryPlan() {
-  return rootValue();
-}
-function DeleteGcpApplicationByRowIdInput_clientMutationId_applyPlan($input, val) {
-  $input.set("clientMutationId", val.get());
-}
 export const typeDefs = /* GraphQL */`type SingleTableTopic implements SingleTableItem {
   rowId: Int!
   type: ItemType!
@@ -16412,23 +13592,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16458,23 +13648,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16504,23 +13704,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16550,23 +13760,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16596,23 +13816,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16656,23 +13886,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_logEntriesByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16702,23 +13942,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_singleTableItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16748,23 +13998,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_relationalItemsByAuthorId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16794,23 +14054,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_awsApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16840,23 +14110,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_gcpApplicationsByPersonId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16907,23 +14187,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Person_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -16953,9 +14243,16 @@ export const plans = {
   },
   LogEntryConnection: {
     __assertStep: ConnectionStep,
-    nodes: LogEntryConnection_nodesPlan,
-    edges: LogEntryConnection_edgesPlan,
-    pageInfo: LogEntryConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17030,23 +14327,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_logEntriesByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17076,23 +14383,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_awsApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17122,23 +14439,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Organization_gcpApplicationsByOrganizationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17428,9 +14755,16 @@ export const plans = {
   },
   AwsApplicationConnection: {
     __assertStep: ConnectionStep,
-    nodes: AwsApplicationConnection_nodesPlan,
-    edges: AwsApplicationConnection_edgesPlan,
-    pageInfo: AwsApplicationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17475,23 +14809,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationFirstPartyVulnerabilitiesByAwsApplicationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17521,23 +14865,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_awsApplicationThirdPartyVulnerabilitiesByAwsApplicationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17588,23 +14942,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: AwsApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17661,18 +15025,32 @@ export const plans = {
   },
   VulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: VulnerabilityConnection_nodesPlan,
-    edges: VulnerabilityConnection_edgesPlan,
-    pageInfo: VulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   ApplicationConnection: {
     __assertStep: ConnectionStep,
-    nodes: ApplicationConnection_nodesPlan,
-    edges: ApplicationConnection_edgesPlan,
-    pageInfo: ApplicationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17688,8 +15066,12 @@ export const plans = {
   },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
-    hasNextPage: PageInfo_hasNextPagePlan,
-    hasPreviousPage: PageInfo_hasPreviousPagePlan,
+    hasNextPage($pageInfo) {
+      return $pageInfo.hasNextPage();
+    },
+    hasPreviousPage($pageInfo) {
+      return $pageInfo.hasPreviousPage();
+    },
     startCursor($pageInfo) {
       return $pageInfo.startCursor();
     },
@@ -17699,9 +15081,16 @@ export const plans = {
   },
   PersonOrOrganizationConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonOrOrganizationConnection_nodesPlan,
-    edges: PersonOrOrganizationConnection_edgesPlan,
-    pageInfo: PersonOrOrganizationConnection_pageInfoPlan
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    }
   },
   PersonOrOrganizationEdge: {
     __assertStep: assertEdgeCapableStep,
@@ -17723,9 +15112,16 @@ export const plans = {
   },
   AwsApplicationFirstPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: AwsApplicationFirstPartyVulnerabilityConnection_nodesPlan,
-    edges: AwsApplicationFirstPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: AwsApplicationFirstPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -17773,23 +15169,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_awsApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17819,23 +15225,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_gcpApplicationFirstPartyVulnerabilitiesByFirstPartyVulnerabilityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -17886,23 +15302,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: FirstPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18112,9 +15538,16 @@ export const plans = {
   },
   GcpApplicationFirstPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: GcpApplicationFirstPartyVulnerabilityConnection_nodesPlan,
-    edges: GcpApplicationFirstPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: GcpApplicationFirstPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18178,23 +15611,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationFirstPartyVulnerabilitiesByGcpApplicationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18224,23 +15667,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_gcpApplicationThirdPartyVulnerabilitiesByGcpApplicationId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18291,23 +15744,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: GcpApplication_vulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18517,9 +15980,16 @@ export const plans = {
   },
   GcpApplicationThirdPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: GcpApplicationThirdPartyVulnerabilityConnection_nodesPlan,
-    edges: GcpApplicationThirdPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: GcpApplicationThirdPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -18567,23 +16037,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_awsApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18613,23 +16093,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_gcpApplicationThirdPartyVulnerabilitiesByThirdPartyVulnerabilityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18680,23 +16170,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: ThirdPartyVulnerability_applications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -18753,9 +16253,16 @@ export const plans = {
   },
   AwsApplicationThirdPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: AwsApplicationThirdPartyVulnerabilityConnection_nodesPlan,
-    edges: AwsApplicationThirdPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: AwsApplicationThirdPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -19869,9 +17376,16 @@ export const plans = {
   },
   GcpApplicationConnection: {
     __assertStep: ConnectionStep,
-    nodes: GcpApplicationConnection_nodesPlan,
-    edges: GcpApplicationConnection_edgesPlan,
-    pageInfo: GcpApplicationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20277,9 +17791,16 @@ export const plans = {
   },
   SingleTableItemConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemConnection_nodesPlan,
-    edges: SingleTableItemConnection_edgesPlan,
-    pageInfo: SingleTableItemConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20904,18 +18425,32 @@ export const plans = {
   },
   RelationalItemConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemConnection_nodesPlan,
-    edges: RelationalItemConnection_edgesPlan,
-    pageInfo: RelationalItemConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
   },
   RelationalItemRelationConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationConnection_nodesPlan,
-    edges: RelationalItemRelationConnection_edgesPlan,
-    pageInfo: RelationalItemRelationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -20953,9 +18488,16 @@ export const plans = {
   },
   RelationalItemRelationCompositePkConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalItemRelationCompositePkConnection_nodesPlan,
-    edges: RelationalItemRelationCompositePkConnection_edgesPlan,
-    pageInfo: RelationalItemRelationCompositePkConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -21608,9 +19150,16 @@ export const plans = {
   },
   SingleTableItemRelationConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationConnection_nodesPlan,
-    edges: SingleTableItemRelationConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -21648,9 +19197,16 @@ export const plans = {
   },
   SingleTableItemRelationCompositePkConnection: {
     __assertStep: ConnectionStep,
-    nodes: SingleTableItemRelationCompositePkConnection_nodesPlan,
-    edges: SingleTableItemRelationCompositePkConnection_edgesPlan,
-    pageInfo: SingleTableItemRelationCompositePkConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -22115,23 +19671,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22161,23 +19727,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22207,23 +19783,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22253,23 +19839,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22299,23 +19895,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTablePost_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22359,23 +19965,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Priority_singleTableItemsByPriorityId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22454,23 +20070,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22500,23 +20126,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22546,23 +20182,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22592,23 +20238,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22638,23 +20294,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22735,23 +20401,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22781,23 +20457,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22827,23 +20513,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22873,23 +20569,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -22919,23 +20625,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklist_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23032,23 +20748,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23078,23 +20804,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23124,23 +20860,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23170,23 +20916,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23216,23 +20972,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23303,23 +21069,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByRootTopicId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23399,23 +21175,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23523,23 +21309,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23577,23 +21373,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23631,23 +21437,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -23685,23 +21501,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalTopic_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24186,23 +22012,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24310,23 +22146,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24364,23 +22210,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24418,23 +22274,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24472,23 +22338,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalPost_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24607,23 +22483,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24731,23 +22617,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24785,23 +22681,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24839,23 +22745,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -24893,23 +22809,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalDivider_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25025,23 +22951,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25149,23 +23085,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25203,23 +23149,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25257,23 +23213,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25311,23 +23277,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklist_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25446,23 +23422,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25570,23 +23556,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25624,23 +23620,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationsByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25678,23 +23684,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByChildId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25732,23 +23748,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: RelationalChecklistItem_relationalItemRelationCompositePksByParentId_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -25773,7 +23799,9 @@ export const plans = {
     __assertStep() {
       return true;
     },
-    query: Query_queryPlan,
+    query() {
+      return rootValue();
+    },
     awsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityId: {
       plan(_$root, args) {
         return otherSource_aws_application_first_party_vulnerabilitiesPgResource.get({
@@ -26041,27 +24069,40 @@ export const plans = {
       }
     },
     allSingleTables: {
-      plan: Query_allSingleTablesPlan,
+      plan($parent, args, info) {
+        const $select = getSelectPlanFromParentAndArgs($parent, args, info);
+        return connection($select, $item => $item, $item => $item.getParentStep ? $item.getParentStep().cursor() : $item.cursor());
+      },
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTables_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         }
       }
     },
@@ -26087,23 +24128,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26143,23 +24194,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26199,23 +24260,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allZeroImplementations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26242,23 +24313,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationFirstPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationFirstPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationFirstPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationFirstPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationFirstPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26285,23 +24366,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationThirdPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationThirdPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationThirdPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationThirdPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplicationThirdPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26328,23 +24419,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationFirstPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationFirstPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationFirstPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationFirstPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationFirstPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26371,23 +24472,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationThirdPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationThirdPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationThirdPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationThirdPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplicationThirdPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26414,23 +24525,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allOrganizations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26457,23 +24578,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPeople_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26500,23 +24631,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allPriorities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26543,23 +24684,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklists_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26586,23 +24737,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26629,23 +24790,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalTopics_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26672,23 +24843,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelationCompositePks_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26715,23 +24896,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalChecklistItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26758,23 +24949,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalDividers_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26801,23 +25002,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26844,23 +25055,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItemRelations_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26887,23 +25108,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allLogEntries_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26930,23 +25161,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalPosts_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -26973,23 +25214,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allFirstPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27016,23 +25267,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allThirdPartyVulnerabilities_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27059,23 +25320,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allAwsApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27102,23 +25373,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allGcpApplications_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27145,23 +25426,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allSingleTableItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27188,23 +25479,33 @@ export const plans = {
       args: {
         first: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_first_applyPlan
+          applyPlan(_, $connection, arg) {
+            $connection.setFirst(arg.getRaw());
+          }
         },
         last: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_last_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          }
         },
         offset: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_offset_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setOffset(val.getRaw());
+          }
         },
         before: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_before_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          }
         },
         after: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Query_allRelationalItems_after_applyPlan
+          applyPlan(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          }
         },
         orderBy: {
           autoApplyAfterParentPlan: true,
@@ -27227,9 +25528,16 @@ export const plans = {
   },
   ZeroImplementationConnection: {
     __assertStep: ConnectionStep,
-    nodes: ZeroImplementationConnection_nodesPlan,
-    edges: ZeroImplementationConnection_edgesPlan,
-    pageInfo: ZeroImplementationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27366,9 +25674,16 @@ export const plans = {
   },
   OrganizationConnection: {
     __assertStep: ConnectionStep,
-    nodes: OrganizationConnection_nodesPlan,
-    edges: OrganizationConnection_edgesPlan,
-    pageInfo: OrganizationConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27537,9 +25852,16 @@ export const plans = {
   },
   PersonConnection: {
     __assertStep: ConnectionStep,
-    nodes: PersonConnection_nodesPlan,
-    edges: PersonConnection_edgesPlan,
-    pageInfo: PersonConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27708,9 +26030,16 @@ export const plans = {
   },
   PriorityConnection: {
     __assertStep: ConnectionStep,
-    nodes: PriorityConnection_nodesPlan,
-    edges: PriorityConnection_edgesPlan,
-    pageInfo: PriorityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -27879,9 +26208,16 @@ export const plans = {
   },
   RelationalChecklistConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistConnection_nodesPlan,
-    edges: RelationalChecklistConnection_edgesPlan,
-    pageInfo: RelationalChecklistConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -28563,9 +26899,16 @@ export const plans = {
   },
   RelationalTopicConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalTopicConnection_nodesPlan,
-    edges: RelationalTopicConnection_edgesPlan,
-    pageInfo: RelationalTopicConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -29247,9 +27590,16 @@ export const plans = {
   },
   RelationalChecklistItemConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalChecklistItemConnection_nodesPlan,
-    edges: RelationalChecklistItemConnection_edgesPlan,
-    pageInfo: RelationalChecklistItemConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -29988,9 +28338,16 @@ export const plans = {
   },
   RelationalDividerConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalDividerConnection_nodesPlan,
-    edges: RelationalDividerConnection_edgesPlan,
-    pageInfo: RelationalDividerConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -30729,9 +29086,16 @@ export const plans = {
   },
   RelationalPostConnection: {
     __assertStep: ConnectionStep,
-    nodes: RelationalPostConnection_nodesPlan,
-    edges: RelationalPostConnection_edgesPlan,
-    pageInfo: RelationalPostConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -31527,9 +29891,16 @@ export const plans = {
   },
   FirstPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: FirstPartyVulnerabilityConnection_nodesPlan,
-    edges: FirstPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: FirstPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -31812,9 +30183,16 @@ export const plans = {
   },
   ThirdPartyVulnerabilityConnection: {
     __assertStep: ConnectionStep,
-    nodes: ThirdPartyVulnerabilityConnection_nodesPlan,
-    edges: ThirdPartyVulnerabilityConnection_edgesPlan,
-    pageInfo: ThirdPartyVulnerabilityConnection_pageInfoPlan,
+    nodes($connection) {
+      return $connection.nodes();
+    },
+    edges($connection) {
+      return $connection.edges();
+    },
+    pageInfo($connection) {
+      // TYPES: why is this a TypeScript issue without the 'any'?
+      return $connection.pageInfo();
+    },
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint);
     }
@@ -32108,7 +30486,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAwsApplicationFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32123,7 +30503,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAwsApplicationThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32138,7 +30520,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGcpApplicationFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32153,7 +30537,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGcpApplicationThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32168,7 +30554,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createOrganization_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32183,7 +30571,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPerson_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32198,7 +30588,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createPriority_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32213,7 +30605,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32228,7 +30622,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelationCompositePk_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32243,7 +30639,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createRelationalItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32258,7 +30656,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createSingleTableItemRelation_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32273,7 +30673,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createLogEntry_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32288,7 +30690,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createFirstPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32303,7 +30707,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createThirdPartyVulnerability_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32318,7 +30724,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createAwsApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32333,7 +30741,9 @@ export const plans = {
       args: {
         input: {
           autoApplyAfterParentPlan: true,
-          applyPlan: Mutation_createGcpApplication_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32350,7 +30760,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32367,7 +30779,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32384,7 +30798,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32401,7 +30817,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32417,7 +30835,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32433,7 +30853,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32449,7 +30871,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32465,7 +30889,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32481,7 +30907,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updatePriorityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32498,7 +30926,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32515,7 +30945,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32531,7 +30963,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32548,7 +30982,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32564,7 +31000,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32581,7 +31019,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32597,7 +31037,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateLogEntryByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32613,7 +31055,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateFirstPartyVulnerabilityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32629,7 +31073,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateThirdPartyVulnerabilityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32645,7 +31091,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateAwsApplicationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32661,7 +31109,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_updateGcpApplicationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32678,7 +31128,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32695,7 +31147,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32712,7 +31166,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32729,7 +31185,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32745,7 +31203,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByOrganizationId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32761,7 +31221,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteOrganizationByName_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32777,7 +31239,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByPersonId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32793,7 +31257,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePersonByUsername_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32809,7 +31275,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deletePriorityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32826,7 +31294,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32843,7 +31313,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationCompositePkByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32859,7 +31331,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32876,7 +31350,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteRelationalItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32892,7 +31368,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32909,7 +31387,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteSingleTableItemRelationByParentIdAndChildId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32925,7 +31405,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteLogEntryByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32941,7 +31423,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteFirstPartyVulnerabilityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32957,7 +31441,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteThirdPartyVulnerabilityByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32973,7 +31459,9 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteAwsApplicationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     },
@@ -32989,16 +31477,24 @@ export const plans = {
       },
       args: {
         input: {
-          applyPlan: Mutation_deleteGcpApplicationByRowId_input_applyPlan
+          applyPlan(_, $object) {
+            return $object;
+          }
         }
       }
     }
   },
   CreateAwsApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationFirstPartyVulnerability: CreateAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan,
-    query: CreateAwsApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33033,11 +31529,16 @@ export const plans = {
   },
   CreateAwsApplicationFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateAwsApplicationFirstPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     awsApplicationFirstPartyVulnerability: {
-      applyPlan: CreateAwsApplicationFirstPartyVulnerabilityInput_awsApplicationFirstPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33059,9 +31560,15 @@ export const plans = {
   },
   CreateAwsApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationThirdPartyVulnerability: CreateAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan,
-    query: CreateAwsApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33096,11 +31603,16 @@ export const plans = {
   },
   CreateAwsApplicationThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateAwsApplicationThirdPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     awsApplicationThirdPartyVulnerability: {
-      applyPlan: CreateAwsApplicationThirdPartyVulnerabilityInput_awsApplicationThirdPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33122,9 +31634,15 @@ export const plans = {
   },
   CreateGcpApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationFirstPartyVulnerability: CreateGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan,
-    query: CreateGcpApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33159,11 +31677,16 @@ export const plans = {
   },
   CreateGcpApplicationFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateGcpApplicationFirstPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     gcpApplicationFirstPartyVulnerability: {
-      applyPlan: CreateGcpApplicationFirstPartyVulnerabilityInput_gcpApplicationFirstPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33185,9 +31708,15 @@ export const plans = {
   },
   CreateGcpApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationThirdPartyVulnerability: CreateGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan,
-    query: CreateGcpApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33222,11 +31751,16 @@ export const plans = {
   },
   CreateGcpApplicationThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateGcpApplicationThirdPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     gcpApplicationThirdPartyVulnerability: {
-      applyPlan: CreateGcpApplicationThirdPartyVulnerabilityInput_gcpApplicationThirdPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33248,9 +31782,15 @@ export const plans = {
   },
   CreateOrganizationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateOrganizationPayload_clientMutationIdPlan,
-    organization: CreateOrganizationPayload_organizationPlan,
-    query: CreateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33285,11 +31825,16 @@ export const plans = {
   },
   CreateOrganizationInput: {
     clientMutationId: {
-      applyPlan: CreateOrganizationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     organization: {
-      applyPlan: CreateOrganizationInput_organization_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33311,9 +31856,15 @@ export const plans = {
   },
   CreatePersonPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePersonPayload_clientMutationIdPlan,
-    person: CreatePersonPayload_personPlan,
-    query: CreatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33348,11 +31899,16 @@ export const plans = {
   },
   CreatePersonInput: {
     clientMutationId: {
-      applyPlan: CreatePersonInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     person: {
-      applyPlan: CreatePersonInput_person_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33374,9 +31930,15 @@ export const plans = {
   },
   CreatePriorityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreatePriorityPayload_clientMutationIdPlan,
-    priority: CreatePriorityPayload_priorityPlan,
-    query: CreatePriorityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    priority($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     priorityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33411,11 +31973,16 @@ export const plans = {
   },
   CreatePriorityInput: {
     clientMutationId: {
-      applyPlan: CreatePriorityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     priority: {
-      applyPlan: CreatePriorityInput_priority_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33437,9 +32004,15 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: CreateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: CreateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33474,11 +32047,16 @@ export const plans = {
   },
   CreateRelationalItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelationCompositePk: {
-      applyPlan: CreateRelationalItemRelationCompositePkInput_relationalItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33500,9 +32078,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: CreateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: CreateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33537,11 +32121,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationCompositePkInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelationCompositePk: {
-      applyPlan: CreateSingleTableItemRelationCompositePkInput_singleTableItemRelationCompositePk_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33563,9 +32152,15 @@ export const plans = {
   },
   CreateRelationalItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: CreateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: CreateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33600,11 +32195,16 @@ export const plans = {
   },
   CreateRelationalItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateRelationalItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     relationalItemRelation: {
-      applyPlan: CreateRelationalItemRelationInput_relationalItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33633,9 +32233,15 @@ export const plans = {
   },
   CreateSingleTableItemRelationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: CreateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: CreateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33670,11 +32276,16 @@ export const plans = {
   },
   CreateSingleTableItemRelationInput: {
     clientMutationId: {
-      applyPlan: CreateSingleTableItemRelationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     singleTableItemRelation: {
-      applyPlan: CreateSingleTableItemRelationInput_singleTableItemRelation_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33703,9 +32314,15 @@ export const plans = {
   },
   CreateLogEntryPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateLogEntryPayload_clientMutationIdPlan,
-    logEntry: CreateLogEntryPayload_logEntryPlan,
-    query: CreateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33740,11 +32357,16 @@ export const plans = {
   },
   CreateLogEntryInput: {
     clientMutationId: {
-      applyPlan: CreateLogEntryInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     logEntry: {
-      applyPlan: CreateLogEntryInput_logEntry_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33780,9 +32402,15 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: CreateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: CreateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33817,11 +32445,16 @@ export const plans = {
   },
   CreateFirstPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     firstPartyVulnerability: {
-      applyPlan: CreateFirstPartyVulnerabilityInput_firstPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33857,9 +32490,15 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: CreateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: CreateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33894,11 +32533,16 @@ export const plans = {
   },
   CreateThirdPartyVulnerabilityInput: {
     clientMutationId: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     thirdPartyVulnerability: {
-      applyPlan: CreateThirdPartyVulnerabilityInput_thirdPartyVulnerability_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -33934,9 +32578,15 @@ export const plans = {
   },
   CreateAwsApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: CreateAwsApplicationPayload_awsApplicationPlan,
-    query: CreateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -33971,11 +32621,16 @@ export const plans = {
   },
   CreateAwsApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateAwsApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     awsApplication: {
-      applyPlan: CreateAwsApplicationInput_awsApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -34025,9 +32680,15 @@ export const plans = {
   },
   CreateGcpApplicationPayload: {
     __assertStep: assertExecutableStep,
-    clientMutationId: CreateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: CreateGcpApplicationPayload_gcpApplicationPlan,
-    query: CreateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34062,11 +32723,16 @@ export const plans = {
   },
   CreateGcpApplicationInput: {
     clientMutationId: {
-      applyPlan: CreateGcpApplicationInput_clientMutationId_applyPlan,
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      },
       autoApplyAfterParentApplyPlan: true
     },
     gcpApplication: {
-      applyPlan: CreateGcpApplicationInput_gcpApplication_applyPlan,
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      },
       autoApplyAfterParentApplyPlan: true
     }
   },
@@ -34116,9 +32782,15 @@ export const plans = {
   },
   UpdateAwsApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationFirstPartyVulnerability: UpdateAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan,
-    query: UpdateAwsApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34153,12 +32825,17 @@ export const plans = {
   },
   UpdateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     awsApplicationId: undefined,
     firstPartyVulnerabilityId: undefined,
     awsApplicationFirstPartyVulnerabilityPatch: {
-      applyPlan: UpdateAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_awsApplicationFirstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AwsApplicationFirstPartyVulnerabilityPatch: {
@@ -34179,9 +32856,15 @@ export const plans = {
   },
   UpdateAwsApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationThirdPartyVulnerability: UpdateAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan,
-    query: UpdateAwsApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34216,12 +32899,17 @@ export const plans = {
   },
   UpdateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     awsApplicationId: undefined,
     thirdPartyVulnerabilityId: undefined,
     awsApplicationThirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_awsApplicationThirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AwsApplicationThirdPartyVulnerabilityPatch: {
@@ -34242,9 +32930,15 @@ export const plans = {
   },
   UpdateGcpApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationFirstPartyVulnerability: UpdateGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan,
-    query: UpdateGcpApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34279,12 +32973,17 @@ export const plans = {
   },
   UpdateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     gcpApplicationId: undefined,
     firstPartyVulnerabilityId: undefined,
     gcpApplicationFirstPartyVulnerabilityPatch: {
-      applyPlan: UpdateGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_gcpApplicationFirstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GcpApplicationFirstPartyVulnerabilityPatch: {
@@ -34305,9 +33004,15 @@ export const plans = {
   },
   UpdateGcpApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationThirdPartyVulnerability: UpdateGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan,
-    query: UpdateGcpApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34342,12 +33047,17 @@ export const plans = {
   },
   UpdateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     gcpApplicationId: undefined,
     thirdPartyVulnerabilityId: undefined,
     gcpApplicationThirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_gcpApplicationThirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GcpApplicationThirdPartyVulnerabilityPatch: {
@@ -34368,9 +33078,15 @@ export const plans = {
   },
   UpdateOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateOrganizationPayload_clientMutationIdPlan,
-    organization: UpdateOrganizationPayload_organizationPlan,
-    query: UpdateOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34405,11 +33121,16 @@ export const plans = {
   },
   UpdateOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByOrganizationIdInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   OrganizationPatch: {
@@ -34430,18 +33151,29 @@ export const plans = {
   },
   UpdateOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: UpdateOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined,
     organizationPatch: {
-      applyPlan: UpdateOrganizationByNameInput_organizationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePersonPayload_clientMutationIdPlan,
-    person: UpdatePersonPayload_personPlan,
-    query: UpdatePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34476,11 +33208,16 @@ export const plans = {
   },
   UpdatePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByPersonIdInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PersonPatch: {
@@ -34501,18 +33238,29 @@ export const plans = {
   },
   UpdatePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: UpdatePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined,
     personPatch: {
-      applyPlan: UpdatePersonByUsernameInput_personPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdatePriorityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdatePriorityPayload_clientMutationIdPlan,
-    priority: UpdatePriorityPayload_priorityPlan,
-    query: UpdatePriorityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    priority($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     priorityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34547,11 +33295,16 @@ export const plans = {
   },
   UpdatePriorityByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdatePriorityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     priorityPatch: {
-      applyPlan: UpdatePriorityByRowIdInput_priorityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   PriorityPatch: {
@@ -34572,9 +33325,15 @@ export const plans = {
   },
   UpdateRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: UpdateRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: UpdateRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34609,12 +33368,17 @@ export const plans = {
   },
   UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationCompositePkPatch: {
-      applyPlan: UpdateRelationalItemRelationCompositePkByParentIdAndChildIdInput_relationalItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationCompositePkPatch: {
@@ -34635,9 +33399,15 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: UpdateSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: UpdateSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34672,12 +33442,17 @@ export const plans = {
   },
   UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationCompositePkPatch: {
-      applyPlan: UpdateSingleTableItemRelationCompositePkByParentIdAndChildIdInput_singleTableItemRelationCompositePkPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationCompositePkPatch: {
@@ -34698,9 +33473,15 @@ export const plans = {
   },
   UpdateRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: UpdateRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: UpdateRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34735,11 +33516,16 @@ export const plans = {
   },
   UpdateRelationalItemRelationByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByRowIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   RelationalItemRelationPatch: {
@@ -34767,19 +33553,30 @@ export const plans = {
   },
   UpdateRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     relationalItemRelationPatch: {
-      applyPlan: UpdateRelationalItemRelationByParentIdAndChildIdInput_relationalItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: UpdateSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: UpdateSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34814,11 +33611,16 @@ export const plans = {
   },
   UpdateSingleTableItemRelationByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByRowIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   SingleTableItemRelationPatch: {
@@ -34846,19 +33648,30 @@ export const plans = {
   },
   UpdateSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined,
     singleTableItemRelationPatch: {
-      applyPlan: UpdateSingleTableItemRelationByParentIdAndChildIdInput_singleTableItemRelationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   UpdateLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateLogEntryPayload_clientMutationIdPlan,
-    logEntry: UpdateLogEntryPayload_logEntryPlan,
-    query: UpdateLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34893,11 +33706,16 @@ export const plans = {
   },
   UpdateLogEntryByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateLogEntryByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     logEntryPatch: {
-      applyPlan: UpdateLogEntryByRowIdInput_logEntryPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   LogEntryPatch: {
@@ -34932,9 +33750,15 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: UpdateFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: UpdateFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -34969,11 +33793,16 @@ export const plans = {
   },
   UpdateFirstPartyVulnerabilityByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateFirstPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     firstPartyVulnerabilityPatch: {
-      applyPlan: UpdateFirstPartyVulnerabilityByRowIdInput_firstPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   FirstPartyVulnerabilityPatch: {
@@ -35008,9 +33837,15 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: UpdateThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: UpdateThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35045,11 +33880,16 @@ export const plans = {
   },
   UpdateThirdPartyVulnerabilityByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateThirdPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     thirdPartyVulnerabilityPatch: {
-      applyPlan: UpdateThirdPartyVulnerabilityByRowIdInput_thirdPartyVulnerabilityPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   ThirdPartyVulnerabilityPatch: {
@@ -35084,9 +33924,15 @@ export const plans = {
   },
   UpdateAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: UpdateAwsApplicationPayload_awsApplicationPlan,
-    query: UpdateAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35121,11 +33967,16 @@ export const plans = {
   },
   UpdateAwsApplicationByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateAwsApplicationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     awsApplicationPatch: {
-      applyPlan: UpdateAwsApplicationByRowIdInput_awsApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   AwsApplicationPatch: {
@@ -35174,9 +34025,15 @@ export const plans = {
   },
   UpdateGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: UpdateGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: UpdateGcpApplicationPayload_gcpApplicationPlan,
-    query: UpdateGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35211,11 +34068,16 @@ export const plans = {
   },
   UpdateGcpApplicationByRowIdInput: {
     clientMutationId: {
-      applyPlan: UpdateGcpApplicationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined,
     gcpApplicationPatch: {
-      applyPlan: UpdateGcpApplicationByRowIdInput_gcpApplicationPatch_applyPlan
+      applyPlan($object) {
+        const $record = $object.getStepForKey("result");
+        return $record.setPlan();
+      }
     }
   },
   GcpApplicationPatch: {
@@ -35264,9 +34126,15 @@ export const plans = {
   },
   DeleteAwsApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAwsApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationFirstPartyVulnerability: DeleteAwsApplicationFirstPartyVulnerabilityPayload_awsApplicationFirstPartyVulnerabilityPlan,
-    query: DeleteAwsApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35301,16 +34169,24 @@ export const plans = {
   },
   DeleteAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationFirstPartyVulnerabilityByAwsApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     awsApplicationId: undefined,
     firstPartyVulnerabilityId: undefined
   },
   DeleteAwsApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAwsApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    awsApplicationThirdPartyVulnerability: DeleteAwsApplicationThirdPartyVulnerabilityPayload_awsApplicationThirdPartyVulnerabilityPlan,
-    query: DeleteAwsApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35345,16 +34221,24 @@ export const plans = {
   },
   DeleteAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationThirdPartyVulnerabilityByAwsApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     awsApplicationId: undefined,
     thirdPartyVulnerabilityId: undefined
   },
   DeleteGcpApplicationFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGcpApplicationFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationFirstPartyVulnerability: DeleteGcpApplicationFirstPartyVulnerabilityPayload_gcpApplicationFirstPartyVulnerabilityPlan,
-    query: DeleteGcpApplicationFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationFirstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationFirstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35389,16 +34273,24 @@ export const plans = {
   },
   DeleteGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationFirstPartyVulnerabilityByGcpApplicationIdAndFirstPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     gcpApplicationId: undefined,
     firstPartyVulnerabilityId: undefined
   },
   DeleteGcpApplicationThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGcpApplicationThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    gcpApplicationThirdPartyVulnerability: DeleteGcpApplicationThirdPartyVulnerabilityPayload_gcpApplicationThirdPartyVulnerabilityPlan,
-    query: DeleteGcpApplicationThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplicationThirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationThirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35433,16 +34325,24 @@ export const plans = {
   },
   DeleteGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationThirdPartyVulnerabilityByGcpApplicationIdAndThirdPartyVulnerabilityIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     gcpApplicationId: undefined,
     thirdPartyVulnerabilityId: undefined
   },
   DeleteOrganizationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteOrganizationPayload_clientMutationIdPlan,
-    organization: DeleteOrganizationPayload_organizationPlan,
-    query: DeleteOrganizationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    organization($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     organizationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35477,21 +34377,31 @@ export const plans = {
   },
   DeleteOrganizationByOrganizationIdInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByOrganizationIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     organizationId: undefined
   },
   DeleteOrganizationByNameInput: {
     clientMutationId: {
-      applyPlan: DeleteOrganizationByNameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     name: undefined
   },
   DeletePersonPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePersonPayload_clientMutationIdPlan,
-    person: DeletePersonPayload_personPlan,
-    query: DeletePersonPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    person($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     personEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35526,21 +34436,31 @@ export const plans = {
   },
   DeletePersonByPersonIdInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByPersonIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     personId: undefined
   },
   DeletePersonByUsernameInput: {
     clientMutationId: {
-      applyPlan: DeletePersonByUsernameInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     username: undefined
   },
   DeletePriorityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeletePriorityPayload_clientMutationIdPlan,
-    priority: DeletePriorityPayload_priorityPlan,
-    query: DeletePriorityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    priority($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     priorityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35575,15 +34495,23 @@ export const plans = {
   },
   DeletePriorityByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeletePriorityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteRelationalItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationCompositePkPayload_clientMutationIdPlan,
-    relationalItemRelationCompositePk: DeleteRelationalItemRelationCompositePkPayload_relationalItemRelationCompositePkPlan,
-    query: DeleteRelationalItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35618,16 +34546,24 @@ export const plans = {
   },
   DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationCompositePkPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationCompositePkPayload_clientMutationIdPlan,
-    singleTableItemRelationCompositePk: DeleteSingleTableItemRelationCompositePkPayload_singleTableItemRelationCompositePkPlan,
-    query: DeleteSingleTableItemRelationCompositePkPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelationCompositePk($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationCompositePkEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35662,16 +34598,24 @@ export const plans = {
   },
   DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationCompositePkByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteRelationalItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteRelationalItemRelationPayload_clientMutationIdPlan,
-    relationalItemRelation: DeleteRelationalItemRelationPayload_relationalItemRelationPlan,
-    query: DeleteRelationalItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    relationalItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     relationalItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35706,22 +34650,32 @@ export const plans = {
   },
   DeleteRelationalItemRelationByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteRelationalItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteRelationalItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteSingleTableItemRelationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteSingleTableItemRelationPayload_clientMutationIdPlan,
-    singleTableItemRelation: DeleteSingleTableItemRelationPayload_singleTableItemRelationPlan,
-    query: DeleteSingleTableItemRelationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    singleTableItemRelation($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     singleTableItemRelationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35756,22 +34710,32 @@ export const plans = {
   },
   DeleteSingleTableItemRelationByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteSingleTableItemRelationByParentIdAndChildIdInput: {
     clientMutationId: {
-      applyPlan: DeleteSingleTableItemRelationByParentIdAndChildIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     parentId: undefined,
     childId: undefined
   },
   DeleteLogEntryPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteLogEntryPayload_clientMutationIdPlan,
-    logEntry: DeleteLogEntryPayload_logEntryPlan,
-    query: DeleteLogEntryPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    logEntry($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     logEntryEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35806,15 +34770,23 @@ export const plans = {
   },
   DeleteLogEntryByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteLogEntryByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteFirstPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteFirstPartyVulnerabilityPayload_clientMutationIdPlan,
-    firstPartyVulnerability: DeleteFirstPartyVulnerabilityPayload_firstPartyVulnerabilityPlan,
-    query: DeleteFirstPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    firstPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     firstPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35849,15 +34821,23 @@ export const plans = {
   },
   DeleteFirstPartyVulnerabilityByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteFirstPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteThirdPartyVulnerabilityPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteThirdPartyVulnerabilityPayload_clientMutationIdPlan,
-    thirdPartyVulnerability: DeleteThirdPartyVulnerabilityPayload_thirdPartyVulnerabilityPlan,
-    query: DeleteThirdPartyVulnerabilityPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    thirdPartyVulnerability($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     thirdPartyVulnerabilityEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35892,15 +34872,23 @@ export const plans = {
   },
   DeleteThirdPartyVulnerabilityByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteThirdPartyVulnerabilityByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteAwsApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteAwsApplicationPayload_clientMutationIdPlan,
-    awsApplication: DeleteAwsApplicationPayload_awsApplicationPlan,
-    query: DeleteAwsApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    awsApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     awsApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35935,15 +34923,23 @@ export const plans = {
   },
   DeleteAwsApplicationByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteAwsApplicationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   },
   DeleteGcpApplicationPayload: {
     __assertStep: ObjectStep,
-    clientMutationId: DeleteGcpApplicationPayload_clientMutationIdPlan,
-    gcpApplication: DeleteGcpApplicationPayload_gcpApplicationPlan,
-    query: DeleteGcpApplicationPayload_queryPlan,
+    clientMutationId($mutation) {
+      return $mutation.getStepForKey("clientMutationId", true) ?? constant(null);
+    },
+    gcpApplication($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    },
     gcpApplicationEdge: {
       plan($mutation, args, info) {
         const $result = $mutation.getStepForKey("result", true);
@@ -35978,7 +34974,9 @@ export const plans = {
   },
   DeleteGcpApplicationByRowIdInput: {
     clientMutationId: {
-      applyPlan: DeleteGcpApplicationByRowIdInput_clientMutationId_applyPlan
+      applyPlan($input, val) {
+        $input.set("clientMutationId", val.get());
+      }
     },
     rowId: undefined
   }

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -22,7 +22,7 @@ const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.c
     }
   }
 });
-const executor_mainPgExecutor = new PgExecutor({
+const executor = new PgExecutor({
   name: "main",
   context() {
     const ctx = context();
@@ -48,7 +48,7 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   aws_application_id: {
@@ -86,7 +86,7 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
@@ -124,7 +124,7 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   gcp_application_id: {
@@ -162,7 +162,7 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const organizationsAttributes = Object.assign(Object.create(null), {
   organization_id: {
@@ -200,7 +200,7 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const peopleAttributes = Object.assign(Object.create(null), {
   person_id: {
@@ -254,7 +254,7 @@ const peopleCodec = recordCodec({
   attributes: peopleAttributes,
   description: undefined,
   extensions: extensions6,
-  executor: executor_mainPgExecutor
+  executor
 });
 const prioritiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -292,7 +292,7 @@ const prioritiesCodec = recordCodec({
       omit: "create,update,delete,filter,order"
     })
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const itemTypeCodec = enumCodec({
   name: "itemType",
@@ -453,7 +453,7 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -489,7 +489,7 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalTopicsAttributes = Object.assign(Object.create(null), {
   topic_item_id: {
@@ -636,7 +636,7 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
   parent_id: {
@@ -672,7 +672,7 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
   checklist_item_item_id: {
@@ -828,7 +828,7 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalDividersAttributes = Object.assign(Object.create(null), {
   divider_item_id: {
@@ -984,7 +984,7 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1029,7 +1029,7 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1074,7 +1074,7 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const logEntriesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1145,7 +1145,7 @@ const logEntriesCodec = recordCodec({
   attributes: logEntriesAttributes,
   description: undefined,
   extensions: extensions17,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalPostsAttributes = Object.assign(Object.create(null), {
   post_item_id: {
@@ -1310,7 +1310,7 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor: executor_mainPgExecutor
+  executor
 });
 const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1393,7 +1393,7 @@ const firstPartyVulnerabilitiesCodec = recordCodec({
   attributes: firstPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions19,
-  executor: executor_mainPgExecutor
+  executor
 });
 const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1476,7 +1476,7 @@ const thirdPartyVulnerabilitiesCodec = recordCodec({
   attributes: thirdPartyVulnerabilitiesAttributes,
   description: undefined,
   extensions: extensions20,
-  executor: executor_mainPgExecutor
+  executor
 });
 const awsApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1577,7 +1577,7 @@ const awsApplicationsCodec = recordCodec({
   attributes: awsApplicationsAttributes,
   description: undefined,
   extensions: extensions21,
-  executor: executor_mainPgExecutor
+  executor
 });
 const gcpApplicationsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1678,7 +1678,7 @@ const gcpApplicationsCodec = recordCodec({
   attributes: gcpApplicationsAttributes,
   description: undefined,
   extensions: extensions22,
-  executor: executor_mainPgExecutor
+  executor
 });
 const singleTableItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1860,7 +1860,7 @@ const singleTableItemsCodec = recordCodec({
   attributes: singleTableItemsAttributes,
   description: undefined,
   extensions: extensions23,
-  executor: executor_mainPgExecutor
+  executor
 });
 const relationalItemsAttributes = Object.assign(Object.create(null), {
   id: {
@@ -1972,7 +1972,7 @@ const relationalItemsCodec = recordCodec({
   attributes: relationalItemsAttributes,
   description: undefined,
   extensions: extensions24,
-  executor: executor_mainPgExecutor
+  executor
 });
 const ApplicationAttributes = Object.assign(Object.create(null), {
   id: {
@@ -2062,7 +2062,7 @@ const ZeroImplementationAttributes = Object.assign(Object.create(null), {
     }
   }
 });
-const uniques = [{
+const aws_application_first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["aws_application_id", "first_party_vulnerability_id"],
   description: undefined,
@@ -2071,12 +2071,12 @@ const uniques = [{
   }
 }];
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
   from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
   codec: awsApplicationFirstPartyVulnerabilitiesCodec,
-  uniques,
+  uniques: aws_application_first_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2091,7 +2091,7 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
     }
   }
 };
-const uniques2 = [{
+const aws_application_third_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["aws_application_id", "third_party_vulnerability_id"],
   description: undefined,
@@ -2100,12 +2100,12 @@ const uniques2 = [{
   }
 }];
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
   from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques2,
+  uniques: aws_application_third_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2120,7 +2120,7 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
     }
   }
 };
-const uniques3 = [{
+const gcp_application_first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["gcp_application_id", "first_party_vulnerability_id"],
   description: undefined,
@@ -2129,12 +2129,12 @@ const uniques3 = [{
   }
 }];
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
   from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
-  uniques: uniques3,
+  uniques: gcp_application_first_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2149,7 +2149,7 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
     }
   }
 };
-const uniques4 = [{
+const gcp_application_third_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["gcp_application_id", "third_party_vulnerability_id"],
   description: undefined,
@@ -2158,12 +2158,12 @@ const uniques4 = [{
   }
 }];
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
   from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
-  uniques: uniques4,
+  uniques: gcp_application_third_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2178,7 +2178,7 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
     }
   }
 };
-const uniques5 = [{
+const organizationsUniques = [{
   isPrimary: true,
   attributes: ["organization_id"],
   description: undefined,
@@ -2194,12 +2194,12 @@ const uniques5 = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
   from: organizationsCodec.sqlType,
   codec: organizationsCodec,
-  uniques: uniques5,
+  uniques: organizationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2214,7 +2214,7 @@ const registryConfig_pgResources_organizations_organizations = {
     }
   }
 };
-const uniques6 = [{
+const peopleUniques = [{
   isPrimary: true,
   attributes: ["person_id"],
   description: undefined,
@@ -2230,12 +2230,12 @@ const uniques6 = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "people",
   identifier: "main.polymorphic.people",
   from: peopleCodec.sqlType,
   codec: peopleCodec,
-  uniques: uniques6,
+  uniques: peopleUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2252,7 +2252,7 @@ const registryConfig_pgResources_people_people = {
     }
   }
 };
-const uniques7 = [{
+const prioritiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2261,12 +2261,12 @@ const uniques7 = [{
   }
 }];
 const registryConfig_pgResources_priorities_priorities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
   from: prioritiesCodec.sqlType,
   codec: prioritiesCodec,
-  uniques: uniques7,
+  uniques: prioritiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2281,7 +2281,7 @@ const registryConfig_pgResources_priorities_priorities = {
     }
   }
 };
-const uniques8 = [{
+const relational_checklistsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_id"],
   description: undefined,
@@ -2290,12 +2290,12 @@ const uniques8 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
   from: relationalChecklistsCodec.sqlType,
   codec: relationalChecklistsCodec,
-  uniques: uniques8,
+  uniques: relational_checklistsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2308,7 +2308,7 @@ const registryConfig_pgResources_relational_checklists_relational_checklists = {
     tags: {}
   }
 };
-const uniques9 = [{
+const relational_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2317,12 +2317,12 @@ const uniques9 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
   from: relationalItemRelationCompositePksCodec.sqlType,
   codec: relationalItemRelationCompositePksCodec,
-  uniques: uniques9,
+  uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2335,7 +2335,7 @@ const registryConfig_pgResources_relational_item_relation_composite_pks_relation
     tags: {}
   }
 };
-const uniques10 = [{
+const relational_topicsUniques = [{
   isPrimary: true,
   attributes: ["topic_item_id"],
   description: undefined,
@@ -2344,12 +2344,12 @@ const uniques10 = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
   from: relationalTopicsCodec.sqlType,
   codec: relationalTopicsCodec,
-  uniques: uniques10,
+  uniques: relational_topicsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2362,7 +2362,7 @@ const registryConfig_pgResources_relational_topics_relational_topics = {
     tags: {}
   }
 };
-const uniques11 = [{
+const single_table_item_relation_composite_pksUniques = [{
   isPrimary: true,
   attributes: ["parent_id", "child_id"],
   description: undefined,
@@ -2371,12 +2371,12 @@ const uniques11 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
   from: singleTableItemRelationCompositePksCodec.sqlType,
   codec: singleTableItemRelationCompositePksCodec,
-  uniques: uniques11,
+  uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2389,7 +2389,7 @@ const registryConfig_pgResources_single_table_item_relation_composite_pks_single
     tags: {}
   }
 };
-const uniques12 = [{
+const relational_checklist_itemsUniques = [{
   isPrimary: true,
   attributes: ["checklist_item_item_id"],
   description: undefined,
@@ -2398,12 +2398,12 @@ const uniques12 = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
   from: relationalChecklistItemsCodec.sqlType,
   codec: relationalChecklistItemsCodec,
-  uniques: uniques12,
+  uniques: relational_checklist_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2416,7 +2416,7 @@ const registryConfig_pgResources_relational_checklist_items_relational_checklist
     tags: {}
   }
 };
-const uniques13 = [{
+const relational_dividersUniques = [{
   isPrimary: true,
   attributes: ["divider_item_id"],
   description: undefined,
@@ -2425,12 +2425,12 @@ const uniques13 = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
   from: relationalDividersCodec.sqlType,
   codec: relationalDividersCodec,
-  uniques: uniques13,
+  uniques: relational_dividersUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2443,7 +2443,7 @@ const registryConfig_pgResources_relational_dividers_relational_dividers = {
     tags: {}
   }
 };
-const uniques14 = [{
+const relational_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2459,12 +2459,12 @@ const uniques14 = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
   from: relationalItemRelationsCodec.sqlType,
   codec: relationalItemRelationsCodec,
-  uniques: uniques14,
+  uniques: relational_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2477,7 +2477,7 @@ const registryConfig_pgResources_relational_item_relations_relational_item_relat
     tags: {}
   }
 };
-const uniques15 = [{
+const single_table_item_relationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2493,12 +2493,12 @@ const uniques15 = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
   from: singleTableItemRelationsCodec.sqlType,
   codec: singleTableItemRelationsCodec,
-  uniques: uniques15,
+  uniques: single_table_item_relationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2511,7 +2511,7 @@ const registryConfig_pgResources_single_table_item_relations_single_table_item_r
     tags: {}
   }
 };
-const uniques16 = [{
+const log_entriesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2520,12 +2520,12 @@ const uniques16 = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
   from: logEntriesCodec.sqlType,
   codec: logEntriesCodec,
-  uniques: uniques16,
+  uniques: log_entriesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2541,7 +2541,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     }
   }
 };
-const uniques17 = [{
+const relational_postsUniques = [{
   isPrimary: true,
   attributes: ["post_item_id"],
   description: undefined,
@@ -2550,12 +2550,12 @@ const uniques17 = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
   from: relationalPostsCodec.sqlType,
   codec: relationalPostsCodec,
-  uniques: uniques17,
+  uniques: relational_postsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2568,7 +2568,7 @@ const registryConfig_pgResources_relational_posts_relational_posts = {
     tags: {}
   }
 };
-const uniques18 = [{
+const first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2577,12 +2577,12 @@ const uniques18 = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
   from: firstPartyVulnerabilitiesCodec.sqlType,
   codec: firstPartyVulnerabilitiesCodec,
-  uniques: uniques18,
+  uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2599,7 +2599,7 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     }
   }
 };
-const uniques19 = [{
+const third_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2608,12 +2608,12 @@ const uniques19 = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
   from: thirdPartyVulnerabilitiesCodec.sqlType,
   codec: thirdPartyVulnerabilitiesCodec,
-  uniques: uniques19,
+  uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2630,7 +2630,7 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     }
   }
 };
-const uniques20 = [{
+const aws_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2639,12 +2639,12 @@ const uniques20 = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
   from: awsApplicationsCodec.sqlType,
   codec: awsApplicationsCodec,
-  uniques: uniques20,
+  uniques: aws_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2661,7 +2661,7 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     }
   }
 };
-const uniques21 = [{
+const gcp_applicationsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2670,12 +2670,12 @@ const uniques21 = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
   from: gcpApplicationsCodec.sqlType,
   codec: gcpApplicationsCodec,
-  uniques: uniques21,
+  uniques: gcp_applicationsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2692,8 +2692,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     }
   }
 };
-const sqlIdent2 = sql.identifier("polymorphic", "custom_delete_relational_item");
-const uniques22 = [{
+const custom_delete_relational_itemFunctionIdentifer = sql.identifier("polymorphic", "custom_delete_relational_item");
+const single_table_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2702,12 +2702,12 @@ const uniques22 = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
   from: singleTableItemsCodec.sqlType,
   codec: singleTableItemsCodec,
-  uniques: uniques22,
+  uniques: single_table_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2724,9 +2724,9 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     }
   }
 };
-const sqlIdent3 = sql.identifier("polymorphic", "all_single_tables");
-const sqlIdent4 = sql.identifier("polymorphic", "get_single_table_topic_by_id");
-const uniques23 = [{
+const all_single_tablesFunctionIdentifer = sql.identifier("polymorphic", "all_single_tables");
+const get_single_table_topic_by_idFunctionIdentifer = sql.identifier("polymorphic", "get_single_table_topic_by_id");
+const relational_itemsUniques = [{
   isPrimary: true,
   attributes: ["id"],
   description: undefined,
@@ -2735,12 +2735,12 @@ const uniques23 = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor: executor_mainPgExecutor,
+  executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
   from: relationalItemsCodec.sqlType,
   codec: relationalItemsCodec,
-  uniques: uniques23,
+  uniques: relational_itemsUniques,
   isVirtual: false,
   description: undefined,
   extensions: {
@@ -2833,7 +2833,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     Vulnerability: recordCodec({
       name: "Vulnerability",
@@ -2878,7 +2878,7 @@ const registryConfig = {
           }
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     }),
     ZeroImplementation: recordCodec({
       name: "ZeroImplementation",
@@ -2898,7 +2898,7 @@ const registryConfig = {
           behavior: "node"
         })
       },
-      executor: executor_mainPgExecutor
+      executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -2924,11 +2924,11 @@ const registryConfig = {
     aws_applications: registryConfig_pgResources_aws_applications_aws_applications,
     gcp_applications: registryConfig_pgResources_gcp_applications_gcp_applications,
     custom_delete_relational_item: {
-      executor: executor_mainPgExecutor,
+      executor,
       name: "custom_delete_relational_item",
       identifier: "main.polymorphic.custom_delete_relational_item(polymorphic.relational_items)",
       from(...args) {
-        return sql`${sqlIdent2}(${sqlFromArgDigests(args)})`;
+        return sql`${custom_delete_relational_itemFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "nodeId",
@@ -2961,7 +2961,7 @@ const registryConfig = {
       name: "all_single_tables",
       identifier: "main.polymorphic.all_single_tables()",
       from(...args) {
-        return sql`${sqlIdent3}(${sqlFromArgDigests(args)})`;
+        return sql`${all_single_tablesFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [],
       returnsArray: false,
@@ -2983,7 +2983,7 @@ const registryConfig = {
       name: "get_single_table_topic_by_id",
       identifier: "main.polymorphic.get_single_table_topic_by_id(int4)",
       from(...args) {
-        return sql`${sqlIdent4}(${sqlFromArgDigests(args)})`;
+        return sql`${get_single_table_topic_by_idFunctionIdentifer}(${sqlFromArgDigests(args)})`;
       },
       parameters: [{
         name: "id",
@@ -14492,7 +14492,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -14508,7 +14508,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques16[0].attributes.forEach(attributeName => {
+        log_entriesUniques[0].attributes.forEach(attributeName => {
           const attribute = logEntriesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15389,7 +15389,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        aws_application_first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15405,7 +15405,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques[0].attributes.forEach(attributeName => {
+        aws_application_first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15831,7 +15831,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        gcp_application_first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -15847,7 +15847,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques3[0].attributes.forEach(attributeName => {
+        gcp_application_first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationFirstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16301,7 +16301,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        aws_application_third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16317,7 +16317,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques2[0].attributes.forEach(attributeName => {
+        aws_application_third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16454,7 +16454,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        gcp_application_third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16470,7 +16470,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques4[0].attributes.forEach(attributeName => {
+        gcp_application_third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationThirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -16999,7 +16999,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17015,7 +17015,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques20[0].attributes.forEach(attributeName => {
+        aws_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = awsApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17405,7 +17405,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17421,7 +17421,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques21[0].attributes.forEach(attributeName => {
+        gcp_applicationsUniques[0].attributes.forEach(attributeName => {
           const attribute = gcpApplicationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17820,7 +17820,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -17836,7 +17836,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques22[0].attributes.forEach(attributeName => {
+        single_table_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18545,7 +18545,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -18561,7 +18561,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques23[0].attributes.forEach(attributeName => {
+        relational_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19245,7 +19245,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19261,7 +19261,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques15[0].attributes.forEach(attributeName => {
+        single_table_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19455,7 +19455,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -19471,7 +19471,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques11[0].attributes.forEach(attributeName => {
+        single_table_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = singleTableItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -21554,7 +21554,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -21570,7 +21570,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques14[0].attributes.forEach(attributeName => {
+        relational_item_relationsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -21764,7 +21764,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -21780,7 +21780,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques9[0].attributes.forEach(attributeName => {
+        relational_item_relation_composite_pksUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalItemRelationCompositePksCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25703,7 +25703,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25719,7 +25719,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques5[0].attributes.forEach(attributeName => {
+        organizationsUniques[0].attributes.forEach(attributeName => {
           const attribute = organizationsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25881,7 +25881,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -25897,7 +25897,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques6[0].attributes.forEach(attributeName => {
+        peopleUniques[0].attributes.forEach(attributeName => {
           const attribute = peopleCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26059,7 +26059,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        prioritiesUniques[0].attributes.forEach(attributeName => {
           const attribute = prioritiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26075,7 +26075,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques7[0].attributes.forEach(attributeName => {
+        prioritiesUniques[0].attributes.forEach(attributeName => {
           const attribute = prioritiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26237,7 +26237,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26253,7 +26253,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques8[0].attributes.forEach(attributeName => {
+        relational_checklistsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26928,7 +26928,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -26944,7 +26944,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques10[0].attributes.forEach(attributeName => {
+        relational_topicsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalTopicsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27619,7 +27619,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -27635,7 +27635,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques12[0].attributes.forEach(attributeName => {
+        relational_checklist_itemsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalChecklistItemsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28367,7 +28367,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -28383,7 +28383,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques13[0].attributes.forEach(attributeName => {
+        relational_dividersUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalDividersCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29115,7 +29115,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29131,7 +29131,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques17[0].attributes.forEach(attributeName => {
+        relational_postsUniques[0].attributes.forEach(attributeName => {
           const attribute = relationalPostsCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29920,7 +29920,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -29936,7 +29936,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques18[0].attributes.forEach(attributeName => {
+        first_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = firstPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30212,7 +30212,7 @@ export const plans = {
     },
     PRIMARY_KEY_ASC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -30228,7 +30228,7 @@ export const plans = {
     },
     PRIMARY_KEY_DESC: {
       applyPlan(step) {
-        uniques19[0].attributes.forEach(attributeName => {
+        third_party_vulnerabilitiesUniques[0].attributes.forEach(attributeName => {
           const attribute = thirdPartyVulnerabilitiesCodec.attributes[attributeName];
           step.orderBy({
             codec: attribute.codec,
@@ -31505,7 +31505,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31579,7 +31579,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31653,7 +31653,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31727,7 +31727,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31801,7 +31801,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31875,7 +31875,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -31949,7 +31949,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = prioritiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32023,7 +32023,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32097,7 +32097,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32171,7 +32171,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32252,7 +32252,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32333,7 +32333,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32421,7 +32421,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32509,7 +32509,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32597,7 +32597,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32699,7 +32699,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32801,7 +32801,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32875,7 +32875,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -32949,7 +32949,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33023,7 +33023,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33097,7 +33097,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33184,7 +33184,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33271,7 +33271,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = prioritiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33344,7 +33344,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33418,7 +33418,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33492,7 +33492,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33587,7 +33587,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33682,7 +33682,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33769,7 +33769,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33856,7 +33856,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -33943,7 +33943,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34044,7 +34044,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34145,7 +34145,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34197,7 +34197,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques2[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34249,7 +34249,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques3[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34301,7 +34301,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques4[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_application_third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34353,7 +34353,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques5[0].attributes.reduce((memo, attributeName) => {
+            const spec = organizationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34412,7 +34412,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques6[0].attributes.reduce((memo, attributeName) => {
+            const spec = peopleUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34471,7 +34471,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques7[0].attributes.reduce((memo, attributeName) => {
+            const spec = prioritiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34522,7 +34522,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques9[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34574,7 +34574,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques11[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relation_composite_pksUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34626,7 +34626,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques14[0].attributes.reduce((memo, attributeName) => {
+            const spec = relational_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34686,7 +34686,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques15[0].attributes.reduce((memo, attributeName) => {
+            const spec = single_table_item_relationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34746,7 +34746,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques16[0].attributes.reduce((memo, attributeName) => {
+            const spec = log_entriesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34797,7 +34797,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques18[0].attributes.reduce((memo, attributeName) => {
+            const spec = first_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34848,7 +34848,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques19[0].attributes.reduce((memo, attributeName) => {
+            const spec = third_party_vulnerabilitiesUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34899,7 +34899,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques20[0].attributes.reduce((memo, attributeName) => {
+            const spec = aws_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));
@@ -34950,7 +34950,7 @@ export const plans = {
           if ($result instanceof PgDeleteSingleStep) {
             return pgSelectFromRecord($result.resource, $result.record());
           } else {
-            const spec = uniques21[0].attributes.reduce((memo, attributeName) => {
+            const spec = gcp_applicationsUniques[0].attributes.reduce((memo, attributeName) => {
               memo[attributeName] = $result.get(attributeName);
               return memo;
             }, Object.create(null));

--- a/postgraphile/postgraphile/src/plugins/PgV4SimpleSubscriptionsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SimpleSubscriptionsPlugin.ts
@@ -90,6 +90,7 @@ const nodeObjToNodeId = EXPORTABLE(
       return Buffer.from(JSON.stringify(obj), "utf8").toString("base64");
     },
   [],
+  "nodeObjToNodeId",
 );
 
 // WARNING: this function assumes that you're using the `base64JSON` NodeID codec, which was the case for PostGraphile V4. If you are not doing so, YMMV.
@@ -101,4 +102,5 @@ const nodeIdFromEvent = EXPORTABLE(
       return $nodeId;
     },
   [lambda, nodeObjToNodeId],
+  "nodeIdFromEvent",
 );

--- a/utils/graphile-export/README.md
+++ b/utils/graphile-export/README.md
@@ -46,7 +46,7 @@ undefined
 
 When you do so, the `add` function is augmented with the properties
 `$exporter$factory` and `$exporter$args` that represent the first and second
-arguments to the `EXPORTABLE(factory, args)` function respectively.
+arguments to the `EXPORTABLE(factory, args, nameHint)` function respectively.
 
 The function still works as before:
 
@@ -167,7 +167,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;
@@ -186,7 +186,7 @@ export function EXPORTABLE(factory, args, nameHint) {
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;

--- a/utils/graphile-export/README.md
+++ b/utils/graphile-export/README.md
@@ -157,6 +157,7 @@ into your code:
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -166,6 +167,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;
@@ -175,7 +177,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
 (Or, if you're using plain JavaScript:
 
 ```js
-export function EXPORTABLE(factory, args) {
+export function EXPORTABLE(factory, args, nameHint) {
   const fn = factory(...args);
   if (
     ((typeof fn === "object" && fn !== null) || typeof fn === "function") &&
@@ -184,6 +186,7 @@ export function EXPORTABLE(factory, args) {
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -118,7 +118,9 @@ function getNameForThing(
   locationHint: string,
   baseNameHint: string,
 ): string {
-  if (typeof thing === "function") {
+  if (thing.$exporter$name) {
+    return thing.$exporter$name;
+  } else if (typeof thing === "function") {
     if (baseNameHint) {
       return baseNameHint;
     }
@@ -130,7 +132,10 @@ function getNameForThing(
   } else {
     const thingConstructor = thing.constructor;
     const thingConstructorNameRaw =
-      thingConstructor?.name ?? thingConstructor?.displayName ?? null;
+      thingConstructor?.$exporter$name ??
+      thingConstructor?.name ??
+      thingConstructor?.displayName ??
+      null;
     const thingConstructorName = ["Array", "Object", "Set", "Map"].includes(
       thingConstructorNameRaw,
     )
@@ -191,6 +196,7 @@ type AnyFunction = {
 type ExportedFromFactory<T, TTuple extends any[]> = T & {
   $exporter$args: [...TTuple];
   $exporter$factory: (...args: TTuple) => T;
+  $exporter$name: string | undefined;
 };
 
 function isExportedFromFactory<T, TTuple extends any[]>(

--- a/utils/graphile-export/src/helpers.ts
+++ b/utils/graphile-export/src/helpers.ts
@@ -1,6 +1,7 @@
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -10,6 +11,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;

--- a/utils/graphile-export/src/optimize/index.ts
+++ b/utils/graphile-export/src/optimize/index.ts
@@ -1,4 +1,6 @@
 // import generate from "@babel/generator";
+import generate from "@babel/generator";
+import { parse } from "@babel/parser";
 import traverse, { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
@@ -36,7 +38,10 @@ function isSimpleParam(param: t.Node): param is t.Identifier {
   return t.isIdentifier(param);
 }
 
-export const optimize = (ast: t.File, runs = 1): t.File => {
+export const optimize = (inAst: t.File, runs = 1): t.File => {
+  let ast = inAst;
+  // Reset the full AST
+  ast = parse(generate(ast).code, { sourceType: "module" });
   traverse(ast, {
     VariableDeclaration: {
       enter(path) {
@@ -236,6 +241,8 @@ export const optimize = (ast: t.File, runs = 1): t.File => {
       },
     },
   });
+
+  ast = parse(generate(ast).code, { sourceType: "module" });
 
   // convert `plan: function plan() {...}` to `plan() { ... }`
   traverse(ast, {

--- a/utils/tamedevil/src/index.ts
+++ b/utils/tamedevil/src/index.ts
@@ -825,6 +825,7 @@ function tmp(obj: TE, callback: (tmp: TE) => TE): TE {
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -834,6 +835,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/utils/tamedevil/src/index.ts
+++ b/utils/tamedevil/src/index.ts
@@ -835,7 +835,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;

--- a/utils/website/graphile-export/exportable.md
+++ b/utils/website/graphile-export/exportable.md
@@ -25,7 +25,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;
@@ -44,7 +44,7 @@ export function EXPORTABLE(factory, args, nameHint) {
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
-      $exporter$name: { value: nameHint },
+      $exporter$name: { writable: true, value: nameHint },
     });
   }
   return fn;

--- a/utils/website/graphile-export/exportable.md
+++ b/utils/website/graphile-export/exportable.md
@@ -15,6 +15,7 @@ into your code:
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
   args: [...TScope],
+  nameHint?: string,
 ): T {
   const fn: T = factory(...args);
   if (
@@ -24,6 +25,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;
@@ -33,7 +35,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
 (Or, if you're using plain JavaScript:
 
 ```js
-export function EXPORTABLE(factory, args) {
+export function EXPORTABLE(factory, args, nameHint) {
   const fn = factory(...args);
   if (
     ((typeof fn === "object" && fn !== null) || typeof fn === "function") &&
@@ -42,6 +44,7 @@ export function EXPORTABLE(factory, args) {
     Object.defineProperties(fn, {
       $exporter$args: { value: args },
       $exporter$factory: { value: factory },
+      $exporter$name: { value: nameHint },
     });
   }
   return fn;

--- a/utils/website/graphile-export/index.md
+++ b/utils/website/graphile-export/index.md
@@ -48,7 +48,7 @@ undefined
 
 When you do so, the `add` function is augmented with the properties
 `$exporter$factory` and `$exporter$args` that represent the first and second
-arguments to the `EXPORTABLE(factory, args)` function respectively.
+arguments to the `EXPORTABLE(factory, args, nameHint)` function respectively.
 
 The function still works as before:
 


### PR DESCRIPTION
## Description

- Add third argument to `EXPORTABLE`.
- Use this argument in a few places.
- Fix `graphile-export` optimize function so it re-evaluates scope (by stringifying and re-parsing), fixing some inlining issues
- Tidy up a number of the exports by using these two new features
- Convert `foo(...["a", "b])` to `foo("a", "b")` automatically

## Performance impact

Exports are probably slower (but better).

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
